### PR TITLE
Linux platform refactoring

### DIFF
--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -502,6 +502,50 @@ class Cpu(object):
             where += 1
         return s.getvalue()
 
+    def push_bytes(self, data):
+        '''
+        Write `data` to the stack and decrement the stack pointer accordingly.
+
+        :param str data: Data to write
+        '''
+        self.STACK -= len(data)
+        self.write_bytes(self.STACK, data)
+        return self.STACK
+
+    def pop_bytes(self, nbytes):
+        '''
+        Read `nbytes` from the stack, increment the stack pointer, and return
+        data.
+
+        :param int nbytes: How many bytes to read
+        :return: Data read from the stack
+        '''
+        data = self.read_bytes(self.STACK, nbytes)
+        self.STACK += nbytes
+        return data
+
+    def push_int(self, value):
+        '''
+        Decrement the stack pointer and write `value` to the stack.
+
+        :param int value: The value to write
+        :return: New stack pointer
+        '''
+        self.STACK -= self.address_bit_size / 8
+        self.write_int(self.STACK, value)
+        return self.STACK
+
+    def pop_int(self):
+        '''
+        Read a value from the stack and increment the stack pointer.
+
+        :return: Value read
+        '''
+        value = self.read_int(self.STACK)
+        self.STACK += self.address_bit_size / 8
+        return value
+
+
     #######################################
     # Decoder
     @abstractmethod

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -492,8 +492,12 @@ class Cpu(object):
         s = StringIO.StringIO()
         while True:
             c = self.read_int(where, 8)
+
+            assert not issymbolic(c)
+
             if c == 0:
                 break
+
             if max_length is not None:
                 if max_length == 0:
                     break

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -326,8 +326,8 @@ class Cpu(object):
         self.instruction = None
 
         # Ensure that regfile created STACK/PC aliases
-        assert hasattr(self, 'STACK')
-        assert hasattr(self, 'PC')
+        assert 'STACK' in self._regfile
+        assert 'PC' in self._regfile
 
     def __getstate__(self):
         state = {}

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -325,6 +325,10 @@ class Cpu(object):
         self._md.syntax = 0
         self.instruction = None
 
+        # Ensure that regfile created STACK/PC aliases
+        assert hasattr(self, 'STACK')
+        assert hasattr(self, 'PC')
+
     def __getstate__(self):
         state = {}
         state['regfile'] = self._regfile

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -12,6 +12,7 @@ import inspect
 import sys
 import types
 import logging
+import StringIO
 
 logger = logging.getLogger("CPU")
 register_logger = logging.getLogger("REGISTERS")
@@ -476,6 +477,30 @@ class Cpu(object):
         for i in xrange(size):
             result.append(Operators.CHR(self.read_int( where+i, 8)))
         return result
+
+    def read_string(self, where, max_length=None):
+        '''
+        Read a NUL-terminated concrete buffer from memory.
+
+        :param int where: Address to read string from
+        :param int max_length:
+            The size in bytes to cap the string at, or None [default] for no
+            limit.
+        :return: string read
+        :rtype: str
+        '''
+        s = StringIO.StringIO()
+        while True:
+            c = self.read_int(where, 8)
+            if c == 0:
+                break
+            if max_length is not None:
+                if max_length == 0:
+                    break
+                max_length = max_length - 1
+            s.write(Operators.CHR(c))
+            where += 1
+        return s.getvalue()
 
     #######################################
     # Decoder

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -412,19 +412,6 @@ class Linux(Platform):
         if '_arm_tls_memory' in state:
             self._arm_tls_memory = state['_arm_tls_memory'] 
 
-    def _read_string(self, buf):
-        """
-        Reads a null terminated concrete buffer form memory
-        :todo: FIX. move to cpu or memory 
-        """
-        filename = ""
-        for i in xrange(0,1024):
-            c = Operators.CHR(self.current.read_int(buf + i, 8))
-            if c == '\x00':
-                break
-            filename += c
-        return filename
-
     def _init_arm_kernel_helpers(self):
         '''
         ARM kernel helpers
@@ -1140,7 +1127,7 @@ class Linux(Platform):
         # buf: address of zero-terminated pathname
         # flags/access: file access bits
         # perms: file permission mode
-        filename = self._read_string(buf)
+        filename = self.current.read_string(buf)
         try :
             if os.path.abspath(filename).startswith('/proc/self'):
                 if filename == '/proc/self/exe':
@@ -1207,7 +1194,7 @@ class Linux(Platform):
         '''
         if bufsize <= 0:
             return -errno.EINVAL
-        filename = self._read_string(path)
+        filename = self.current.read_string(path)
         data = os.readlink(filename)[:bufsize]
         self.current.write_bytes(buf, data)
         logger.debug("READLINK %d %x %d -> %s",path,buf,bufsize,data)
@@ -1400,7 +1387,7 @@ class Linux(Platform):
         logger.debug("sys_set_tid_address(%016x) -> 0", tidptr)
         return 1000 #tha pid
     def sys_faccessat(self, dirfd, pathname, mode, flags):
-        filename = self._read_string(pathname)
+        filename = self.current.read_string(pathname)
         logger.debug("sys_faccessat(%016x, %s, %x, %x) -> 0", dirfd, filename, mode, flags)
         return -1
 

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -37,10 +37,10 @@ class LinuxTest(unittest.TestCase):
         envp_ptr = argv_ptr + len(real_argv)*8 + 8
 
         for i, arg in enumerate(real_argv):
-            self.assertEqual(self.linux._read_string(cpu.read_int(argv_ptr + i*8)), arg)
+            self.assertEqual(cpu.read_string(cpu.read_int(argv_ptr + i*8)), arg)
 
         for i, env in enumerate(envp):
-            self.assertEqual(self.linux._read_string(cpu.read_int(envp_ptr + i*8)), env)
+            self.assertEqual(cpu.read_string(cpu.read_int(envp_ptr + i*8)), env)
 
     def test_load_maps(self):
         mappings = self.linux.current.memory.mappings()


### PR DESCRIPTION
 * Move stack-based helpers to `Cpu`
 * Refactor initialization so that we can create a platform model that isn't associated with an ELF file
 * Simplify SLinux sys call handling to rely on normal `ConcretizeArgument` exceptions