### PR TITLE
Expose symbolic files to command line interface, implement whence for symbolic seek

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -32,6 +32,8 @@ def parse_arguments():
                         help='Initial concrete concrete_data for the input symbolic buffer')
     parser.add_argument('--env', type=str, nargs=1, default=[], action='append',
                         help='Specify symbolic environment variable VARNAME=++++++')
+    parser.add_argument('--file', type=str, action='append', dest='files',
+                        help='Specify symbolic input file, \'+\' marks symbolic bytes')
     parser.add_argument('--policy', type=str, default='random',
                         help='Search policy. random|adhoc|uncovered|dicount|icount|syscount|depth.'\
                              ' (use + (max) or - (min) to specify order. e.g. +random)')
@@ -97,6 +99,10 @@ def main():
         for entry in args.env:
             name, val = entry[0].split('=')
             m.env_add(name, val)
+
+    if args.files:
+        for file in args.files:
+            m.add_symbolic_file(file)
 
     if args.assertions:
         m.load_assertions(args.assertions)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -172,23 +172,28 @@ class SymbolicFile(File):
 
     def seek(self, offset, whence = os.SEEK_SET):
         '''
-        Returns the read/write file offset
+        Repositions the file C{offset} according to C{whence}.
+        Returns the resulting offset or -1 in case of error.
         :rtype: int
-        :return: the read/write file offset.
+        :return: the file offset.
         '''
         assert isinstance(offset, (int, long))
-        assert isinstance(whence, (int, long))
+        assert whence in (os.SEEK_SET, os.SEEK_CUR, os.SEEK_END)
 
-        # horribly simplified (omits mode checks, error handling)
+        new_position = 0
         if whence == os.SEEK_SET:
-            self.pos = offset
+            new_position = offset
         elif whence == os.SEEK_CUR:
-            self.pos += offset
+            new_position = self.pos + offset
         elif whence == os.SEEK_END:
-            self.max_size += offset
-        # SEEK_DATA, SEEK_HOLE niy
-        else:
-            logger.warning("Symbolic seek: whence %d is not implemented yet", whence)
+            new_position = self.max_size + offset
+
+        if new_position < 0:
+            return -1
+
+        self.pos = new_position
+
+        return self.pos
 
     def read(self, count):
         '''

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -113,7 +113,7 @@ class SymbolicFile(File):
         :param constraints: the SMT constraints
         :param str path: the pathname of the symbolic file
         :param str mode: the access permissions of the symbolic file
-        :param max_size: Maximun amount of bytes of the symbolic file
+        :param max_size: Maximum amount of bytes of the symbolic file
         :param str wildcard: Wildcard to be used in symbolic file
         '''
         super(SymbolicFile, self).__init__(path, mode)
@@ -170,14 +170,25 @@ class SymbolicFile(File):
         '''
         return self.pos
 
-    def seek(self, pos):
+    def seek(self, offset, whence = os.SEEK_SET):
         '''
         Returns the read/write file offset
         :rtype: int
         :return: the read/write file offset.
         '''
-        assert isinstance(pos, (int, long))
-        self.pos = pos
+        assert isinstance(offset, (int, long))
+        assert isinstance(whence, (int, long))
+
+        # horribly simplified (omits mode checks, error handling)
+        if whence == os.SEEK_SET:
+            self.pos = offset
+        elif whence == os.SEEK_CUR:
+            self.pos += offset
+        elif whence == os.SEEK_END:
+            self.max_size += offset
+        # SEEK_DATA, SEEK_HOLE niy
+        else:
+            logger.warning("Symbolic seek: whence %d is not implemented yet", whence)
 
     def read(self, count):
         '''


### PR DESCRIPTION
As requested in Slack:

* a new parameter `--file` to add symbolic files
* a very simple symbolic seek implementation (current `seek` lacks a `whence` parameter and fails with TypeError)

Edit: changed `symfile` to `file` for consistent naming