### PR TITLE
[fix] Issue #550: generates extra workspace folder

### DIFF
--- a/examples/evm/seth.py
+++ b/examples/evm/seth.py
@@ -140,7 +140,7 @@ class ManticoreEVM(Manticore):
         #make the ethereum world state
         world = evm.EVMWorld(constraints)
         initial_state = State(constraints, world)
-        super(ManticoreEVM, self).__init__(initial_state)
+        super(ManticoreEVM, self).__init__(initial_state, workspace_url='mem:')
 
 
         #The following should go to manticore.context so we can use multiprocessing

--- a/examples/evm/seth.py
+++ b/examples/evm/seth.py
@@ -140,7 +140,7 @@ class ManticoreEVM(Manticore):
         #make the ethereum world state
         world = evm.EVMWorld(constraints)
         initial_state = State(constraints, world)
-        super(ManticoreEVM, self).__init__(initial_state, workspace_url='mem:')
+        super(ManticoreEVM, self).__init__(initial_state)
 
 
         #The following should go to manticore.context so we can use multiprocessing

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -164,7 +164,7 @@ class Executor(Eventful):
 
     _published_events = {'enqueue_state', 'generate_testcase', 'fork_state', 'load_state', 'terminate_state'}
 
-    def __init__(self, initial=None, workspace=None, policy='random', context=None, **kwargs):
+    def __init__(self, initial=None, store=None, policy='random', context=None, **kwargs):
         super(Executor, self).__init__(**kwargs)
 
 
@@ -185,7 +185,7 @@ class Executor(Eventful):
         # Number of currently running workers. Initially no running workers
         self._running = manager.Value('i', 0 )
 
-        self._workspace = Workspace(self._lock, workspace)
+        self._workspace = Workspace(self._lock, store)
 
         # Executor wide shared context
         if context is None:

--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -334,8 +334,11 @@ class Workspace(object):
     A workspace maintains a list of states to run and assigns them IDs.
     """
 
-    def __init__(self, lock, desc=None):
-        self._store = Store.fromdescriptor(desc)
+    def __init__(self, lock, store_or_desc=None):
+        if isinstance(store_or_desc, Store):
+            self._store = store_or_desc
+        else:
+            self._store = Store.fromdescriptor(store_or_desc)
         self._serializer = PickleSerializer()
         self._last_id = manager.Value('i', 0)
         self._lock = lock
@@ -413,8 +416,8 @@ class ManticoreOutput(object):
         self._lock = manager.Condition(manager.RLock())
 
     @property
-    def uri(self):
-        return self._store.uri
+    def store(self):
+        return self._store
 
     @property
     def descriptor(self):

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -21,7 +21,7 @@ from .core.executor import Executor
 from .core.parser import parse
 from .core.state import State, TerminateState
 from .core.smtlib import solver, ConstraintSet
-from .core.workspace import ManticoreOutput, Workspace
+from .core.workspace import ManticoreOutput
 from .platforms import linux, decree, evm
 from .utils.helpers import issymbolic, is_binja_disassembler
 from .utils.nointerrupt import WithKeyboardInterruptAs
@@ -161,7 +161,7 @@ class Manticore(Eventful):
 
         #sugar for 'will_execute_instruction"
         self._hooks = {}
-        self._executor = Executor(workspace=ws_path, policy=policy)
+        self._executor = Executor(store=self._output.store, policy=policy)
         self._workers = []
 
         #Link Executor events to default callbacks in manticore object
@@ -711,6 +711,6 @@ class Manticore(Eventful):
             f.write(' '.join(sys.argv))
 
         elapsed = time.time() - self._time_started
-        logger.info('Results in %s', self._output.uri)
+        logger.info('Results in %s', self._output.store.uri)
         logger.info('Total time: %s', elapsed)
 

--- a/tests/test_manticore.py
+++ b/tests/test_manticore.py
@@ -42,7 +42,7 @@ class ManticoreTest(unittest.TestCase):
         import os, struct
         self.m = Manticore('tests/binaries/basic_linux_amd64')
         self.m.run()
-        workspace = self.m._output.uri# os.path.join(os.getcwd(), self.m.workspace)
+        workspace = self.m._output.store.uri
         with open(os.path.join(workspace, 'test_00000000.stdin')) as f:
             a = struct.unpack('<I', f.read())[0]
         with open(os.path.join(workspace, 'test_00000001.stdin')) as f:


### PR DESCRIPTION
This change fixes Issue #550, where the Manticore workspace dumps state onto the filesystem. The fix works by using the `workspace_url` knob in the `ManticoreEVM` constructor. 

Signed-off-by: Cole Lightfighter <cole@onicsla.bz>