### PR TITLE
Fix signal_transmit crash

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1590,10 +1590,12 @@ class Linux(Platform):
 
     def signal_transmit(self, fd):
         ''' Awake one process waiting to transmit data on fd '''
-        connections = self.connections
-        if connections(fd) and self.rwait[connections(fd)]:
-            procid = random.sample(self.rwait[connections(fd)], 1)[0]
-            self.awake(procid)
+        connection = self.connections(fd)
+        if connection is None or connection >= len(self.rwait):
+            return
+
+        procid = random.sample(self.rwait[connection], 1)[0]
+        self.awake(procid)
 
     def check_timers(self):
         ''' Awake process if timer has expired '''

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1594,8 +1594,10 @@ class Linux(Platform):
         if connection is None or connection >= len(self.rwait):
             return
 
-        procid = random.sample(self.rwait[connection], 1)[0]
-        self.awake(procid)
+        procs = self.rwait[connection]
+        if procs:
+            procid = random.sample(procs, 1)[0]
+            self.awake(procid)
 
     def check_timers(self):
         ''' Awake process if timer has expired '''


### PR DESCRIPTION
signal_transmit can crash if the `fd` passed is not being waited on ( `connections(fd)` does not correspond to an index in `self.rwait`). This PR slightly restructures the code checks that this condition is true.