### PR TITLE
Fix state.generate_testcase

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -372,4 +372,4 @@ class State(Eventful):
         :param str name: Short string identifying this testcase used to prefix workspace entries.
         :param str message: Longer description
         """
-        self.publish('will_generate_inputs', name, message)
+        self.publish('will_generate_testcase', name, message)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -199,10 +199,12 @@ class StateTest(unittest.TestCase):
 
 
     def _test_state_gen_helper(self, name, msg):
-        self.assertEqual(name, self._tmp_name)
-        self.assertEqual(msg, self._tmp_msg)
+        self.assertEqual(name, 'statename')
+        self.assertEqual(msg, 'statemsg')
+        raise Exception('callback')
+
     def test_state_gen(self):
         self.state.subscribe('will_generate_testcase', self._test_state_gen_helper)
-        self._tmp_name = 'statename'
-        self._tmp_msg = 'statemsg'
-        self.state.generate_testcase(self._tmp_name, self._tmp_msg)
+        with self.assertRaises(Exception) as cm:
+            self.state.generate_testcase('statename', 'statemsg')
+        self.assertEqual(cm.exception.message, 'callback', 'callback did not execute correctly!')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,6 +4,10 @@ from manticore.platforms import linux
 from manticore.core.state import State
 from manticore.core.smtlib import BitVecVariable, ConstraintSet
 
+class _CallbackExecuted(Exception):
+    pass
+
+
 class FakeMemory(object):
     def __init__(self):
         self._constraints = None
@@ -201,10 +205,9 @@ class StateTest(unittest.TestCase):
     def _test_state_gen_helper(self, name, msg):
         self.assertEqual(name, 'statename')
         self.assertEqual(msg, 'statemsg')
-        raise Exception('callback')
+        raise _CallbackExecuted
 
     def test_state_gen(self):
         self.state.subscribe('will_generate_testcase', self._test_state_gen_helper)
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(_CallbackExecuted):
             self.state.generate_testcase('statename', 'statemsg')
-        self.assertEqual(cm.exception.message, 'callback', 'callback did not execute correctly!')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -196,4 +196,13 @@ class StateTest(unittest.TestCase):
         self.assertEqual( new_state.context['step'], 20)
         new_new_state = pickle.loads(new_new_file)
         self.assertEqual( new_new_state.context['step'], 30)
-        
+
+
+    def _test_state_gen_helper(self, name, msg):
+        self.assertEqual(name, self._tmp_name)
+        self.assertEqual(msg, self._tmp_msg)
+    def test_state_gen(self):
+        self.state.subscribe('will_generate_testcase', self._test_state_gen_helper)
+        self._tmp_name = 'statename'
+        self._tmp_msg = 'statemsg'
+        self.state.generate_testcase(self._tmp_name, self._tmp_msg)


### PR DESCRIPTION
Fixes #450 

Fixes the typo that caused the bug, and adds a unit test to check that `state.generate_testcase` publishes the proper event. It's not easy to write a unit test that actually checks that a testcase is generated due to how the State is coupled with the Executor for this functionality.