### PR TITLE
Catch and refactor MemoryExceptions

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -479,7 +479,7 @@ class Executor(object):
                         current_state = None
 
                     except TerminateState as e:
-                        #logger.error("MemoryException at PC: 0x{:016x}. Cause: {}\n".format(current_state.cpu.instruction.address, e.cause))
+                        #logger.error("MemoryException at PC: 0x{:016x}. Cause: {}\n".format(current_state.cpu.instruction.address, e.message))
                         #self.generate_testcase(current_state, "Memory Exception: " + str(e))
                         #self.generate_testcase(current_state, "Invalid PC Exception" + str(e))
                         #self.generate_testcase(current_state, "Program finished correctly")

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -479,12 +479,6 @@ class Executor(object):
                         current_state = None
 
                     except TerminateState as e:
-                        #logger.error("MemoryException at PC: 0x{:016x}. Cause: {}\n".format(current_state.cpu.instruction.address, e.message))
-                        #self.generate_testcase(current_state, "Memory Exception: " + str(e))
-                        #self.generate_testcase(current_state, "Invalid PC Exception" + str(e))
-                        #self.generate_testcase(current_state, "Program finished correctly")
-                        #logger.error("Syscall not implemented: %s", str(e))
-
                         #Notify this worker is done
                         self.will_terminate_state(current_state, current_state_id, e)
 

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -12,35 +12,37 @@ class MemoryException(Exception):
     '''
     Memory exceptions
     '''
-    def __init__(self, cause, address):
+    def __init__(self, message, address=None):
         '''
         Builds a memory exception.
 
-        :param cause: exception message.
+        :param message: exception message.
         :param address: memory address where the exception occurred.
         '''
-        super(MemoryException, self, ).__init__('{} <{}>'.format(cause, address))
-        self.cause = cause
+        self.message = '{} <{}>'.format(message, address)
         self.address = address
 
     def __str__(self):
-        return '%s <%s>'%(self.cause, '%08x'%self.address)
+        return '%s <%s>'%(self.message, '%08x'%self.address)
 
 class InvalidMemoryAccess(MemoryException):
+    _message = 'Invalid memory access'
     def __init__(self, address, mode):
+        assert mode in 'rwx'
+        suffix = ' (mode:{})'.format(mode)
+        super(InvalidMemoryAccess, self, ).__init__(self._message + suffix, address)
         self.mode = mode
-        super(InvalidMemoryAccess, self, ).__init__('Invalid mode trying to access memory in mode {}'.format(mode), address)
 
 class InvalidSymbolicMemoryAccess(InvalidMemoryAccess):
-    def __init__(self, cause, address, size, constraint):
-        super(InvalidSymbolicMemoryAccess, self, ).__init__(cause, address)
+    _message = 'Invalid symbolic memory access'
+    def __init__(self, address, mode, size, constraint):
+        super(InvalidSymbolicMemoryAccess, self, ).__init__(address, mode)
         #the crashing constraint you need to assert 
         self.constraint = constraint 
         self.size = size
 
     def __str__(self):
