### PR TITLE
Changed Socket parameters to accept seek paramaters

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -257,7 +257,7 @@ class Socket(object):
     def sync(self):
         raise BadFd("Invalid sync() operation on Socket")
 
-    def seek(self):
+    def seek(self, *args):
         raise BadFd("Invalid lseek() operation on Socket")
 
 class Linux(Platform):


### PR DESCRIPTION
If you run `manticore crackme` you'll get the error `seek() takes exactly 1 argument (2 given)`, this is because the `seek` function in the `Socket` class of `linux.py` is implemented without accepting any parameters. I changed this to match the other seek declarations.