### PR TITLE
Fix logger verbosity and test

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -433,7 +433,7 @@ class Executor(Eventful):
                             if current_state_id is not None:
                                 current_state = self._workspace.load_state(current_state_id)
                                 self.forward_events_from(current_state, True)
-                                logger.info("load state %r", state_id)
+                                logger.info("load state %r", current_state_id)
                                 self.publish('will_load_state', current_state, current_state_id)
                                 #notify siblings we have a state to play with
                             self._start_run()

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -433,6 +433,7 @@ class Executor(Eventful):
                             if current_state_id is not None:
                                 current_state = self._workspace.load_state(current_state_id)
                                 self.forward_events_from(current_state, True)
+                                logger.info("load state %r", state_id)
                                 self.publish('will_load_state', current_state, current_state_id)
                                 #notify siblings we have a state to play with
                             self._start_run()

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -586,10 +586,10 @@ class Manticore(object):
                 self._assertions[pc] = ' '.join(line.split(' ')[1:])
 
     def _store_state_callback(self, state, state_id):
-        logger.info("store state %r", state_id)
+        pass
 
     def _load_state_callback(self, state, state_id):
-        logger.info("load state %r", state_id)
+        pass
 
     def _terminate_state_callback(self, state, state_id, ex):
         #aggregates state statistics into exceutor statistics. FIXME split

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -211,7 +211,6 @@ class Manticore(object):
         self._executor.subscribe('will_write_memory', self._write_memory_callback)
         self._executor.subscribe('will_execute_instruction', self._execute_instruction_callback)
         self._executor.subscribe('will_decode_instruction', self._decode_instruction_callback)
-        self._executor.subscribe('will_store_state', self._store_state_callback)
         self._executor.subscribe('will_load_state', self._load_state_callback)
         self._executor.subscribe('will_fork_state', self._fork_state_callback)
         self._executor.subscribe('forking_state', self._forking_state_callback)
@@ -584,9 +583,6 @@ class Manticore(object):
                 if pc in self._assertions:
                     logger.debug("Repeated PC in assertions file %s", path)
                 self._assertions[pc] = ' '.join(line.split(' ')[1:])
-
-    def _store_state_callback(self, state, state_id):
-        pass
 
     def _load_state_callback(self, state, state_id):
         pass

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -211,7 +211,6 @@ class Manticore(object):
         self._executor.subscribe('will_write_memory', self._write_memory_callback)
         self._executor.subscribe('will_execute_instruction', self._execute_instruction_callback)
         self._executor.subscribe('will_decode_instruction', self._decode_instruction_callback)
-        self._executor.subscribe('will_load_state', self._load_state_callback)
         self._executor.subscribe('will_fork_state', self._fork_state_callback)
         self._executor.subscribe('forking_state', self._forking_state_callback)
         self._executor.subscribe('will_terminate_state', self._terminate_state_callback)
@@ -583,9 +582,6 @@ class Manticore(object):
                 if pc in self._assertions:
                     logger.debug("Repeated PC in assertions file %s", path)
                 self._assertions[pc] = ' '.join(line.split(' ')[1:])
-
-    def _load_state_callback(self, state, state_id):
-        pass
 
     def _terminate_state_callback(self, state, state_id, ex):
         #aggregates state statistics into exceutor statistics. FIXME split

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -64,7 +64,7 @@ class IntegrationTest(unittest.TestCase):
 
         self.assertTrue(time.time()-t < 20)
 
-    def test_cli_verbosity(self):
+    def test_logger_verbosity(self):
         """
         Tests that default verbosity produces the expected volume of output
         """
@@ -72,13 +72,16 @@ class IntegrationTest(unittest.TestCase):
         dirname = os.path.dirname(__file__)
         filename = os.path.join(dirname, 'binaries/basic_linux_amd64')
         output = subprocess.check_output(['python', '-m', 'manticore', filename])
-        self.assertLessEqual(len(output.splitlines()), 60)
-        output = subprocess.check_output(['python', '-m', 'manticore', filename, "-v"])
-        self.assertLessEqual(len(output.splitlines()), 80)
-        #  output = subprocess.check_output(['python', '-m', 'manticore', filename, "-vvv"])
-        #  self.assertGreaterEqual(len(output.splitlines()), 435000)
-        #  output = subprocess.check_output(['python', '-m', 'manticore', filename, "-vvvv"])
-        #  self.assertGreaterEqual(len(output.splitlines()), 950000)
+        output_lines = output.splitlines()
+        start_info = output_lines[:2]
+        testcase_info = output_lines[2:-5]
+        stop_info = output_lines[-5:]
+
+        self.assertEqual(len(start_info), 2)
+        self.assertEqual(len(stop_info), 5)
+
+        for line in testcase_info:
+            self.assertIn('Generated testcase', line)
 
     def testArgumentsAssertions(self):
         dirname = os.path.dirname(__file__)


### PR DESCRIPTION
Fixes a minor logging verbosity regression (load state messages were being logged on verbosity=1) (see #431)

Also improve test to check for this.