### PR TITLE
Fix arm PUSH

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -626,9 +626,9 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def PUSH(cpu, *regs):
-        high_to_low_regs = regs[::-1]
+        high_to_low_regs = [r.read() for r in regs[::-1]]
         for reg in high_to_low_regs:
-            cpu.stack_push(reg.read())
+            cpu.stack_push(reg)
 
 
     @instruction


### PR DESCRIPTION
If sp is in the list, it gets pushed incorrectly because it gets
updated by the stack_pushes for registers that occur before it