### PR TITLE
Check returncode of manticore integration tests

### DIFF
--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -30,7 +30,8 @@ class IntegrationTest(unittest.TestCase):
                 time.sleep(1)
                 sys.stderr.write("~")
                 secs_used += 1
-    
+
+            self.assertEqual(po.returncode, 0)
             self.assertTrue(secs_used < timeout)
             sys.stderr.write("\n")
 
@@ -45,7 +46,7 @@ class IntegrationTest(unittest.TestCase):
         workspace = '%s/workspace'%self.test_dir
         t = time.time()
         with open(os.path.join(os.pardir, '%s/output.log'%self.test_dir), "w") as output:
-            po = subprocess.call(['python', '-m', 'manticore', 
+            subprocess.check_call(['python', '-m', 'manticore',
                                 '--workspace', workspace,
                                 '--timeout', '1', 
                                 '--procs', '4',


### PR DESCRIPTION
Without this, the manticore subprocess can fail, but the test still passes