### PR TITLE
Add memory tracing

### DIFF
--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -217,6 +217,7 @@ class AnonMap(Map):
             return map(chr, self._data[index])
         return chr(self._data[index])
 
+
 class FileMap(Map):
     '''
     A file map.
@@ -809,15 +810,16 @@ class Memory(object):
 
     def write(self, addr, buf):
 
-        if self._recording_stack:
-            self._recording_stack[-1].append((addr, buf))
-
         size = len(buf)
         if not self.access_ok(slice(addr, addr + size), 'w'):
             raise MemoryException('No access writing', addr)
         assert size > 0
         stop = addr + size
         start = addr
+
+        if self._recording_stack:
+            self._recording_stack[-1].append((addr, buf))
+
         while addr < stop:
             m = self.map_containing(addr)
             size = min(m.end-addr, stop-addr)

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -773,28 +773,28 @@ class Memory(object):
         return result
 
 
-    def start_write_trace(self):
+    def push_record_writes(self):
         '''
-        Begin recording all writes. Retrieve all writes with `stop_write_trace()`
+        Begin recording all writes. Retrieve all writes with `pop_record_writes()`
 
         :return: None
         '''
-        print '[d] starting trace..'
         self._recording_stack.append([])
 
-    def stop_write_trace(self):
+    def pop_record_writes(self):
         '''
         Stop recording trace and return a `list[(address, value)]` of all the writes
         that occurred, where `value` is of type list[str]. Can be called without
-        intermediate `stop_write_trace()`.
+        intermediate `pop_record_writes()`.
 
-        For example,
-            mem.start_write_trace()
+        For example::
+
+            mem.push_record_writes()
                 mem.write(1, 'a')
-                mem.start_write_trace()
+                mem.push_record_writes()
                     mem.write(2, 'b')
-                mem.stop_write_trace()  # Will return [(2, 'b')]
-            mem.stop_write_trace()  # Will return [(1, 'a'), (2, 'b')]
+                mem.pop_record_writes()  # Will return [(2, 'b')]
+            mem.pop_record_writes()  # Will return [(1, 'a'), (2, 'b')]
 
         Multiple writes to the same address will all be included in the trace in the
         same order they occurred.

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -783,8 +783,9 @@ class Memory(object):
 
     def stop_write_trace(self):
         '''
-        Stop recording trace and return a list[(address, value)] of all the writes
-        that occurred. Can be called without intermediate `stop_write_trace()`.
+        Stop recording trace and return a `list[(address, value)]` of all the writes
+        that occurred, where `value` is of type list[str]. Can be called without
+        intermediate `stop_write_trace()`.
 
         For example,
             mem.start_write_trace()
@@ -793,6 +794,9 @@ class Memory(object):
                     mem.write(2, 'b')
                 mem.stop_write_trace()  # Will return [(2, 'b')]
             mem.stop_write_trace()  # Will return [(1, 'a'), (2, 'b')]
+
+        Multiple writes to the same address will all be included in the trace in the
+        same order they occurred.
 
         :return: list[tuple]
         '''

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -776,8 +776,6 @@ class Memory(object):
     def push_record_writes(self):
         '''
         Begin recording all writes. Retrieve all writes with `pop_record_writes()`
-
-        :return: None
         '''
         self._recording_stack.append([])
 
@@ -809,7 +807,6 @@ class Memory(object):
         return lst
 
     def write(self, addr, buf):
-
         size = len(buf)
         if not self.access_ok(slice(addr, addr + size), 'w'):
             raise MemoryException('No access writing', addr)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1620,10 +1620,10 @@ class MemoryTest(unittest.TestCase):
 
         addr = mem.mmap(None, 0x1000, 'rw')
 
-        mem.start_write_trace()
+        mem.push_record_writes()
         mem.write(addr, 'a')
         mem.write(addr+1, 'b')
-        writes = mem.stop_write_trace()
+        writes = mem.pop_record_writes()
 
         self.assertIn((addr, ['a']), writes)
         self.assertIn((addr+1, ['b']), writes)
