### PR TITLE
short circuit _getState when queue is empty

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -332,6 +332,8 @@ class Executor(object):
         return self._getState(policy, order, fudge)
 
     def _getState(self, policy='random', order='max', fudge=1):
+        if not self._states.items():
+            return None
         assert order in ['max','min']
         assert abs(fudge)>0
         assert policy in ['random','adhoc','uncovered','dicount','icount','syscount','depth','bucket']


### PR DESCRIPTION
When the number of workers is high but the queue is empty, manticore spends a ton of time in _getState doing nothing. Running [this script](https://github.com/trailofbits/manticore-examples/blob/master/google2016_unbreakable/win.py) with 40 processes instead of 10 on my machine takes ~12,000 seconds before this PR and ~300 after.