### PR TITLE
Localize log formatting changes

### DIFF
--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -34,11 +34,14 @@ def init_logging():
     ctxfilter = ContextFilter()
     logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s:"
               " %(message)s")
-    logging.basicConfig(format=logfmt, stream=sys.stdout, level=logging.ERROR)
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(logfmt)
+    handler.setFormatter(formatter)
     for name in logging.getLogger().manager.loggerDict.keys():
         logger = logging.getLogger(name)
         if not name.startswith('manticore'):
             next
+        logger.addHandler(handler)
         logger.setLevel(logging.WARNING)
         logger.addFilter(ctxfilter)
         logger.setState = types.MethodType(loggerSetState, logger)

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -37,11 +37,12 @@ def init_logging():
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(logfmt)
     handler.setFormatter(formatter)
-    for name in logging.getLogger().manager.loggerDict.keys():
+    for name in all_loggers:
         logger = logging.getLogger(name)
         if not name.startswith('manticore'):
-            next
+            continue
         logger.addHandler(handler)
+        logger.propagate = False
         logger.setLevel(logging.WARNING)
         logger.addFilter(ctxfilter)
         logger.setState = types.MethodType(loggerSetState, logger)


### PR DESCRIPTION
Older code set a custom format string on the global log handler, and added a context filter to add the required field to each log record. This will fail if manticore is used as a library and a non-filtered logger is used. This localizes custom handler only to manticore loggers.

Fixes #544 