### PR TITLE
Use newer, less broken capstone version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
 install:
 - travis_retry pip install -U pip
 - travis_retry pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
-- travis_retry pip install --no-binary keystone-engine -e .[dev]  # cs/ks can have pip install issues (cs issues #445)
+- travis_retry pip install --no-binary keystone-engine -e .[dev]  # ks can have pip install issues
 - scripts/travis_install_z3.sh
 script:
 - scripts/travis_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
 install:
 - travis_retry pip install -U pip
 - travis_retry pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
-- travis_retry pip install --no-binary capstone --no-binary keystone-engine -e .[dev]  # cs/ks can have pip install issues (cs issues #445)
+- travis_retry pip install --no-binary keystone-engine -e .[dev]  # cs/ks can have pip install issues (cs issues #445)
 - scripts/travis_install_z3.sh
 script:
 - scripts/travis_test.sh

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ python -m pip install -U pip
 
 # Install manticore and its dependencies
 git clone https://github.com/trailofbits/manticore.git && cd manticore
-sudo pip install --no-binary capstone .
+sudo pip install .
 
 # Build the examples
 cd examples/linux
@@ -61,7 +61,7 @@ Option 1: Perform a user install (requires `~/.local/bin` in your `PATH`).
 echo "PATH=\$PATH:~/.local/bin" >> ~/.profile
 source ~/.profile
 git clone https://github.com/trailofbits/manticore.git && cd manticore
-pip install --user --no-binary capstone .
+pip install --user .
 ```
 
 Option 2: Use a virtual environment (requires [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) or [similar](https://virtualenv.pypa.io/en/stable/)).
@@ -72,14 +72,14 @@ echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.profile
 source ~/.profile
 git clone https://github.com/trailofbits/manticore.git && cd manticore
 mkvirtualenv manticore
-pip install --no-binary capstone .
+pip install .
 ```
 
 Option 3: Perform a system install.
 
 ```
 git clone https://github.com/trailofbits/manticore.git && cd manticore
-sudo pip install --no-binary capstone .
+sudo pip install .
 ```
 
 Once installed, the `manticore` CLI tool and its Python API will be available.
@@ -89,7 +89,7 @@ Once installed, the `manticore` CLI tool and its Python API will be available.
 For a dev install that includes dependencies for tests, run:
 
 ```
-pip install --no-binary capstone --no-binary keystone-engine -e .[dev]
+pip install --no-binary keystone-engine -e .[dev]
 ```
 
 You can run the tests with the commands below:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version='0.1.1',
     packages=find_packages(),
     install_requires=[
-        'capstone',
+        'capstone>=3.0.5rc2',
         'pyelftools',
         'unicorn',
         'ply',


### PR DESCRIPTION
3.0.4, the default as-is is from 2015 and has a slightly broken installer, necessitating the use of --no-binary