### PR TITLE
Add read the docs mock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,8 +155,17 @@ texinfo_documents = [
 
 # -- Custom
 
-# awful way to mock z3 existence so readthedocs will not error out when
+# mock z3 existence so readthedocs will not error out when
 # generating docs
+
 import subprocess
-subprocess.check_output = lambda *args, **kwargs: 'Z3 Version 4.4.2'
+
+saved_check_output = subprocess.check_output
+def z3_mock_check_output(*args, **kwargs):
+    if args and 'z3' in args[0]:
+        return 'Z3 Version 4.4.2'
+
+    return saved_check_output(*args, **kwargs)
+
+subprocess.check_output = z3_mock_check_output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,4 +153,10 @@ texinfo_documents = [
 ]
 
 
+# -- Custom
+
+# awful way to mock z3 existence so readthedocs will not error out when
+# generating docs
+import subprocess
+subprocess.check_output = lambda *args, **kwargs: 'Z3 Version 4.4.2'
 


### PR DESCRIPTION
Readthedoc was unable to build our docs because we check for z3 on the machine and fail if its not there. Using the officially supported mocking mechanism `autodoc_mock_imports` doesn't work because that doesn't handle submodules well, and in addition to mocking the specified submode (in our case `manticore.core.smtlib.solver`), mocks modules higher in the hierarchy also.

You can see docs built from this branch at http://manticore.readthedocs.io/en/dev-rtd-mock/api.html#helpers