### PR TITLE
Require Z3 in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install and try Manticore in a few shell commands (see an [asciinema](https://as
 
 ```
 # Install system dependencies
-sudo apt-get update && sudo apt-get install python-pip -y
+sudo apt-get update && sudo apt-get install z3 python-pip -y
 python -m pip install -U pip
 
 # Install manticore and its dependencies


### PR DESCRIPTION
Followed instructions including installed via pip only to find out it requires z3, which was clarified in the Dockerfile. Specifying in the README that z3 is necessary.