### PR TITLE
WIP - Dev add mrc and movt

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -55,7 +55,9 @@ class Armv7Operand(Operand):
     def type(self):
         type_map = { ARM_OP_REG: 'register',
                      ARM_OP_MEM: 'memory',
-                     ARM_OP_IMM: 'immediate'}
+                     ARM_OP_IMM: 'immediate',
+                     ARM_OP_PIMM:'coprocessor',
+                     ARM_OP_CIMM:'opcode'}
 
         return type_map[self.op.type]
 

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -588,7 +588,7 @@ class Armv7Cpu(Cpu):
         :param ARMv7Operand dest: the source register; register
         '''
         val = GetNBits(src.read(), 8)
-        word = Operators.ZEXTEND(32, val)
+        word = Operators.ZEXTEND(val, cpu.address_bit_size)
         dest.write(word)
 
     @instruction

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -510,6 +510,20 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         cpu.setFlags(C=carry_out, N=HighBit(result), Z=(result == 0))
 
+    @instruction
+    def MOVT(cpu, dest, src):
+        '''
+        MOVT writes imm16 to Rd[31:16]. The write does not affect Rd[15:0].
+
+        :param Armv7Operand dest: The destination operand; register
+        :param Armv7Operand src: The source operand; 16-bit immediate
+        '''
+        assert src.type == 'immediate'
+        imm = src.read()
+        low_halfword = dest.read() & Mask(16)
+        dest.write((imm << 16) | low_halfword)
+
+
     def _compute_writeback(cpu, operand, offset):
         if offset:
             off = offset.read()

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -564,6 +564,46 @@ class Armv7Cpu(Cpu):
                         return
         raise NotImplementedError("MRC: unimplemented combination of coprocessor, opcode, and coprocessor register")
 
+    @instruction
+    def LDREX(cpu, dest, src, offset=None):
+        '''
+        LDREX loads data from memory.
+        * If the physical address has the shared TLB attribute, LDREX
+          tags the physical address as exclusive access for the current
+          processor, and clears any exclusive access tag for this
+          processor for any other physical address.
+        * Otherwise, it tags the fact that the executing processor has
+          an outstanding tagged physical address.
+
+        :param Armv7Operand dest: the destination register; register
+        :param Armv7Operand src: the source operand: register
+        '''
+        #TODO: add lock mechanism to underlying memory --GR, 2017-06-06
+        cpu._LDR(dest, src, 32, False, offset)
+
+    @instruction
+    def STREX(cpu, status, *args):
+        '''
+        STREX performs a conditional store to memory.
+        :param Armv7Operand status: the destination register for the returned status; register
+        '''
+        #TODO: implement conditional return with appropriate status --GR, 2017-06-06
+        status.write(0)
+        return cpu._STR(cpu.address_bit_size, *args)
+
+    @instruction
+    def UXTB(cpu, dest, src):
+        '''
+        UXTB extracts an 8-bit value from a register, zero-extends
+        it to the size of the register, and writes the result to the destination register.
+
+        :param ARMv7Operand dest: the destination register; register
+        :param ARMv7Operand dest: the source register; register
+        '''
+        val = GetNBits(src.read(), 8)
+        word = Operators.ZEXTEND(32, val)
+        dest.write(word)
+
     def _compute_writeback(cpu, operand, offset):
         if offset:
             off = offset.read()

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1202,6 +1202,7 @@ class Linux(Platform):
     def sys_ARM_NR_set_tls(self, val):
         if hasattr(self, '_arm_tls_memory'):
             self.current.write_int(self._arm_tls_memory, val)
+            self.current.set_arm_tls(val)
         return 0
 
     #Signals..

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -41,7 +41,10 @@ class UnicornEmulator(object):
 
     def _unicorn(self):
         if self._cpu.arch == CS_ARCH_ARM:
-            return Uc(UC_ARCH_ARM, UC_MODE_ARM)
+            if self._cpu.mode == CS_MODE_ARM:
+                return Uc(UC_ARCH_ARM, UC_MODE_ARM)
+            elif self._cpu.mode == CS_MODE_THUMB:
+                return Uc(UC_ARCH_ARM, UC_MODE_THUMB)
         elif self._cpu.arch == CS_ARCH_X86:
             if self._cpu.mode == CS_MODE_32:
                 return Uc(UC_ARCH_X86, UC_MODE_32)

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -1391,7 +1391,7 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.cpu.D10, 20)
         self.assertEqual(self.cpu.R1, pre)
 
-    @itest_setregs("R1=3")
+    @itest_setregs("R3=3")
     @itest("movt R3, #9")
     def test_movt(self):
         self.assertEqual(self.cpu.R3, 0x90003)
@@ -1399,12 +1399,12 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_custom("mrc p15, #0, r2, c13, c0, #3")
     def test_mrc(self):
         self.cpu.set_arm_tls(0x55555)
-        self.cpu.rf.write('R2', 0)
+        self.cpu.write_register('R2', 0)
         self.cpu.execute()
         self.assertEqual(self.cpu.R2, 0x55555)
 
     @itest_setregs("R1=0x45", "R2=0x55555555")
-    @itest("utxb r1 r2")
-    def test_utxb(self):
+    @itest("uxtb r1, r2")
+    def test_uxtb(self):
         self.assertEqual(self.cpu.R2, 0x55555555)
         self.assertEqual(self.cpu.R1, 0x55)

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -1390,3 +1390,21 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.cpu.D9, 21)
         self.assertEqual(self.cpu.D10, 20)
         self.assertEqual(self.cpu.R1, pre)
+
+    @itest_setregs("R1=3")
+    @itest("movt R3, #9")
+    def test_movt(self):
+        self.assertEqual(self.cpu.R3, 0x90003)
+
+    @itest_custom("mrc p15, #0, r2, c13, c0, #3")
+    def test_mrc(self):
+        self.cpu.set_arm_tls(0x55555)
+        self.cpu.rf.write('R2', 0)
+        self.cpu.execute()
+        self.assertEqual(self.cpu.R2, 0x55555)
+
+    @itest_setregs("R1=0x45", "R2=0x55555555")
+    @itest("utxb r1 r2")
+    def test_utxb(self):
+        self.assertEqual(self.cpu.R2, 0x55555555)
+        self.assertEqual(self.cpu.R1, 0x55)


### PR DESCRIPTION
WIP, soliciting feedback

this branch implements the `mrc`, `movt`, `utxb`, `ldrex`, and `strex` instructions, in an effort to support the binary associated with #182

Still to do:
* implement handling of `lsl.w   r5, r5, #3`  -- it causes an assertion error, as the current implementation of `LSL` assumes the shift amount operand is a register
* implement `ldrd` instruction
* implement `strd` instruction