### PR TITLE
m.start -> m.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ def hook(state):
   m.terminate()  # tell Manticore to stop
 
 m.add_hook(hook_pc, hook)
-m.start()
+m.run()
 ```

--- a/examples/script/count_instructions.py
+++ b/examples/script/count_instructions.py
@@ -24,6 +24,6 @@ if __name__ == '__main__':
 
     m.add_hook(None, explore)
 
-    m.start()
+    m.run()
 
     print "Executed ", m.context['count'], " instructions."

--- a/examples/script/guide_exec.py
+++ b/examples/script/guide_exec.py
@@ -29,4 +29,4 @@ if __name__ == '__main__':
 
     # Start path exploration. start() returns when Manticore
     # finishes
-    m.start()
+    m.run()

--- a/examples/script/lads-baby-re.py
+++ b/examples/script/lads-baby-re.py
@@ -26,5 +26,5 @@ if __name__ == '__main__':
 
     m.add_hook(0x109f0, myhook)
 
-    m.start()
+    m.run()
     print 'done'

--- a/examples/script/manticore_config.py
+++ b/examples/script/manticore_config.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
     # Start path exploration. start() returns when Manticore
     # finishes
-    m.start()
+    m.run()
 
     # Print high level statistics
     m.dump_stats()

--- a/examples/script/run_callback.py
+++ b/examples/script/run_callback.py
@@ -34,5 +34,5 @@ if __name__ == '__main__':
 
     # Start path exploration. start() returns when Manticore
     # finishes
-    m.start()
+    m.run()
 

--- a/examples/script/run_simple.py
+++ b/examples/script/run_simple.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     m = Manticore(None, path)
     # Start path exploration. start() returns when Manticore
     # finishes
-    m.start()
+    m.run()
     # Print high level statistics
     m.dump_stats()
 

--- a/examples/script/state_explore.py
+++ b/examples/script/state_explore.py
@@ -19,4 +19,4 @@ if __name__ == '__main__':
     print "Adding hook to: ", hex(to_abandon)
     m.add_hook(to_abandon, explore)
 
-    m.start()
+    m.run()

--- a/examples/script/sym.py
+++ b/examples/script/sym.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     m.add_pc_hook(target[0], entered_func)
 
     # Start path exploration. start() returns when Manticore finishes
-    m.start()
+    m.run()
 
     # Print high level statistics
     #m.dump_stats()

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -145,7 +145,7 @@ def main():
 
     logger.info('[+] Loading challenge %s', args.programs)
 
-    m.start()
+    m.run()
 
     m.dump_stats()
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -525,7 +525,7 @@ class Manticore(object):
                 self._assertions[pc] = ' '.join(line.split(' ')[1:])
 
 
-    def start(self):
+    def run(self):
         '''
         Start Manticore, creating all necessary support classes.
         '''


### PR DESCRIPTION
😈  breaking the api while it's easy
`.run` appears to be more idiomatic, based on a cursory survey of some other projects (Flask, Twisted, TensorFlow, angr)