### PR TITLE
Add .sync to regular Files also

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -65,6 +65,9 @@ class File(object):
     def is_full(self):
         return False
 
+    def sync(self):
+        return
+
     def __getstate__(self):
         state = {}
         state['name'] = self.name


### PR DESCRIPTION
Fixes a bug where if a program opens a non-symbolic file, sys_write will crash since Files don't have .sync, only SymbolicFiles