### PR TITLE
Implement state.generate_testcase

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,7 +20,7 @@ State
 -----
 
 .. autoclass:: manticore.core.state.State
-   :members: abandon, constrain, new_symbolic_buffer, new_symbolic_value, solve_n, solve_one, solve_buffer, symbolicate_buffer, invoke_model
+   :members: abandon, constrain, new_symbolic_buffer, new_symbolic_value, solve_n, solve_one, solve_buffer, symbolicate_buffer, invoke_model, generate_testcase
 
 Cpu
 ---

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -284,7 +284,7 @@ class Executor(Eventful):
 
         #broadcast test generation. This is the time for other modules
         #to output whatever helps to understand this testcase
-        self.publish('will_generate_testcase', state, message)
+        self.publish('will_generate_testcase', state, 'test', message)
 
 
 

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -366,5 +366,5 @@ class State(Eventful):
         self.context['branches'] = dict()
 
     # XXX(mark) naming? generate_testcase? to keep with testcase parlance
-    def generate_inputs(self, name):
-        self.publish('state_generate_inputs', self, name=name)
+    def generate_inputs(self, name, message='State generated inputs'):
+        self.publish('state_generate_inputs', message=message, name=name)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -364,3 +364,7 @@ class State(Eventful):
 
     def _init_context(self):
         self.context['branches'] = dict()
+
+    # XXX(mark) naming? generate_testcase? to keep with testcase parlance
+    def generate_inputs(self):
+        self.publish('state_generate_inputs', self)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -366,4 +366,4 @@ class State(Eventful):
         self.context['branches'] = dict()
 
     def generate_testcase(self, name, message='State generated testcase'):
-        self.publish('state_generate_inputs', message=message, name=name)
+        self.publish('state_generate_inputs', name, message)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -366,4 +366,10 @@ class State(Eventful):
         self.context['branches'] = dict()
 
     def generate_testcase(self, name, message='State generated testcase'):
+        """
+        Generate a testcase for this state and place in the analysis workspace.
+
+        :param str name: Short string identifying this testcase used to prefix workspace entries.
+        :param str message: Longer description
+        """
         self.publish('state_generate_inputs', name, message)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -366,5 +366,5 @@ class State(Eventful):
         self.context['branches'] = dict()
 
     # XXX(mark) naming? generate_testcase? to keep with testcase parlance
-    def generate_inputs(self):
-        self.publish('state_generate_inputs', self)
+    def generate_inputs(self, name):
+        self.publish('state_generate_inputs', self, name=name)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -365,6 +365,5 @@ class State(Eventful):
     def _init_context(self):
         self.context['branches'] = dict()
 
-    # XXX(mark) naming? generate_testcase? to keep with testcase parlance
-    def generate_inputs(self, name, message='State generated inputs'):
+    def generate_testcase(self, name, message='State generated testcase'):
         self.publish('state_generate_inputs', message=message, name=name)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -372,4 +372,4 @@ class State(Eventful):
         :param str name: Short string identifying this testcase used to prefix workspace entries.
         :param str message: Longer description
         """
-        self.publish('state_generate_inputs', name, message)
+        self.publish('will_generate_inputs', name, message)

--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -400,6 +400,7 @@ class ManticoreOutput(object):
 
         :param desc: A descriptor ('type:uri') of where to write output.
         """
+        self._named_key_prefix = 'test'
         self._store = _create_store(desc)
         self._last_id = 0
         self._id_gen = manager.Value('i', self._last_id)
@@ -415,9 +416,9 @@ class ManticoreOutput(object):
         self._id_gen.value += 1
 
     def _named_key(self, suffix):
-        return 'test_{:08x}.{}'.format(self._last_id, suffix)
+        return '{}_{:08x}.{}'.format(self._named_key_prefix, self._last_id, suffix)
 
-    def save_testcase(self, state, message=''):
+    def save_testcase(self, state, prefix, message=''):
         """
         Save the environment from `state` to storage. Return a state id
         describing it, which should be an int or a string.
@@ -427,6 +428,7 @@ class ManticoreOutput(object):
         :return: A state id representing the saved state
         """
 
+        self._named_key_prefix = self._prepare_named_key(prefix)
         self._increment_id()
 
         self.save_summary(state, message)
@@ -515,3 +517,7 @@ class ManticoreOutput(object):
                                     _in.write(chr(solver.get_value(state.constraints, c)))
                             except SolverException:
                                 _in.write('{SolverException}')
+
+    def _prepare_named_key(self, prefix):
+        return ''.join(['_' if str.isspace(c) else c for c in prefix])
+