@@ -1635,10 +1635,10 @@ class MemoryTest(unittest.TestCase):
 
         addr = mem.mmap(None, 0x1000, 'rw')
 
-        mem.start_write_trace()
+        mem.push_record_writes()
         mem.write(addr, 'a')
         mem.write(addr, 'b')
-        writes = mem.stop_write_trace()
+        writes = mem.pop_record_writes()
 
         self.assertIn((addr, ['a']), writes)
         self.assertIn((addr, ['b']), writes)
@@ -1649,21 +1649,21 @@ class MemoryTest(unittest.TestCase):
 
         addr = mem.mmap(None, 0x1000, 'rw')
 
-        mem.start_write_trace()
+        mem.push_record_writes()
         mem.write(addr, 'a')
         mem.write(addr+1, 'b')
-        mem.start_write_trace()
+        mem.push_record_writes()
         mem.write(addr+2, 'c')
         mem.write(addr+3, 'd')
-        inner_writes = mem.stop_write_trace()
-        outer_writes = mem.stop_write_trace()
+        inner_writes = mem.pop_record_writes()
+        outer_writes = mem.pop_record_writes()
 
-        # Make sure the first ones aren't in the inner write
+        # Make sure writes do not appear in a trace started after them
         self.assertNotIn((addr, ['a']), inner_writes)
         self.assertNotIn((addr+1, ['b']), inner_writes)
         # Make sure the first two are in the outer write
-        self.assertNotIn((addr, ['c']), outer_writes)
-        self.assertNotIn((addr+1, ['d']), outer_writes)
+        self.assertIn((addr, ['a']), outer_writes)
+        self.assertIn((addr+1, ['b']), outer_writes)
         # Make sure the last two are in the inner write
         self.assertIn((addr+2, ['c']), inner_writes)
         self.assertIn((addr+3, ['d']), inner_writes)
@@ -1677,10 +1677,10 @@ class MemoryTest(unittest.TestCase):
         mem = SMemory32(cs)
         addr = mem.mmap(None, 0x1000, 'rw')
 
-        mem.start_write_trace()
+        mem.push_record_writes()
         with self.assertRaises(MemoryException):
             mem.write(addr-0x5000, 'a')
-        trace = mem.stop_write_trace()
+        trace = mem.pop_record_writes()
 
         # Make sure erroring writes don't get recorded
         self.assertEqual(len(trace), 0)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1643,7 +1643,7 @@ class MemoryTest(unittest.TestCase):
         self.assertIn((addr, ['a']), writes)
         self.assertIn((addr, ['b']), writes)
 
-    def test_mem_nested(self):
+    def test_mem_trace_nested(self):
         cs = ConstraintSet()
         mem = SMemory32(cs)
 
@@ -1670,6 +1670,20 @@ class MemoryTest(unittest.TestCase):
         # Make sure the last two are also in the outer write
         self.assertIn((addr+2, ['c']), outer_writes)
         self.assertIn((addr+3, ['d']), outer_writes)
+
+
+    def test_mem_trace_ignores_failing(self):
+        cs = ConstraintSet()
+        mem = SMemory32(cs)
+        addr = mem.mmap(None, 0x1000, 'rw')
+
+        mem.start_write_trace()
+        with self.assertRaises(MemoryException):
+            mem.write(addr-0x5000, 'a')
+        trace = mem.stop_write_trace()
+
+        # Make sure erroring writes don't get recorded
+        self.assertEqual(len(trace), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When verifying Manticore's emulation integrity, it is beneficial to run a binary in lock-step with a native or qemu-emulated execution. This works well for general instruction semantics, but fails when emulating system calls. Manticore's state might not exactly match that of the reference implementation.

We would like to be able to capture all of Manticore's memory writes between invoking a system call and its return, to mimic them precisely in the emulated instance.

This implementation lets calling code start and stop memory tracing. Stopping a memory trace returns a list of all write actions that occurred since it begun. Start/stop pairs can also be nested, if a future implementation requires it.