### PR TITLE
Optimizations and bug fixes in smt formulas

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -350,8 +350,12 @@ class Z3Solver(Solver):
             val = None
             while self._check() == 'sat':
                 value = self._getvalue(var)
+                # reset the solver to avoid the incremental mode 
+                # triggered with two consecutive calls to check-sat
+                self._reset(temp_cs.related_to(var) )
                 result.append(value)
-                self._assert( var != value )
+                for value in result:
+                    self._assert( var != value )
                 if len(result) >= maxcnt:
                     if silent:
                         # do not throw an exception if set to silent

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -350,12 +350,19 @@ class Z3Solver(Solver):
             val = None
             while self._check() == 'sat':
                 value = self._getvalue(var)
-                # reset the solver to avoid the incremental mode 
-                # triggered with two consecutive calls to check-sat
-                self._reset(temp_cs.related_to(var) )
                 result.append(value)
-                for value in result:
-                    self._assert( var != value )
+
+                # Reset the solver to avoid the incremental mode 
+                # Triggered with two consecutive calls to check-sat
+                # Yet, if the number of solution is large, sending back
+                # the whole formula is more expensive
+                if len(result) < 50:
+                    self._reset(temp_cs.related_to(var) )
+                    for value in result:
+                        self._assert( var != value )
+                else:
+                    self._assert(var != value)
+                    
                 if len(result) >= maxcnt:
                     if silent:
                         # do not throw an exception if set to silent

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -60,7 +60,18 @@ class Visitor(object):
                     return value
         return expression
 
-    def visit(self, node):
+    def visit(self, node, use_fixed_point=False):
+        '''
+        The entry point of the visitor.
+        The exploration algorithm is a DFS post-order traversal
+        The implementation used two stacks instead of a recursion
+        The final result is store in self.result
+
+        :param node: Node to explore
+        :type node: Expression
+        :param use_fixed_point: if True, it runs _methods until a fixed point is found
+        :type use_fixed_point: Bool
+        '''   
         cache = self._cache
 
         visited = set()
@@ -74,7 +85,15 @@ class Visitor(object):
             elif isinstance(node, Operation):
                 if node in visited:
                     operands = [self.pop() for _ in xrange(len(node.operands))]
-                    value = self._method(node, *operands)
+                    if use_fixed_point:
+                        new_node = self._rebuild(node, operands)
+                        value = self._method(new_node, *operands)
+                        while value is not new_node:
+                            new_node = value
+                            if isinstance(new_node, Operation):
+                                value = self._method(new_node, *new_node.operands)
+                    else:
+                        value = self._method(node, *operands)
                     visited.remove(node)
                     self.push(value)
                     cache[node] = value
@@ -84,6 +103,15 @@ class Visitor(object):
                     stack.extend(node.operands)
             else:
                 self.push(self._method(node))
