### PR TITLE
Only make registers appear on verbosity level 5

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -107,7 +107,7 @@ def main():
         m.load_assertions(args.assertions)
 
     if args.verbose:
-        m.verbosity = 5
+        m.verbosity = 4
     else:
         m.verbosity = 1
 

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -495,6 +495,7 @@ class Cpu(object):
         '''
         result =  self.render_instruction() + "\n"
         result += '\n'.join(self.render_registers())
+        return result
 
 
 class DecodeException(Exception):

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -493,11 +493,8 @@ class Cpu(object):
         :rtype: str
         :return: name and current value for all the registers. 
         '''
-        result =  self.render_instruction()
-        result += "\n"
-        for reg in self.render_registers():
-            result += reg
-            result += "\n"
+        result =  self.render_instruction() + "\n"
+        result += '\n'.join(self.render_registers())
 
 
 class DecodeException(Exception):

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -202,7 +202,7 @@ class Manticore(object):
 
         logging.basicConfig(format='%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s: %(message)s', stream=sys.stdout)
 
-        for loggername in ['VISITOR', 'EXECUTOR', 'CPU', 'SMT', 'MEMORY', 'MAIN', 'MODEL']:
+        for loggername in ['VISITOR', 'EXECUTOR', 'CPU', 'REGISTERS', 'SMT', 'MEMORY', 'MAIN', 'MODEL']:
             logging.getLogger(loggername).addFilter(ctxfilter)
             logging.getLogger(loggername).setState = types.MethodType(loggerSetState, logging.getLogger(loggername))
         
@@ -275,7 +275,7 @@ class Manticore(object):
                   [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG), ('MODEL', logging.DEBUG)],
                   [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG), ('MODEL', logging.DEBUG), ('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG)],
                   [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG), ('MODEL', logging.DEBUG), ('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG)],
-                  [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG), ('MODEL', logging.DEBUG), ('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG), ('SMTLIB', logging.DEBUG)]]
+                  [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG), ('MODEL', logging.DEBUG), ('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG), ('SMT', logging.DEBUG), ('REGISTERS', logging.DEBUG)]]
         # Takes a value and ensures it's in a certain range
         def clamp(val, minimum, maximum):
             return sorted((minimum, val, maximum))[1]


### PR DESCRIPTION
This PR also sets the default `--verbose` verbosity to 4, which is in my opinion much more sane