-        return '%s <%s>'%(self.cause, repr(self.address))
-
+        return '%s <%s>'%(self.message, repr(self.address))
 
 class ConcretizeMemory(MemoryException):
     '''
@@ -501,7 +503,7 @@ class Memory(object):
                 return p << self.page_bit_size
             counter+=1
             if counter >= self.memory_size/self.page_size:
-                raise MemoryException('Not enough memory', 0)
+                raise MemoryException('Not enough memory')
 
         return self._search( size, self.memory_size-size, counter  )
 
@@ -752,7 +754,7 @@ class Memory(object):
     #write and read potentially symbolic bytes at symbolic indexes
     def read(self, addr, size):
         if not self.access_ok(slice(addr, addr+size), 'r'):
-            raise MemoryException('No access reading', addr)
+            raise InvalidMemoryAccess(addr, 'r')
 
         assert size > 0
         result = []
@@ -806,7 +808,7 @@ class Memory(object):
     def write(self, addr, buf):
         size = len(buf)
         if not self.access_ok(slice(addr, addr + size), 'w'):
-            raise MemoryException('No access writing', addr)
+            raise InvalidMemoryAccess(addr, 'w')
         assert size > 0
         stop = addr + size
         start = addr
@@ -913,10 +915,10 @@ class SMemory(Memory):
             logger.debug('Reading %d bytes from symbolic address %s', size, address)
             try:
                 solutions = solver.get_all_values(self.constraints, address, maxcnt=0x1000) #if more than 0x3000 exception
-            except TooManySolutions, e:
+            except TooManySolutions as e:
+                print 1234
                 m, M = solver.minmax(self.constraints, address)
-                logger.info('Got TooManySolutions on a symbolic read. Range [%x, %x]. Not crashing!', m, M)
-                logger.info('Memory:%s',  self)
+                logger.debug('Got TooManySolutions on a symbolic read. Range [%x, %x]. Not crashing!', m, M)
 
                 crashing_condition = True
                 for start, end, perms, offset, name  in self.mappings():
@@ -925,7 +927,7 @@ class SMemory(Memory):
                             crashing_condition = Operators.AND(Operators.OR( (address+size).ult(start), address.uge(end) ), crashing_condition)
 
                 if solver.can_be_true(self.constraints, crashing_condition):
-                    raise InvalidSymbolicMemoryAccess('No access reading symbolic', address, size, crashing_condition)
+                    raise InvalidSymbolicMemoryAccess(address, 'r', size, crashing_condition)
 
 
                 #INCOMPLETE Result! We could also fork once for every map
@@ -945,7 +947,7 @@ class SMemory(Memory):
                     crashing_condition = Operators.OR(address == base, crashing_condition)
 
             if solver.can_be_true(self.constraints, crashing_condition):
-                raise InvalidSymbolicMemoryAccess('No access reading symbolic', address, size, crashing_condition)
+                raise InvalidSymbolicMemoryAccess(address, 'r', size, crashing_condition)
 
             condition = False
             for base in solutions:
@@ -997,7 +999,7 @@ class SMemory(Memory):
                     crashing_condition = Operators.OR(address == base, crashing_condition)
 
             if solver.can_be_true(self.constraints, crashing_condition):
-                raise InvalidSymbolicMemoryAccess('No access writing symbolic', address, size, crashing_condition)
+                raise InvalidSymbolicMemoryAccess(address, 'w', size, crashing_condition)
 
             for offset in xrange(size):
                 for base in solutions:
@@ -1009,7 +1011,7 @@ class SMemory(Memory):
             for offset in xrange(size):
                 if issymbolic(value[offset]):
                     if not self.access_ok(address+offset, 'w'):
-                        raise MemoryException('No access writing', address+offset)
+                        raise InvalidMemoryAccess(address+offset, 'w')
                     self._symbols[address+offset] = [(True, value[offset])]
                 else:
                     # overwrite all previous items

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -23,7 +23,7 @@ class MemoryException(Exception):
         self.address = address
         self.message = message
         if not issymbolic(address):
-            self.message += ' <{}>'.format(address)
+            self.message += ' <0x{:x}>'.format(address)
 
     def __str__(self):
         return '%s <%s>'%(self.message, '%08x'%self.address)

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -22,11 +22,11 @@ class MemoryException(Exception):
         '''
         self.address = address
         self.message = message
-        if not issymbolic(address):
-            self.message += ' <0x{:x}>'.format(address)
+        if address is not None and not issymbolic(address):
+            self.message += ' <{:x}>'.format(address)
 
     def __str__(self):
-        return '%s <%s>'%(self.message, '%08x'%self.address)
+        return self.message
 
 
 class ConcretizeMemory(MemoryException):
