### PR TITLE
Fix verbosity=1 

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -271,8 +271,8 @@ class Manticore(object):
     @verbosity.setter
     def verbosity(self, setting):
         levels = [[],
-                  [('MAIN', logging.INFO), ('EXECUTOR', logging.DEBUG)],
-                  [('PLATFORM', logging.DEBUG)],
+                  [('MAIN', logging.INFO), ('EXECUTOR', logging.INFO)],
+                  [('PLATFORM', logging.DEBUG), ('EXECUTOR', logging.DEBUG)],
                   [('MEMORY', logging.DEBUG), ('CPU', logging.DEBUG)],
                   [('REGISTERS', logging.DEBUG)],
                   [('SMT', logging.DEBUG)]]

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -1,3 +1,4 @@
+import StringIO
 import unittest
 import sys
 import shutil
@@ -54,6 +55,21 @@ class IntegrationTest(unittest.TestCase):
                                 '+++++++++'], stdout=output)
         self.assertTrue(time.time()-t < 20)
 
+    def test_cli_verbosity(self):
+        """
+        Tests that default verbosity should result in output like below, with only the
+        "Generating testcase" lines printed as main output.
+
+        2017-06-21 17:14:24,119: [111703] MAIN:INFO: Loading program: ['/mnt/hgfs/code/manticore/tests/binaries/basic_linux_amd64']
+        2017-06-21 17:14:24,120: [111703] MAIN:INFO: Workspace: /mnt/hgfs/code/manticore/tests/mcore_rtDVZS
+        2017-06-21 17:14:30,369: [111762][3] EXECUTOR:INFO: Generating testcase No. 1 for state No.3 - Program finished correctly
+        2017-06-21 17:14:31,294: [111762][5] EXECUTOR:INFO: Generating testcase No. 2 for state No.5 - Program finished correctly
+        """
+
+        dirname = os.path.dirname(__file__)
+        filename = os.path.join(dirname, 'binaries/basic_linux_amd64')
+        output = subprocess.check_output(['python', '-m', 'manticore', filename])
+        self.assertEqual(len(output.splitlines()), 4)
 
     @unittest.skip('TODO(mark); skipping so we can move on with our lives and merge x86_new. ask felipe to fix later.')
     def testArgumentsAssertions(self):


### PR DESCRIPTION
#310 accidentally changed the default of Manticore to be much more verbose than just the minimal "Generating testcase" lines. This reverts that and adds Executor debug verbosity only on level 2+. 