+
+    @staticmethod
+    def _rebuild(expression, operands):
+        if isinstance(expression, Operation):
+            import copy
+            aux = copy.copy(expression)
+            aux._operands = operands
+            return aux
+        return type(expression)(*operands, taint=expression.taint)
 
 class GetDeclarations(Visitor):
     ''' Simple visitor to collect all variables in an expression or set of
@@ -136,7 +164,28 @@ class PrettyPrinter(Visitor):
         self.output += '\n'
 
     def visit(self, expression):
+        '''
+        Overload Visitor.visit because:
+        - We need a pre-order traversal
+        - We use a recursion as it makes eaiser to keep track of the indentation
+
+        '''
         self._method(expression)
+
+    def _method(self, expression, *args):
+        '''
+        Overload Visitor._method because we want to stop to iterate over the
+        visit_ functions as soon as a valide visit_ function is found
+        '''
+        assert expression.__class__.__mro__[-1] is object
+        for cls in expression.__class__.__mro__:
+            sort = cls.__name__
+            methodname = 'visit_%s' % sort
+            method = getattr(self, methodname)
+            if method is not None:
+                method(expression, *args)
+                return
+        return
 
     def visit_Operation(self, expression, *operands):
         self._print(expression.__class__.__name__, expression)
@@ -199,10 +248,6 @@ class ConstantFolderSimplifier(Visitor):
                     Equal : operator.__eq__ ,
                     GreaterThan : operator.__gt__ ,
                     GreaterOrEqual : operator.__ge__ ,
-                    # None, as visit_<name> is called
-                    BitVecConcat : None ,
-                    BitVecZeroExtend : None ,
-                    BitVecExtract: None ,
                  }
 
     def visit_BitVecConcat(self, expression, *operands):
@@ -253,36 +298,6 @@ class ArithmeticSimplifier(Visitor):
     def __init__(self, parent=None, **kw):
         super(ArithmeticSimplifier, self).__init__(**kw)
 
-    def visit(self, node):
-        cache = self._cache
-
-        visited = set()
-        stack = []
-        stack.append(node)
-        while stack:
-            node = stack.pop()
- 
-            if node in cache:
-                self.push(cache[node])
-            elif isinstance(node, Operation):
-                if node in visited:
-                    operands = [self.pop() for _ in xrange(len(node.operands))]
-                    new_node = self._rebuild(node, operands)
-                    value = self._method(new_node, *operands)
-                    while value is not new_node:
-                        new_node = value
-                        if isinstance(new_node, Operation):
-                            value = self._method(new_node, *new_node.operands)
-                    visited.remove(node)
-                    self.push(value)
-                    cache[node] = value
-                else:
-                    visited.add(node)
-                    stack.append(node)
-                    stack.extend(node.operands)
-            else:
-                self.push(self._method(node))
-
     @staticmethod
     def _same_constant(a,b):
         return isinstance(a, Constant) and\
@@ -294,25 +309,12 @@ class ArithmeticSimplifier(Visitor):
         arity = len(operands)
         return any( operands[i] is not expression.operands[i] for i in range(arity))
 
-    @staticmethod
-    def _rebuild(expression, operands):
-        if isinstance(expression, Operation):
-            import copy
-            aux = copy.copy(expression)
-            aux._operands = operands
-            return aux
-        return type(expression)(*operands, taint=expression.taint)
-
     def visit_Operation(self, expression, *operands):
         ''' constant folding, if all operands of an expression are a Constant do the math '''
-        if all( isinstance(o, Constant) for o in operands) :
-            if type(expression) in ConstantFolderSimplifier.operations:
-                return constant_folder(expression)
-        else:
-            if self._changed(expression, operands):
-                expression = self._rebuild(expression, operands)
+        expression = constant_folder(expression)
+        if self._changed(expression, operands):
+            expression = self._rebuild(expression, operands)
         return expression
-
 
     def visit_BitVecZeroExtend(self, expression, *operands):
         if self._changed(expression, operands):
@@ -466,7 +468,7 @@ class ArithmeticSimplifier(Visitor):
         
 def arithmetic_simplifier(expression):
     simp = ArithmeticSimplifier()
-    simp.visit(expression)
+    simp.visit(expression, use_fixed_point=True)
     return simp.result
 
 class TranslatorSmtlib(Visitor):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -181,7 +181,7 @@ class PrettyPrinter(Visitor):
         for cls in expression.__class__.__mro__:
             sort = cls.__name__
             methodname = 'visit_%s' % sort
-            method = getattr(self, methodname)
+            method = getattr(self, methodname, None)
             if method is not None:
                 method(expression, *args)
                 return
@@ -311,7 +311,8 @@ class ArithmeticSimplifier(Visitor):
 
     def visit_Operation(self, expression, *operands):
         ''' constant folding, if all operands of an expression are a Constant do the math '''
-        expression = constant_folder(expression)
+        if all( isinstance(o, Constant) for o in operands) :
+            expression = constant_folder(expression)
         if self._changed(expression, operands):
             expression = self._rebuild(expression, operands)
         return expression


### PR DESCRIPTION
in `solve.py`: 
* Remove of the incremental mode in `get_all_values()` (two distinct calls to the solver are faster than using incremental mode in the context of `get_all_values()`)

in `visitors.py`:
* Remove duplicated prints in `PrettyPrinter`and `TranslatorSmtLib` (smt formulas are now smaller)
* Fix `visit` in `ArithmeticSimplifier`
* Fix the use of `ConstantFolderSimplifier` (no-trivial operators were not called by `ArithmeticSimplifier`)