### PR TITLE
Fix warning during regular analysis

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -189,7 +189,8 @@ class Manticore(object):
         if self._executor is None:
             return self._context
         else:
-            logger.warning("Using shared context without a lock")
+            if self._running and len(self._workers) > 1:
+                logger.warning("Using shared context without a lock")
             return self._executor._shared_context
         
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -189,8 +189,7 @@ class Manticore(object):
         if self._executor is None:
             return self._context
         else:
-            if self._running and len(self._workers) > 1:
-                logger.warning("Using shared context without a lock")
+            logger.warning("Using shared context without a lock")
             return self._executor._shared_context
         
 
@@ -756,8 +755,8 @@ class Manticore(object):
                 t.cancel()
         #Copy back the shared conext
         self._context = dict(self._executor._shared_context)
-        self.finish_run()
         self._executor = None
+        self.finish_run()
 
 
     def terminate(self):


### PR DESCRIPTION
Previously `manticore helloworld` would show a warning about using an unlocked shared context