### PR TITLE
Fixes ConcretizeArgument Misspelling

### DIFF
--- a/manticore/models.py
+++ b/manticore/models.py
@@ -83,9 +83,9 @@ def strcmp(state, s1, s2):
     cpu = state.cpu
 
     if issymbolic(s1):
-        raise ConcretizeArgumet(state.cpu, 1)
+        raise ConcretizeArgument(state.cpu, 1)
     if issymbolic(s2):
-        raise ConcretizeArgumet(state.cpu, 2)
+        raise ConcretizeArgument(state.cpu, 2)
 
     s1_zero_idx = _find_zero(cpu, state.constraints, s1)
     s2_zero_idx = _find_zero(cpu, state.constraints, s2)
@@ -126,7 +126,7 @@ def strlen(state, s):
     cpu = state.cpu
 
     if issymbolic(s):
-        raise ConcretizeArgumet(state.cpu, 1)
+        raise ConcretizeArgument(state.cpu, 1)
 
     zero_idx = _find_zero(cpu, state.constraints, s)
 

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -1086,15 +1086,15 @@ class DecreeEmu(object):
         import cgcrandom
         if issymbolic(buf):
             logger.info("Ask to write random bytes to a symbolic buffer")
-            raise ConcretizeArgumet(platform.current, 0)
+            raise ConcretizeArgument(platform.current, 0)
 
         if issymbolic(count):
             logger.info("Ask to read a symbolic number of random bytes ")
-            raise ConcretizeArgumet(platform.current, 1)
+            raise ConcretizeArgument(platform.current, 1)
 
         if issymbolic(rnd_bytes):
             logger.info("Ask to return rnd size to a symbolic address ")
-            raise ConcretizeArgumet(platform.current, 2)
+            raise ConcretizeArgument(platform.current, 2)
 
         data = []
         for i in xrange(count):

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2067,29 +2067,29 @@ class SLinux(Linux):
     def sys_read(self, fd, buf, count):
         if issymbolic(fd):
             logger.debug("Ask to read from a symbolic file descriptor!!")
-            raise ConcretizeArgumet(self, 0)
+            raise ConcretizeArgument(self, 0)
 
         if issymbolic(buf):
             logger.debug("Ask to read to a symbolic buffer")
-            raise ConcretizeArgumet(self, 1)
+            raise ConcretizeArgument(self, 1)
 
         if issymbolic(count):
             logger.debug("Ask to read a symbolic number of bytes ")
-            raise ConcretizeArgumet(self, 2)
+            raise ConcretizeArgument(self, 2)
 
         return super(SLinux, self).sys_read(fd, buf, count)
 
     def sys_write(self, fd, buf, count):
         if issymbolic(fd):
             logger.debug("Ask to write to a symbolic file descriptor!!")
-            raise ConcretizeArgumet(self, 0)
+            raise ConcretizeArgument(self, 0)
 
         if issymbolic(buf):
             logger.debug("Ask to write to a symbolic buffer")
-            raise ConcretizeArgumet(self, 1)
+            raise ConcretizeArgument(self, 1)
 
         if issymbolic(count):
             logger.debug("Ask to write a symbolic number of bytes ")
-            raise ConcretizeArgumet(self, 2)
+            raise ConcretizeArgument(self, 2)
 
         return super(SLinux, self).sys_write(fd, buf, count)

--- a/manticore/platforms/windows.py
+++ b/manticore/platforms/windows.py
@@ -541,7 +541,7 @@ class ntdll(object):
     def RtlAllocateHeap(platform, handle, flags, size):
         if issymbolic(size):
             logger.info("RtlAllcoateHeap({}, {}, SymbolicSize); concretizing size".format(str(handle), str(flags)) )
-            raise ConcretizeArgumet(platform.current, 2)
+            raise ConcretizeArgument(platform.current, 2)
         else:
             raise IgnoreAPI("RtlAllocateHeap({}, {}, {:08x})".format(str(handle), str(flags), size))
 
@@ -583,7 +583,7 @@ class kernel32(object):
         except MemoryException as me:
             raise MemoryException("{}: {}".format(myname, me.cause), 0xFFFFFFFF)
         except SymbolicAPIArgument:
-            raise ConcretizeArgumet(platform.current, 1)
+            raise ConcretizeArgument(platform.current, 1)
 
         logger.info("{}({}, [{}], {}, {}, {})".format(
             myname,
@@ -647,7 +647,7 @@ class kernel32(object):
         except MemoryException as me:
             raise MemoryException("{}: {}".format(myname, me.cause), 0xFFFFFFFF)
         except SymbolicAPIArgument:
-            raise ConcretizeArgumet(platform.current, 1)
+            raise ConcretizeArgument(platform.current, 1)
 
         logger.info("{}({}, [{}], {}, {}, {}, {}, {}, {}, {})".format(myname,
             str(hKey), key_str, str(Reserved), str(lpClass), str(dwOptions), 
@@ -747,7 +747,7 @@ class kernel32(object):
             msg = "CreateFile{}: {}".format(utf16 and "W" or "A", me.cause)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
-            raise ConcretizeArgumet(platform.current, 0)
+            raise ConcretizeArgument(platform.current, 0)
 
 
         logger.info("""CreateFile%s(
@@ -853,7 +853,7 @@ class kernel32(object):
             msg = "{}: {}".format(myname, me.cause)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
-            raise ConcretizeArgumet(platform.current, 0)
+            raise ConcretizeArgument(platform.current, 0)
 
         try:
             cmdline = readStringFromPointer(platform, cpu, lpCommandLine, utf16)
@@ -861,7 +861,7 @@ class kernel32(object):
             msg = "{}: {}".format(myname, me.cause)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
-            raise ConcretizeArgumet(platform.current, 1)
+            raise ConcretizeArgument(platform.current, 1)
 
         raise IgnoreAPI("{}([{}], [{}], {}, {}, {}, {}, {}, {}, {}, {})".format(myname,
             appname, cmdline, str(lpProcessAttributes), 


### PR DESCRIPTION
Fixes ConcretizeArgumet misspelling.

Files In Effect:
-manticore\models.py | Line 86 & 88

-manticore\platforms\decree.py | Line 1089, 1093, & 1097

-manticore\platforms\linux.py | Line 2070, 2074, 2078, 2085, 2089, & 2093

-manticore\platforms\windows.py | Line 544, 586, 650, 750, 856, & 864.

Thank you for letting me contribute to your project!
 - Signed Ffio1