@@ -60,9 +60,6 @@ class InvalidSymbolicMemoryAccess(InvalidMemoryAccess):
         #the crashing constraint you need to assert 
         self.constraint = constraint 
         self.size = size
-
-    def __str__(self):
-        return '%s <%s>'%(self.message, repr(self.address))
 
 
 class Map(object):

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -9,20 +9,19 @@ from ..utils.event import Signal, forward_signals
 
 #import exceptions
 from .cpu.abstractcpu import ConcretizeRegister
-from .memory import ConcretizeMemory
+from .memory import ConcretizeMemory, MemoryException
 from ..platforms.platform import *
 
 class StateException(Exception):
     ''' All state related exceptions '''
-    def __init__(self, *args, **kwargs):
-        super(StateException, self).__init__(*args)
-        
+    pass
+
 
 class TerminateState(StateException):
     ''' Terminates current state exploration '''
-    def __init__(self, *args, **kwargs):
-        super(TerminateState, self).__init__(*args, **kwargs)
-        self.testcase = kwargs.get('testcase', False)
+    def __init__(self, message, testcase=False):
+        super(TerminateState, self).__init__(message)
+        self.testcase = testcase
 
 
 class Concretize(StateException):
@@ -138,6 +137,8 @@ class State(object):
                                 expression=expression, 
                                 setstate=setstate,
                                 policy=e.policy)
+        except MemoryException as e:
+            raise TerminateState(e.message, testcase=True)
 
         #Remove when code gets stable?
         assert self.platform.constraints is self.constraints

--- a/manticore/platforms/windows.py
+++ b/manticore/platforms/windows.py
@@ -581,7 +581,7 @@ class kernel32(object):
         try:
             key_str = readStringFromPointer(platform, cpu, lpSubKey, utf16)
         except MemoryException as me:
-            raise MemoryException("{}: {}".format(myname, me.cause), 0xFFFFFFFF)
+            raise MemoryException("{}: {}".format(myname, me.message), 0xFFFFFFFF)
         except SymbolicAPIArgument:
             raise ConcretizeArgumet(platform.current, 1)
 
@@ -645,7 +645,7 @@ class kernel32(object):
         try:
             key_str = readStringFromPointer(platform, cpu, lpSubKey, utf16)
         except MemoryException as me:
-            raise MemoryException("{}: {}".format(myname, me.cause), 0xFFFFFFFF)
+            raise MemoryException("{}: {}".format(myname, me.message), 0xFFFFFFFF)
         except SymbolicAPIArgument:
             raise ConcretizeArgumet(platform.current, 1)
 
@@ -744,7 +744,7 @@ class kernel32(object):
         try:
             filename = readStringFromPointer(platform, cpu, lpFileName, utf16)
         except MemoryException as me:
-            msg = "CreateFile{}: {}".format(utf16 and "W" or "A", me.cause)
+            msg = "CreateFile{}: {}".format(utf16 and "W" or "A", me.message)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
             raise ConcretizeArgumet(platform.current, 0)
@@ -850,7 +850,7 @@ class kernel32(object):
         try:
             appname = readStringFromPointer(platform, cpu, lpApplicationName, utf16)
         except MemoryException as me:
-            msg = "{}: {}".format(myname, me.cause)
+            msg = "{}: {}".format(myname, me.message)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
             raise ConcretizeArgumet(platform.current, 0)
@@ -858,7 +858,7 @@ class kernel32(object):
         try:
             cmdline = readStringFromPointer(platform, cpu, lpCommandLine, utf16)
         except MemoryException as me:
-            msg = "{}: {}".format(myname, me.cause)
+            msg = "{}: {}".format(myname, me.message)
             raise MemoryException(msg, 0xFFFFFFFF)
         except SymbolicAPIArgument:
             raise ConcretizeArgumet(platform.current, 1)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1280,7 +1280,9 @@ class MemoryTest(unittest.TestCase):
         self.assertEqual(mem[addr], 'a')
 
         mem.mprotect(addr, size, 'w')
