### PR TITLE
Fix arm/x86(32) linux stat

### DIFF
--- a/manticore/models/linux.py
+++ b/manticore/models/linux.py
@@ -1952,10 +1952,10 @@ class SLinux(Linux):
         bufstat += struct.pack('<L', stat.st_ino)
         bufstat += struct.pack('<L', stat.st_mode)
         bufstat += struct.pack('<L', stat.st_nlink)
-        bufstat += struct.pack('<L', 0) # uid
+        bufstat += struct.pack('<L', 0)  # uid
         bufstat += struct.pack('<L', 0)  # gid
         bufstat += struct.pack('<Q', 0)  # rdev
-        bufstat += struct.pack('<L', 0) # pad2
+        bufstat += struct.pack('<L', 0)  # pad2
         bufstat += struct.pack('<L', stat.st_size)
         bufstat += struct.pack('<L', stat.st_blksize)
         bufstat += struct.pack('<L', stat.st_blocks)


### PR DESCRIPTION
This stat shouldn't use our sys_stat64 because on these platforms the fields of the struct stat are smaller. Use correctly sized stat for 32 bit linux, and also fix bugs in the existing implementation of 32 bit stat