### PR TITLE
Add Taint Parameters

### DIFF
--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -612,6 +612,10 @@ class ArrayProxy(ArrayVariable):
     @property
     def operands(self):
         return self._array.operands
+    
+    @property
+    def taint(self):
+        return self._array.taint
 
     def select(self, index):
         return self._array.select(index)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -176,7 +176,8 @@ class State(object):
         :return: :class:`~manticore.core.smtlib.expression.Expression` representing the buffer.
         '''
         name = options.get('name', 'buffer')
-        expr = self.constraints.new_array(name=name, index_max=nbytes)
+        taint = options.get('taint', frozenset())
+        expr = self.constraints.new_array(name=name, index_max=nbytes, taint=taint)
         self.input_symbols.append(expr)
 
         if options.get('cstring', False):
@@ -201,7 +202,7 @@ class State(object):
         self.input_symbols.append(expr)
         return expr
 
-    def symbolicate_buffer(self, data, label='INPUT', wildcard='+', string=False):
+    def symbolicate_buffer(self, data, label='INPUT', wildcard='+', string=False, taint=frozenset()):
         '''Mark parts of a buffer as symbolic (demarked by the wildcard byte)
 
         :param str data: The string to symbolicate. If no wildcard bytes are provided,
@@ -216,7 +217,7 @@ class State(object):
         '''
         if wildcard in data:
             size = len(data)
-            symb = self.constraints.new_array(name=label, index_max=size)
+            symb = self.constraints.new_array(name=label, index_max=size, taint=taint)
             self.input_symbols.append(symb)
 
             tmp = []

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -172,6 +172,8 @@ class State(object):
         :param str name: (keyword arg only) The name to assign to the buffer
         :param bool cstring: (keyword arg only) Whether or not to enforce that the buffer is a cstring
                  (i.e. no \0 bytes, except for the last byte). (bool)
+        :param taint: Taint identifier of the new buffer
+        :type taint: tuple or frozenset
 
         :return: :class:`~manticore.core.smtlib.expression.Expression` representing the buffer.
         '''
@@ -210,6 +212,8 @@ class State(object):
         :param str label: The label to assign to the value
         :param str wildcard: The byte that is considered a wildcard
         :param bool string: Ensure bytes returned can not be \0
+        :param taint: Taint identifier of the symbolicated data
+        :type taint: tuple or frozenset
 
         :return: If data does not contain any wildcard bytes, data itself. Otherwise,
             a list of values derived from data. Non-wildcard bytes are kept as

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -131,6 +131,16 @@ class StateTest(unittest.TestCase):
         with self.assertRaises(Exception):
             expr = self.state.new_symbolic_value(length)
 
+    def test_tainted_symbolic_buffer(self):
+        taint = ('TEST_TAINT', )
+        expr = self.state.new_symbolic_buffer(64, taint=taint)       
+        self.assertEqual(expr.taint, frozenset(taint))
+
+    def test_tainted_symbolic_value(self):
+        taint = ('TEST_TAINT', )
+        expr = self.state.new_symbolic_value(64, taint=taint)
+        self.assertEqual(expr.taint, frozenset(taint))
+
     @unittest.skip('Record branches not a part of state anymore')
     def test_record_branches(self):
         branch = 0x80488bb


### PR DESCRIPTION
Adds parameters allowing the user to specify an ID for taint tracking to `state.new_symbolic_buffer` and `state.symbolicate_buffer`. Also adds a property to `smtlib.expression.ArrayProxy` that allows the taint of the proxied ArrayVariable to be returned.