### PR TITLE
lsl.w in thumb mode fixed, plus tests

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -331,9 +331,9 @@ class Armv7Cpu(Cpu):
         self._force_next = state['_force_next']
 
     def _set_mode(self, new_mode):
-		assert new_mode in (CS_MODE_ARM, CS_MODE_THUMB)
-		self.mode = new_mode
-		self._md.mode = new_mode
+        assert new_mode in (CS_MODE_ARM, CS_MODE_THUMB)
+        self.mode = new_mode
+        self._md.mode = new_mode
 
     def _swap_mode(self):
         #swap from arm to thumb or back

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -6,18 +6,24 @@ from manticore.core.cpu.arm import Armv7Cpu as Cpu, Mask, Interruption
 from manticore.core.memory import Memory32
 
 from capstone.arm import *
-from capstone import CS_MODE_THUMB
+from capstone import CS_MODE_THUMB, CS_MODE_ARM
 from keystone import Ks, KS_ARCH_ARM, KS_MODE_ARM, KS_MODE_THUMB
 
 ks = Ks(KS_ARCH_ARM, KS_MODE_ARM)
+ks_thumb = Ks(KS_ARCH_ARM, KS_MODE_THUMB)
 
 import logging
 
 logger = logging.getLogger("ARM_TESTS")
 
 
-def assemble(asm):
-    ords = ks.asm(asm)[0]
+def assemble(asm, mode=CS_MODE_ARM):
+    if CS_MODE_ARM == mode:
+        ords = ks.asm(asm)[0]
+    elif CS_MODE_THUMB == mode:
+        ords = ks_thumb.asm(asm)[0]
+    else:
+        raise Exception('bad processor mode for assembly: {}'.format(mode))
     if not ords:
         raise Exception('bad assembly: {}'.format(asm))
     return ''.join(map(chr, ords))
@@ -132,6 +138,17 @@ def itest_custom(asm):
 
     return instr_dec
 
+def itest_custom_thumb(asm):
+    def instr_dec(custom_func):
+        @wraps(custom_func)
+        def wrapper(self):
+            self._setupCpu(asm, mode=CS_MODE_THUMB)
+            custom_func(self)
+
+        return wrapper
+
+    return instr_dec
+
 
 class Armv7CpuInstructions(unittest.TestCase):
     def setUp(self):
@@ -139,14 +156,15 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.mem = self.cpu.memory
         self.rf = self.cpu.regfile
 
-    def _setupCpu(self, asm):
+    def _setupCpu(self, asm, mode=CS_MODE_ARM):
         self.code = self.mem.mmap(0x1000, 0x1000, 'rwx')
         self.data = self.mem.mmap(0xd000, 0x1000, 'rw')
         self.stack = self.mem.mmap(0xf000, 0x1000, 'rw')
         start = self.code + 4
-        self.mem.write(start, assemble(asm))
+        self.mem.write(start, assemble(asm, mode))
         self.rf.write('PC', start)
         self.rf.write('SP', self.stack + 0x1000)
+        self.cpu._set_mode(mode)
 
     def _checkFlagsNZCV(self, n, z, c, v):
         self.assertEqual(self.rf.read('APSR_N'), n)
@@ -1244,21 +1262,10 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.cpu.R2, 0x1 << 31)
         self._checkFlagsNZCV(1, 0, 1, 0)
 
-    def test_lslw(self):
-        ''' custom test for degenerate case'''
-        tmp_ks = Ks(KS_ARCH_ARM, KS_MODE_THUMB)
-        ords = tmp_ks.asm("lsl.w r5, r6, #3")[0]
-        asm = ''.join(map(chr, ords))
-        self.code = self.mem.mmap(0x1000, 0x1000, 'rwx')
-        self.data = self.mem.mmap(0xd000, 0x1000, 'rw')
-        self.stack = self.mem.mmap(0xf000, 0x1000, 'rw')
-        start = self.code + 4
-        self.mem.write(start, asm)
-        self.rf.write('PC', start)
-        self.rf.write('SP', self.stack + 0x1000)
-        self.rf.write('R5', 0x1)
-        self.rf.write('R6', 0x2)
-        self.cpu._set_mode(CS_MODE_THUMB)
+    @itest_setregs("R5=1", "R6=2")
+    @itest_custom_thumb("lsl.w r5, r6, #3")
+    def test_lslw_thumb(self):
+        '''thumb mode specific behavior'''
         self.cpu.execute()
         self.assertEqual(self.cpu.R5, 0x2 << 3)
 
@@ -1272,6 +1279,18 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest("lsr r0, r0, #3")
     def test_lsr_reg_imm(self):
         self.assertEqual(self.rf.read('R0'), 0x1000 >> 3)
+
+    @itest_setregs("R5=0", "R6=16")
+    @itest_custom_thumb("lsr.w R5, R6, #3")
+    def test_lsrw_thumb(self):
+        self.cpu.execute()
+        self.assertEqual(self.cpu.R5, 16>>3)
+
+    @itest_setregs("R5=0", "R6=16")
+    @itest_custom_thumb("asr.w R5, R6, #3")
+    def test_asrw_thumb(self):
+        self.cpu.execute()
+        self.assertEqual(self.cpu.R5, 16>>3)
 
     @itest_setregs("R2=29")
     @itest("RSB r2, r2, #31")

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -1031,6 +1031,7 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_bx_basic(self):
         self.cpu.execute()
         self.assertEqual(self.rf.read('PC'), 0x1008)
+        self.assertEqual(self.cpu.mode, CS_MODE_ARM)
 
     @itest_custom("bx r1")
     @itest_setregs("R1=0x1009")
@@ -1038,6 +1039,7 @@ class Armv7CpuInstructions(unittest.TestCase):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
         self.assertEqual(self.rf.read('PC'), pre_pc + 4)
+        self.assertEqual(self.cpu.mode, CS_MODE_THUMB)
 
     # ORR
 
@@ -1351,12 +1353,14 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_blx_reg(self):
         self.assertEqual(self.rf.read('PC'), 0x1008)
         self.assertEqual(self.rf.read('LR'), 0x1008)
+        self.assertEqual(self.cpu.mode, CS_MODE_ARM)
 
     @itest_setregs("R1=0x1009")
     @itest("BLX R1")
     def test_blx_reg_thumb(self):
         self.assertEqual(self.rf.read('PC'), 0x1008)
         self.assertEqual(self.rf.read('LR'), 0x1008)
+        self.assertEqual(self.cpu.mode, CS_MODE_THUMB)
 
     @itest_setregs("R1=0xffffffff", "R2=2")
     @itest("UMULLS R1, R2, R1, R2")


### PR DESCRIPTION
Fixes lsl.w in thumb mode and includes a test that exercised the problematic behavior.

The BX instruction now sets the processor mode appropriately for disassembly.