### PR TITLE
Activate executor debug logging with verbosity=2

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -271,7 +271,7 @@ class Manticore(object):
     @verbosity.setter
     def verbosity(self, setting):
         levels = [[],
-                  [('MAIN', logging.INFO), ('EXECUTOR', logging.INFO)],
+                  [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG)],
                   [('PLATFORM', logging.DEBUG)],
                   [('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG)],
                   [('REGISTERS', logging.DEBUG)],


### PR DESCRIPTION
Currently, at no verbosity level do we activate debug level logging
from the executor, however there is significant debug level logging in the
executor for state forking output.