### PR TITLE
Update forward_signals() behavior

### DIFF
--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -14,7 +14,7 @@ def forward_signals(dest, source, arg=False):
         Replicate and forward all the signals from source to dest
     '''
     #Import all signals from state
-    for signal_name in dir(source):
+    for signal_name in source.__dict__:
         signal = getattr(source, signal_name, None)
         if isinstance(signal, Signal):
             proxy = getattr(dest, signal_name, Signal())


### PR DESCRIPTION
`forward_signals()` iterates through a list of strings returned by `dir(source)`. This has the side-effect of invoking all properties on the source object. If the property has side effects, they will be executed when `getattr()` is called.

Iterating through `source.__dict__` ensures that we only iterate through instance members (which signals should be) and remain side-effect free.