### PR TITLE
Fix testcase generation output

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -284,7 +284,7 @@ class Executor(Eventful):
 
         #broadcast test generation. This is the time for other modules
         #to output whatever helps to understand this testcase
-        self.publish('will_generate_testcase', state)
+        self.publish('will_generate_testcase', state, message)
 
 
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -607,7 +607,7 @@ class Manticore(object):
             state.context['instructions_count'] = count + 1
 
 
-    def _generate_testcase_callback(self, state, message = 'Testcase generated'):
+    def _generate_testcase_callback(self, state, message):
         '''
         Create a serialized description of a given state.
         :param state: The state to generate information about


### PR DESCRIPTION
We used to ignore the message and always log "Testcase generated" even if there was a more specific logging message like "Program finished with exit status: 0"