### PR TITLE
Refactor CLI, and Manticore high level interfaces

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -73,7 +73,7 @@ def main():
 
     Manticore.verbosity(args.v)
 
-    m = Manticore(args.argv[0], args.argv[1:], env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
+    m = Manticore.linux(args.argv[0], args.argv[1:], env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
 
     #Fixme(felipe) remove this, move to plugin
     m.coverage_file = args.coverage

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -75,8 +75,6 @@ def main():
 
     m = Manticore(args.argv[0], args.argv[1:], env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
 
-    #All the following will only affect this instance
-
     #Fixme(felipe) remove this, move to plugin
     m.coverage_file = args.coverage
 

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -73,7 +73,7 @@ def main():
 
     Manticore.verbosity(args.v)
 
-    m = Manticore.linux(args.argv[0], args.argv[1:], env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
+    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
 
     #Fixme(felipe) remove this, move to plugin
     m.coverage_file = args.coverage

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -211,9 +211,7 @@ class Manticore(object):
 
         if isinstance(path_or_state, str):
             assert os.path.isfile(path_or_state)
-            # self._initial_state = make_initial_state(path_or_state, **kwargs)
             self._initial_state = make_initial_state(path_or_state, argv=linux_argv, env=linux_envp, **kwargs)
-            # self._initial_state = make_linux(path_or_state, linux_argv, linux_envp)
         elif isinstance(path_or_state, State):
             self._initial_state = path_or_state
         else:
@@ -233,7 +231,7 @@ class Manticore(object):
     def decree(cls, path, concrete_data='', **kwargs):
         try:
             return cls(make_decree(path, concrete_data), **kwargs)
-        except KeyError:
+        except KeyError:  # FIXME(mark) magic parsing for DECREE should raise better error
             raise Exception('Invalid binary: {}'.format(path))
 
     @property

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -170,7 +170,7 @@ class Manticore(object):
     :ivar dict context: Global context for arbitrary data storage
     '''
 
-    def __init__(self, path_or_state, linux_argv=None, linux_envp=None, workspace_url=None, policy='random', **kwargs):
+    def __init__(self, path_or_state, workspace_url=None, policy='random', **kwargs):
 
         if isinstance(workspace_url, str):
             if ':' not in workspace_url:
@@ -208,7 +208,7 @@ class Manticore(object):
 
         if isinstance(path_or_state, str):
             assert os.path.isfile(path_or_state)
-            self._initial_state = make_initial_state(path_or_state, argv=linux_argv, env=linux_envp, **kwargs)
+            self._initial_state = make_initial_state(path_or_state, **kwargs)
         elif isinstance(path_or_state, State):
             self._initial_state = path_or_state
         else:

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -639,15 +639,6 @@ class Manticore(object):
     #############################################################################
     # Move all the following elsewhere Not all manticores have this
 
-    def add_symbolic_file(self, symbolic_file):
-        '''
-        Add a symbolic file. Each '+' in the file will be considered
-        as symbolic, other char are concretized.
-        Symbolic files must have been defined before the call to `run()`.
-
-        :param str symbolic_file: the name of the symbolic file
-        '''
-        self._symbolic_files.append(symbolic_file)
 
     def _get_symbol_address(self, symbol):
         '''

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -224,10 +224,6 @@ class Manticore(object):
 
     @classmethod
     def linux(cls, path, argv=None, envp=None, symbolic_files=None, concrete_start='', **kwargs):
-        argv = [] if argv is None else argv
-        envp = {} if envp is None else envp
-        symbolic_files = [] if symbolic_files is None else symbolic_files
-
         try:
             return cls(make_linux(path, argv, envp, symbolic_files, concrete_start), **kwargs)
         except elftools.common.exceptions.ELFError:

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -172,9 +172,6 @@ class Manticore(object):
 
     def __init__(self, path_or_state, linux_argv=None, linux_envp=None, workspace_url=None, policy='random', **kwargs):
 
-        linux_argv = [] if linux_argv is None else linux_argv
-        linux_envp = {} if linux_envp is None else linux_envp
-
         if isinstance(workspace_url, str):
             if ':' not in workspace_url:
                 ws_path = 'fs:' + workspace_url

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -289,23 +289,12 @@ class Manticore(object):
                 yield ctx
                 context[key] = ctx
 
-    @property
-    def xverbosity(self):
+    @staticmethod
+    def verbosity(level):
         """Convenience interface for setting logging verbosity to one of
         several predefined logging presets. Valid values: 0-5.
         """
-        return log.manticore_verbosity
-
-    @staticmethod
-    def verbosity(level):
         log.set_verbosity(level)
-
-    # @verbosity.setter
-    # def verbosity(self, setting):
-    #     """A call used to modify the level of output verbosity
-    #     :param int setting: the level of verbosity to be used
-    #     """
-    #     log.set_verbosity(setting)
 
     @property
     def running(self):

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -233,6 +233,13 @@ class Manticore(object):
         except elftools.common.exceptions.ELFError:
             raise Exception('Invalid binary: {}'.format(path))
 
+    @classmethod
+    def decree(cls, path, concrete_data='', **kwargs):
+        try:
+            return cls(make_decree(path, concrete_data), **kwargs)
+        except KeyError:
+            raise Exception('Invalid binary: {}'.format(path))
+
     @property
     def initial_state(self):
         return self._initial_state

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2209,6 +2209,16 @@ class SLinux(Linux):
         cpu = CpuFactory.get_cpu(mem, arch)
         return cpu
 
+    def add_symbolic_file(self, symbolic_file):
+        '''
+        Add a symbolic file. Each '+' in the file will be considered
+        as symbolic, other char are concretized.
+        Symbolic files must have been defined before the call to `run()`.
+
+        :param str symbolic_file: the name of the symbolic file
+        '''
+        self.symbolic_files.append(symbolic_file)
+
     @property
     def constraints(self):
         return self._constraints


### PR DESCRIPTION
- Manticore ctor
- Manticore classmethods
- Controversial Manticore.verbosity() refactor as felipe's been suggesting: what do yall think? I added it because `m.verbosity = 2`, while a nice interface, doesn't let you control logging verbosity of what happens during Manticore ctor. and now, in Linux, the binary is loaded during the Manticore ctor (vs when you call m.run())