### PR TITLE
VORPD and VORPS instructions added

### DIFF
--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -5150,6 +5150,22 @@ class X86Cpu(Cpu):
         '''
         res = dest.write(dest.read()^src.read())
 
+    @instruction
+    def VORPD(cpu, dest, src, src2):
+        '''
+        Performs a bitwise logical OR operation on the source operand (second operand) and second source operand (third operand)
+         and stores the result in the destination operand (first operand). 
+        '''
+        res = dest.write(src.read() | src2.read())
+
+    @instruction
+    def VORPS(cpu, dest, src, src2):
+        '''
+        Performs a bitwise logical OR operation on the source operand (second operand) and second source operand (third operand)
+         and stores the result in the destination operand (first operand). 
+        '''
+        res = dest.write(src.read() | src2.read())
+
  
     @instruction
     def PTEST(cpu, dest, src):


### PR DESCRIPTION
Maticore crashs when it reachs the following instructions:
```
vorpd  ymm8,ymm1,ymm0
vorpd  ymm9,ymm3,ymm2
vorpd  ymm10,ymm5,ymm4
```
Maticore uses a wrong instruction size to increase the PC. 
```
vorpd ymm8, ymm1, ymm0
rol ch, 0x65
push rsi
retf 0x55c5
```

Therefore I added VORPD and VORPS instructions to x86.py