### PR TITLE
Manticore 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `State.generate_testcase` (arbitrary testcase generation from hooks)
 - Documentation on [gotchas](http://manticore.readthedocs.io/en/latest/gotchas.html)
 - Command line interface support for symbolic files (`--file`)
+- [Experimental] `State.context['branches']` (States track symbolic branches)
 - [Experimental] Support for emulation of [Binary Ninja](https://binary.ninja) IL
 
 ### Changed
@@ -23,6 +24,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Numerous bugfixes
 - Fixed double workspace bug
+
+### Removed
+
+- [Experimental] `State.generate_inputs` (superseded by `State.generate_testcase`)
 
 ## 0.1.3 - 2017-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- `Manticore.locked_context` (safe parallel context access)
-- `State.generate_testcase` (arbitrary testcase generation from hooks)
+- `Manticore.locked_context()` (safe parallel context access)
+- `State.generate_testcase()` (arbitrary testcase generation from hooks)
 - Documentation on [gotchas](http://manticore.readthedocs.io/en/latest/gotchas.html)
 - Command line interface support for symbolic files (`--file`)
 - [Experimental] `State.context['branches']` (States track symbolic branches)
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Taint parameters added to `State.new_symbolic_buffer` and `State.symbolicate_buffer`
+- Taint parameters added to `State.new_symbolic_buffer()` and `State.symbolicate_buffer()`
 - Improved support for ARM binaries
 
 ### Fixed
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Removed
 
-- [Experimental] `State.generate_inputs` (superseded by `State.generate_testcase`)
+- [Experimental] `State.generate_inputs()` (superseded by `State.generate_testcase()`)
 
 ## 0.1.3 - 2017-07-14
 
@@ -52,16 +52,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- Function modeling API (`state.invoke_model`, `manticore.variadic`)
+- Function modeling API (`state.invoke_model()`, `manticore.variadic`)
 - `strcmp` and `strlen` models
-- `state.solve_buffer`
+- `state.solve_buffer()`
 - Additional `state` APIs
 - Support for ARMv7 Thumb mode
 
 ### Changed
 
 - Parallel processing API (`m.run(procs)`)
-- `state.solve_n`
+- `state.solve_n()`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Taint parameters added to `State.new_symbolic_buffer()` and `State.symbolicate_buffer()`
 - Improved support for ARM binaries
+- `Manticore.verbosity` logging preset levels
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `Manticore.locked_context()` (safe parallel context access)
 - `State.generate_testcase()` (arbitrary testcase generation from hooks)
 - Documentation on [gotchas](http://manticore.readthedocs.io/en/latest/gotchas.html)
-- Command line interface support for symbolic files (`--file`)
+- Command line interface support for symbolic files (`--file`) (thanks [251](https://github.com/251)!)
 - [Experimental] `State.context['branches']` (States track symbolic branches)
 - [Experimental] Support for emulation of [Binary Ninja](https://binary.ninja) IL
 
 ### Changed
 
-- Taint parameters added to `State.new_symbolic_buffer()` and `State.symbolicate_buffer()`
+- Taint parameters added to `State.new_symbolic_buffer()` and `State.symbolicate_buffer()` (thanks [ehennenfent](https://github.com/ehennenfent)!)
 - Improved support for ARM binaries
 - `Manticore.verbosity` logging preset levels
 
 ### Fixed
 
 - Numerous bugfixes
+- Fixed workspace error message bug (thanks [chowdaryd](https://github.com/chowdaryd)!)
 - Fixed double workspace bug
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased](https://github.com/trailofbits/manticore/compare/0.1.3...HEAD)
+## [Unreleased](https://github.com/trailofbits/manticore/compare/0.1.4...HEAD)
+
+## 0.1.4 - 2017-08-18
+
+### Added
+
+- `Manticore.locked_context` (safe parallel context access)
+- `State.generate_testcase` (arbitrary testcase generation from hooks)
+- Documentation on [gotchas](http://manticore.readthedocs.io/en/latest/gotchas.html)
+- Command line interface support for symbolic files (`--file`)
+- [Experimental] Support for emulation of [Binary Ninja](https://binary.ninja) IL
+
+### Changed
+
+- Taint parameters added to `State.new_symbolic_buffer` and `State.symbolicate_buffer`
+- Improved support for ARM binaries
+
+### Fixed
+
+- Numerous bugfixes
+- Fixed double workspace bug
 
 ## 0.1.3 - 2017-07-14
 
@@ -31,6 +51,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `strcmp` and `strlen` models
 - `state.solve_buffer`
 - Additional `state` APIs
+- Support for ARMv7 Thumb mode
 
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description='Manticore is a prototyping tool for dynamic binary analysis, with support for symbolic execution, taint analysis, and binary instrumentation.',
     url='https://github.com/trailofbits/manticore',
     author='Trail of Bits',
-    version='0.1.3',
+    version='0.1.4',
     packages=find_packages(),
     install_requires=[
         'capstone>=3.0.5rc2',


### PR DESCRIPTION
Updates changelog, bumps version number.

Includes update to 0.1.2 since we forgot to mention that it added thumb mode.