### PR TITLE
linux: Improve error handling if special files (/dev) are opened

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -53,7 +53,11 @@ class File(object):
         state = {}
         state['name'] = self.name
         state['mode'] = self.mode
-        state['pos'] = self.tell()
+        try:
+            state['pos'] = self.tell()
+        except IOError:
+            # This is to handle special files like /dev/tty
+            state['pos'] = None
         return state
 
     def __setstate__(self, state):
@@ -61,7 +65,8 @@ class File(object):
         mode = state['mode']
         pos = state['pos']
         self.file = file(name, mode)
-        self.seek(pos)
+        if pos is not None:
+            self.seek(pos)
 
     @property
     def name(self):


### PR DESCRIPTION
Fixes #537 

If a linux program opens `/dev/tty`, and Manticore tries to save state, it will crash when `.tell()` is attempted to be called on the `/dev/tty` file object. This pr changes the `File` functions for saving and setting state to detects when that happens and handle it.