### PR TITLE
Implement symbolic branch tracking in core, add new fork event

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -323,15 +323,20 @@ class Executor(Eventful):
         children = []
         for new_value in solutions:
             with state as new_state:
-                new_state.constrain(expression == new_value) #We already know it's sat
+                new_state.constrain(expression == new_value)
+
                 #and set the PC of the new state to the concrete pc-dest
                 #(or other register or memory address to concrete)
                 setstate(new_state, new_value)
-                #enqueue new_state 
+
+                with self._lock:
+                    self.publish('fork_state', new_state, expression, new_value, policy)
+
+                #enqueue new_state
                 state_id = self.add(new_state)
                 #maintain a list of childres for logging purpose
                 children.append(state_id)
-        
+
         logger.debug("Forking current state into states %r",children)
         return None
 

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -330,7 +330,7 @@ class Executor(Eventful):
                 setstate(new_state, new_value)
 
                 with self._lock:
-                    self.publish('fork_state', new_state, expression, new_value, policy)
+                    self.publish('forking_state', new_state, expression, new_value, policy)
 
                 #enqueue new_state
                 state_id = self.add(new_state)

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -315,9 +315,7 @@ class Executor(Eventful):
         #Find a set of solutions for expression
         solutions = state.concretize(expression, policy)
 
-        #We are about to fork current_state
-        with self._lock:
-            self.publish('will_fork_state', state, expression, solutions, policy)
+        self.publish('will_fork_state', state, expression, solutions, policy)
 
         #Build and enqueue a state for each solution 
         children = []
@@ -329,8 +327,7 @@ class Executor(Eventful):
                 #(or other register or memory address to concrete)
                 setstate(new_state, new_value)
 
-                with self._lock:
-                    self.publish('forking_state', new_state, expression, new_value, policy)
+                self.publish('forking_state', new_state, expression, new_value, policy)
 
                 #enqueue new_state
                 state_id = self.add(new_state)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -76,9 +76,18 @@ class State(Eventful):
         self._input_symbols = list()
         self._child = None
         self._context = dict()
+        self._init_context()
         ##################################################################33
         # Events are lost in serialization and fork !!
         self.forward_events_from(platform)
+
+    def record_branch(self, target):
+        branches = self.context['branches']
+        branch = (self.cpu._last_pc, target)
+        if branch in branches:
+            branches[branch] += 1
+        else:
+            branches[branch] = 1
 
     def __getstate__(self):
         state = super(State, self).__getstate__()
@@ -352,3 +361,6 @@ class State(Eventful):
     @property
     def mem(self):
         return self._platform.current.memory
+
+    def _init_context(self):
+        self.context['branches'] = dict()

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -562,7 +562,10 @@ class Manticore(object):
             manticore_context['visited'] = manticore_visited.union(state_visited)
 
             manticore_instructions_count = manticore_context.get('instructions_count', 0)
-            manticore_context['instructions_count'] = manticore_instructions_count + state_instructions_count 
+            manticore_context['instructions_count'] = manticore_instructions_count + state_instructions_count
+
+    def _forking_state_callback(self, state, expression, value, policy):
+        state.record_branch(value)
 
     def _fork_state_callback(self, state, expression, values, policy):
         state_visited = state.context.get('visited_since_last_fork', set())
@@ -721,6 +724,7 @@ class Manticore(object):
         self._executor.subscribe('will_store_state', self._store_state_callback)
         self._executor.subscribe('will_load_state', self._load_state_callback)
         self._executor.subscribe('will_fork_state', self._fork_state_callback)
+        self._executor.subscribe('forking_state', self._forking_state_callback)
         self._executor.subscribe('will_terminate_state', self._terminate_state_callback)
         self._executor.subscribe('will_generate_testcase', self._generate_testcase_callback)
 


### PR DESCRIPTION
This PR implements tracking of symbolic branches in each `State` (specifically `state.context['branches']`). It does this using a new event: `forking_state`. Similar to `will_fork_state`, `forking_state` fires when a state fork occurs, however it fires once for each individual state forked, being passed the specific value that has been concretized. `will_fork_state` fires once on a general state forking event, being passed the collection of all concretized values. This is unsuitable for tracking symbolic branches per state because the `State` the event handler has access to during `will_fork_state` is the parent state, and not a child state. For tracking symbolic branches, we want to only modify the specific child state.

Points of discussion and controversy:

#### Whether we should track symbolic branches in the core, versus requiring users to do this.

I think this is general enough and useful enough functionality to compute in the core and have available to users "for free".

#### The name of the event: `forking_state`.

I'm open to suggestions for other names! `forking_child_state`, ...

#### The introduction of `State._init_context`.

I thought it would be useful to have a central place where all the entries of `state.context` are initialized, versus them largely being initialized ad hoc in various places in hooks in manticore.py. Initializing entries of `state.context` here allows code that uses `state.context` to be less cautious about whether a entry actually exists or not. For example: 

https://github.com/trailofbits/manticore/blob/5ad18e736c867f15a22887a0c65f67c3af3b616c/manticore/manticore.py#L558
https://github.com/trailofbits/manticore/blob/5ad18e736c867f15a22887a0c65f67c3af3b616c/manticore/manticore.py#L568
https://github.com/trailofbits/manticore/blob/5ad18e736c867f15a22887a0c65f67c3af3b616c/manticore/manticore.py#L601

Currently only `context['branches']` is initialized here, but the idea is to eventually port other usees of `state.context` in the core to initialize those members here.