### PR TITLE
Remove `state.generate_inputs`

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -311,43 +311,6 @@ class State(object):
             except KeyError:
                 self.branches[key] = 1
 
-    def generate_inputs(self, workspace, generate_files=False):
-        '''
-        Save the inputs of the state
-
-        :param str workspace: the working directory
-        :param bool generate_files: true if symbolic files are also generated
-        '''
-
-        # Save constraints formula
-        smtfile = 'state_{:08x}.smt'.format(self.co)
-        with open(os.path.join(workspace, smtfile), 'wb') as f:
-            f.write(str(self.constraints))
-
-        # check that the state is sat
-        assert solver.check(self.constraints)
-
-        # save the inputs
-        for symbol in self.input_symbols:
-            buf = solver.get_value(self.constraints, symbol)
-            filename = os.path.join(workspace, 'state_{:08x}.txt'.format(self.co))
-            open(filename, 'a').write("{:s}: {:s}\n".format(symbol.name, repr(buf)))
-
-        # save the symbolic files
-        if generate_files:
-            files = getattr(self.platform, 'files', None)
-            if files is not None:
-                for f in files:
-                    array = getattr(f, 'array', None)
-                    if array is not None:
-                        buf = solver.get_value(self.constraints, array)
-                        filename = os.path.basename(array.name)
-                        filename = 'state_{:08x}.{:s}'.format(self.co, filename)
-                        filename = os.path.join(workspace, filename)
-                        with open(filename, 'a') as f:
-                            f.write("{:s}".format(buf))
-
-
     def invoke_model(self, model):
         '''
         Invoke a `model`. A `model` is a callable whose first argument is a


### PR DESCRIPTION
As of right now, this functionality is broken (see: #378, #373), and should arguably be more platform-specific (not all platforms necessarily have files)