### PR TITLE
Add real test for m.hook API

### DIFF
--- a/tests/test_manticore.py
+++ b/tests/test_manticore.py
@@ -20,6 +20,17 @@ class ManticoreTest(unittest.TestCase):
             pass
         self.assertTrue(tmp in self.m._hooks[entry])
 
+    def test_hook(self):
+        self.m.context['x'] = 0
+
+        @self.m.hook(None)
+        def tmp(state):
+            self.m.context['x'] = 1
+            self.m.terminate()
+        self.m.run()
+
+        self.assertEqual(self.m.context['x'], 1)
+
     def test_hook_dec_err(self):
         with self.assertRaises(TypeError):
             @self.m.hook('0x00400e40')


### PR DESCRIPTION
Other tests verify that the hook infrastructure is set up, but not that the hook actually runs.