### PR TITLE
Make Linux write(2) work with Files

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -33,8 +33,8 @@ def makeDecree(args):
 
     #if args.data != '':
     #    logger.info('Starting with concrete input: {}'.format(args.data))
-    platform.input.write(args.data)
-    platform.input.write(initial_state.symbolicate_buffer('+'*14, label='RECEIVE'))
+    platform.input.transmit(args.data)
+    platform.input.transmit(initial_state.symbolicate_buffer('+'*14, label='RECEIVE'))
     return initial_state
 
 def makeLinux(program, argv, env, symbolic_files, concrete_start = ''):

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -33,8 +33,8 @@ def makeDecree(args):
 
     #if args.data != '':
     #    logger.info('Starting with concrete input: {}'.format(args.data))
-    platform.input.transmit(args.data)
-    platform.input.transmit(initial_state.symbolicate_buffer('+'*14, label='RECEIVE'))
+    platform.input.write(args.data)
+    platform.input.write(initial_state.symbolicate_buffer('+'*14, label='RECEIVE'))
     return initial_state
 
 def makeLinux(program, argv, env, symbolic_files, concrete_start = ''):
@@ -60,10 +60,10 @@ def makeLinux(program, argv, env, symbolic_files, concrete_start = ''):
     if any(issymbolic(x) for val in argv + env for x in val):
         platform.setup_stack([program] + argv, env)
 
-    platform.input.transmit(concrete_start)
+    platform.input.write(concrete_start)
 
     #set stdin input...
-    platform.input.transmit(initial_state.symbolicate_buffer('+'*256, label='STDIN'))
+    platform.input.write(initial_state.symbolicate_buffer('+'*256, label='STDIN'))
 
     return initial_state 
 

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -241,9 +241,6 @@ class Socket(object):
         return ret
 
     def write(self, buf):
-        return self.transmit(buf)
-
-    def transmit(self, buf):
         assert self.is_connected()
         return self.peer._transmit(buf)
 
@@ -1062,7 +1059,7 @@ class Linux(Platform):
                 raise RestartSyscall()
 
             data = cpu.read_bytes(buf, count)
-            self.files[fd].transmit(data)
+            self.files[fd].write(data)
 
             for line in ''.join([str(x) for x in data]).split('\n'):
                 logger.debug("WRITE(%d, 0x%08x, %d) -> <%.48r>"%(fd, buf, count, line))

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -60,6 +60,9 @@ class File(object):
     def fileno(self, *args):
         return self.file.fileno(*args)
 
+    def is_full(self):
+        return False
+
     def __getstate__(self):
         state = {}
         state['name'] = self.name

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -51,8 +51,9 @@ class File(object):
         return self.file.tell(*args)
     def seek(self, *args):
         return self.file.seek(*args)
-    def write(self, *args):
-        return self.file.write(*args)
+    def write(self, buf):
+        for c in buf:
+            self.file.write(c)
     def read(self, *args):
         return self.file.read(*args)
     def close(self, *args):


### PR DESCRIPTION
Currently, Linux.sys_write assumes `is_full` and `transmit` methods on file descriptor objects, however File has neither of these. Add `is_full` to File, and refactor so both Files and Sockets use `write`