### PR TITLE
Use global path for workspace

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -375,11 +375,11 @@ class Manticore(object):
         else:
             os.mkdir(path)
 
-        self._workspace_path = path
+        self._workspace_path = os.path.abspath(path)
 
     def _make_workspace(self):
         ''' Make working directory '''
-        return tempfile.mkdtemp(prefix="mcore_", dir='./')
+        return os.path.abspath(tempfile.mkdtemp(prefix="mcore_", dir='./'))
 
     @property
     def policy(self):


### PR DESCRIPTION
Hack around simple chdir OS model, which actually calls chdir on the host. If a program chdirs and we use relative paths for workspace operations, we will fail all future operations on the workspace.

In the future, we should implement a virtual filesystem ( #296 ) to avoid the need for this.