--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -428,7 +428,7 @@ class ManticoreOutput(object):
         :return: A state id representing the saved state
         """
 
-        self._named_key_prefix = self._prepare_named_key(prefix)
+        self._named_key_prefix = prefix
         self._increment_id()
 
         self.save_summary(state, message)
@@ -517,7 +517,3 @@ class ManticoreOutput(object):
                                     _in.write(chr(solver.get_value(state.constraints, c)))
                             except SolverException:
                                 _in.write('{SolverException}')
-
-    def _prepare_named_key(self, prefix):
-        return ''.join(['_' if str.isspace(c) else c for c in prefix])
-

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -727,7 +727,6 @@ class Manticore(object):
         self._executor.subscribe('forking_state', self._forking_state_callback)
         self._executor.subscribe('will_terminate_state', self._terminate_state_callback)
         self._executor.subscribe('will_generate_testcase', self._generate_testcase_callback)
-        self._executor.subscribe('state_generate_inputs', self._generate_testcase_callback)
 
         if self._hooks:
             self._executor.subscribe('will_execute_instruction', self._hook_callback)

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -727,6 +727,7 @@ class Manticore(object):
         self._executor.subscribe('forking_state', self._forking_state_callback)
         self._executor.subscribe('will_terminate_state', self._terminate_state_callback)
         self._executor.subscribe('will_generate_testcase', self._generate_testcase_callback)
+        self._executor.subscribe('state_generate_inputs', self._generate_testcase_callback)
 
         if self._hooks:
             self._executor.subscribe('will_execute_instruction', self._hook_callback)

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -607,7 +607,7 @@ class Manticore(object):
             state.context['instructions_count'] = count + 1
 
 
-    def _generate_testcase_callback(self, state, message, name='test'):
+    def _generate_testcase_callback(self, state, name, message):
         '''
         Create a serialized description of a given state.
         :param state: The state to generate information about

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -607,13 +607,13 @@ class Manticore(object):
             state.context['instructions_count'] = count + 1
 
 
-    def _generate_testcase_callback(self, state, message):
+    def _generate_testcase_callback(self, state, message, name='test'):
         '''
         Create a serialized description of a given state.
         :param state: The state to generate information about
         :param message: Accompanying message
         '''
-        testcase_id = self._output.save_testcase(state, message)
+        testcase_id = self._output.save_testcase(state, name, message)
         logger.info("Generated testcase No. {} - {}".format(testcase_id, message))
 
     def _produce_profiling_data(self):

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -46,8 +46,9 @@ class Eventful(object):
         #A bucket is a dictionary obj -> set(method1, method2...)
         return self._signals.setdefault(name,  dict())
 
-    def publish(self, name, *args, **kwargs):   
-        bucket = self._get_signal_bucket(name)
+    # The underscore _name is to avoid naming collisions with callback params
+    def publish(self, _name, *args, **kwargs):
+        bucket = self._get_signal_bucket(_name)
         for robj, methods in bucket.items():
             for callback in methods:
                 callback(robj(), *args, **kwargs)
@@ -56,9 +57,9 @@ class Eventful(object):
         # the callback signature. This is set on forward_events_from/to 
         for sink, include_source in self._forwards.items():
             if include_source:
-                sink.publish(name, self, *args, **kwargs)
+                sink.publish(_name, self, *args, **kwargs)
             else:
-                sink.publish(name, *args, **kwargs)
+                sink.publish(_name, *args, **kwargs)
 
     def subscribe(self, name, method):
         if not inspect.ismethod(method):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -86,8 +86,8 @@ class StateTest(unittest.TestCase):
 
     def test_output(self):
         out = ManticoreOutput('mem:')
-        out.save_testcase(self.state, 'saving state')
-        keys = [x[14:] for x in out._store._data.keys()]
+        out.save_testcase(self.state, 'test')
+        keys = [x.split('.')[1] for x in out._store._data.keys()]
 
         # Make sure we log everything we should be logging
         self.assertIn('smt', keys)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -97,7 +97,7 @@ class StateTest(unittest.TestCase):
             if 'messages' in name:
                 self.assertTrue(message in data)
 
-        keys = [x.split('.')[1] for x in out._store._data.keys()]
+        keys = [x.split('.')[1] for x in workspace.keys()]
 
         # Make sure we log everything we should be logging
         self.assertIn('smt', keys)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -86,7 +86,17 @@ class StateTest(unittest.TestCase):
 
     def test_output(self):
         out = ManticoreOutput('mem:')
-        out.save_testcase(self.state, 'test')
+        name = 'mytest'
+        message = 'custom message'
+        out.save_testcase(self.state, name, message)
+        workspace = out._store._data
+
+        # Make sure names are constructed correctly
+        for name, data in workspace.items():
+            self.assertTrue(name.startswith(name))
+            if 'messages' in name:
+                self.assertTrue(message in data)
+
         keys = [x.split('.')[1] for x in out._store._data.keys()]
 
         # Make sure we log everything we should be logging


### PR DESCRIPTION
Proposed implementation related to #373 

Fixes #373 

This implements `state.generate_testcase(name, description)` which can be used by hooks to arbitrary generate testcases to the workspace.

discussion
- api name? `state.generate_testcase`, `state.generate_inputs`, `state.dump_inputs`, `state.get_inputs`, `concretize_inputs`