-        self.assertRaisesRegexp(MemoryException, "No access reading <%08x>"%addr, mem.__getitem__, addr)
+        with self.assertRaisesRegexp(InvalidMemoryAccess, 'Invalid memory access \(mode:.\) <{:x}>'.format(addr)):
+            _ = mem[addr]
+
 
 
     def testmprotectFailSymbReading(self):
@@ -1333,7 +1335,10 @@ class MemoryTest(unittest.TestCase):
         #print map(hex,sorted(solver.get_all_values(cs, x, 0x100000))),  map(hex,solver.minmax(cs, x)), mem[x]
 
                                                    #No Access Reading <4160741376>
-        self.assertRaisesRegexp(MemoryException, r"No access reading.*", mem.__getitem__, x)
+        # self.assertRaisesRegexp(MemoryException, r"No access reading.*", mem.__getitem__, x)
+        with self.assertRaisesRegexp(InvalidSymbolicMemoryAccess, 'Invalid symbolic memory access.*'.format(addr)):
+            _ = mem[x]
+            # mem[addr] = 'a'
 
     def testmprotectFailWriting(self):
         mem = Memory32()
@@ -1346,7 +1351,8 @@ class MemoryTest(unittest.TestCase):
         addr = mem.mmap(None, size, 'wx')
         mem[addr] = 'a'
         mem.mprotect(addr, size, 'r')
-        self.assertRaisesRegexp(MemoryException, "No access writing <%08x>"%addr, mem.__setitem__, addr, 'a')
+        with self.assertRaisesRegexp(InvalidMemoryAccess, 'Invalid memory access \(mode:w\) <{:x}>'.format(addr)):
+            mem[addr] = 'a'
 
     def testmprotecNoReadthenOkRead(self):
         mem = Memory32()
@@ -1359,7 +1365,8 @@ class MemoryTest(unittest.TestCase):
         addr = mem.mmap(None, size, 'wx')
         mem[addr] = 'a'
 
-        self.assertRaisesRegexp(MemoryException, "No access reading <%08x>"%addr, mem.__getitem__, addr)
+        with self.assertRaisesRegexp(InvalidMemoryAccess, 'Invalid memory access \(mode:r\) <{:x}>'.format(addr)):
+            _ = mem[addr]
 
         mem.mprotect(addr, size, 'r')
         self.assertEqual(mem[addr], 'a')


### PR DESCRIPTION
Fixes #359 

Previously, raised `MemoryExceptions` were uncaught and caught output like below, which makes it seem like Manticore crashed.

This pull request
- catches MemoryExceptions and generates a testcase
- refactors StateException/TerminateState to use `*args, **kwargs` less for better readability
- refactors MemoryException and children, slightly changes error message format. opinionated UI change: doesn't add the memory exception address to the `.message` if it is symbolic, as something like `<manticore.core.smtlib.expression.BitVecAnd object at 0x7fb801c36410>` is not very useful output.
- update locations where MemoryExceptions are raised


output:

after:

```
2017-06-30 13:40:10,262: [5192] MANTICORE:INFO: Loading program testt
2017-06-30 13:40:11,150: [5192] MANTICORE:INFO: Starting 1 processes.
2017-06-30 13:40:42,820: [5229] EXECUTOR:INFO: Generating testcase No. 1 - Invalid symbolic memory access (mode:r)
2017-06-30 13:40:44,106: [5229] EXECUTOR:INFO: Generating testcase No. 2 - Program finished with exit status: 0L
2017-06-30 13:40:44,265: [5192] MANTICORE:WARNING: Using shared context without a lock
2017-06-30 13:40:44,269: [5192] MANTICORE:INFO: Results in /tmp/mcore_UOrRRs/mcore_FbL06f
2017-06-30 13:40:44,269: [5192] MANTICORE:INFO: Instructions executed: 11886
2017-06-30 13:40:44,269: [5192] MANTICORE:INFO: Coverage: 3135 different instructions executed
2017-06-30 13:40:44,269: [5192] MANTICORE:INFO: Total time: 33.1181659698
2017-06-30 13:40:44,269: [5192] MANTICORE:INFO: IPS: 358

```



