### PR TITLE
Switch instructions to prefer virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Manticore is officially supported on Linux and uses Python 2.7.
 ## Installation
 
 We recommend the use of Manticore in a virtual environment, though this is optional.
-To set up a virtual environment, in the root of the Manticore repository, run
+To manage this, we recommend installing [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/).
+Then, to set up a virtual environment, in the root of the Manticore repository, run
 
 ```
 mkvirtualenv manticore


### PR DESCRIPTION
This should also be consistent with Travis, as it uses virtualenvs by default (source: https://docs.travis-ci.com/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs)