### PR TITLE
Correct loader condition

### DIFF
--- a/manticore/models/linux.py
+++ b/manticore/models/linux.py
@@ -728,7 +728,7 @@ class Linux(object):
                 vaddr = vaddr - ELF_PAGEOFFSET
                 memsz = cpu.memory._ceil(memsz)
 
-                if base == 0:
+                if base == 0 and interpreter.header.e_type == 'ET_DYN':
                     assert vaddr == 0
                     total_size = 0
                     for _elf_segment in interpreter.iter_segments():


### PR DESCRIPTION
We always want to run this code if there is an interpreter present, not
just if the exe is ET_DYN