before:

```
2017-06-30 13:46:16,624: [9496] MANTICORE:INFO: Loading program testt
2017-06-30 13:46:17,526: [9496] MANTICORE:INFO: Starting 1 processes.
2017-06-30 13:46:22,146: [9529] EXECUTOR:INFO: Generating testcase No. 1 - Program finished with exit status: 0L
2017-06-30 13:46:50,089: [9529] MEMORY:INFO: Got TooManySolutions on a symbolic read. Range [4a10a6, 804a1063]. Not crashing!
2017-06-30 13:46:50,089: [9529] MEMORY:INFO: Memory:0000000000400000-00000000004ca000  r x 00000000 testt
00000000006c9000-00000000006ce000  rw  000c9000 testt
00000000006ce000-00000000006d0000  rw  00000000
00000000006d0000-00000000006f1000  rw  00000000
00007ffffffdf000-0000800000000000  rwx 00000000
2017-06-30 13:46:50,118: [9529] EXECUTOR:ERROR: Exception: Invalid mode trying to access memory in mode <manticore.core.smtlib.expression.BitVecAnd object at 0x7fb801c36410> <'No access reading symboli
c'>
Traceback (most recent call last):
  File "/mnt/hgfs/code/manticore/manticore/core/executor.py", line 463, in run
    if not current_state.execute():
  File "/mnt/hgfs/code/manticore/manticore/core/state.py", line 120, in execute
    result = self.platform.execute()
  File "/mnt/hgfs/code/manticore/manticore/platforms/linux.py", line 1803, in execute
    self.current.execute()
  File "/mnt/hgfs/code/manticore/manticore/core/cpu/abstractcpu.py", line 761, in execute
    implementation(*instruction.operands)
  File "/mnt/hgfs/code/manticore/manticore/core/cpu/abstractcpu.py", line 830, in new_method
    return old_method(cpu,*args,**kw_args)
  File "/mnt/hgfs/code/manticore/manticore/core/cpu/x86.py", line 4920, in MOVZX
    op0.write(Operators.ZEXTEND(op1.read(), op0.size))
  File "/mnt/hgfs/code/manticore/manticore/core/cpu/x86.py", line 648, in read
    value = cpu.read_int(self.address(), self.size)
  File "/mnt/hgfs/code/manticore/manticore/core/cpu/abstractcpu.py", line 537, in read_int
    data = self.memory[where:where+size/8]
  File "/mnt/hgfs/code/manticore/manticore/core/memory.py", line 837, in __getitem__
    result = self.read(index.start, index.stop - index.start)
  File "/mnt/hgfs/code/manticore/manticore/core/memory.py", line 928, in read
    raise InvalidSymbolicMemoryAccess('No access reading symbolic', address, size, crashing_condition)
InvalidSymbolicMemoryAccess: Invalid mode trying to access memory in mode <manticore.core.smtlib.expression.BitVecAnd object at 0x7fb801c36410> <'No access reading symbolic'>

2017-06-30 13:46:50,135: [9496] MANTICORE:WARNING: Using shared context without a lock
2017-06-30 13:46:50,140: [9496] MANTICORE:INFO: Results in /tmp/mcore_UOrRRs/mcore_df0HHv
2017-06-30 13:46:50,140: [9496] MANTICORE:INFO: Instructions executed: 11886
2017-06-30 13:46:50,140: [9496] MANTICORE:INFO: Coverage: 3135 different instructions executed
2017-06-30 13:46:50,140: [9496] MANTICORE:INFO: Total time: 32.6134400368
2017-06-30 13:46:50,140: [9496] MANTICORE:INFO: IPS: 364

```