### PR TITLE
Rm requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-# workaround for capstone install issue
---no-binary capstone
-
-# dependencies
-capstone
-pyelftools
-unicorn


### PR DESCRIPTION
All dependency installation happens during `pip install` now, so there isn't a real need for this anymore. We can add it back when we have a specific need.