### PR TITLE
Init cpu.instruction to a nop

### DIFF
--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -156,7 +156,7 @@ class Cpu(object):
         self._md = Cs(self.arch, self.mode)
         self._md.detail = True
         self._md.syntax = 0
-        self.instruction = None
+        self.instruction = next(self._md.disasm(self._nop, 0))
         #FIXME self.transactions = []
 
     def __getstate__(self):

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -282,6 +282,7 @@ class Armv7Cpu(Cpu):
     machine = 'armv7'
     arch = CS_ARCH_ARM
     mode = CS_MODE_ARM
+    _nop = '\x00\xf0\x20\xe3'
 
 
     def __init__(self, memory, *args, **kwargs):

--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -714,6 +714,9 @@ class X86Cpu(Cpu):
     '''
     A CPU model.
     '''
+    max_instr_width = 15
+    _nop = '\x90'
+
     def __init__(self, regfile, memory, *args, **kwargs):
         '''
         Builds a CPU model.
@@ -5791,7 +5794,6 @@ class ABI:
 
 class AMD64Cpu(X86Cpu):
     #Config
-    max_instr_width = 15
     address_bit_size = 64
     arch = CS_ARCH_X86
     mode = CS_MODE_64
@@ -5899,7 +5901,6 @@ class AMD64Cpu(X86Cpu):
 
 class I386Cpu(X86Cpu):
     #Config
-    max_instr_width = 15
     address_bit_size = 32
     arch = CS_ARCH_X86
     mode = CS_MODE_32


### PR DESCRIPTION
Previously, it was None, and so scripts that registered every insn
hooks had to check for the edge case, for the first insn, whether
state.cpu.instruction is None or not.