### PR TITLE
Optimize forking when only one solution exists

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -380,6 +380,10 @@ class Executor(Eventful):
         #Find a set of solutions for expression
         solutions = state.concretize(expression, policy)
 
+        if len(solutions) == 1:
+            setstate(state, solutions[0])
+            return state
+
         logger.info("Forking, about to store. (policy: %s, values: %s)",
                     policy,
                     ', '.join('0x{:x}'.format(sol) for sol in solutions))
@@ -468,8 +472,7 @@ class Executor(Eventful):
                         #setstate()
 
                         logger.debug("Generic state fork on condition")
-                        self.fork(current_state, e.expression, e.policy, e.setstate)
-                        current_state = None
+                        current_state = self.fork(current_state, e.expression, e.policy, e.setstate)
 
                     except TerminateState as e:
                         #Notify this worker is done


### PR DESCRIPTION
This PR implements a optimization to forking. Fixes #526 

Currently, when manticore has a symbolic PC, or other Concretize exception, it uses the `fork` function to fork execution for each solution to the symbolic expr (depending on the policy). Forking is expensive and among other things, involved touching the workspace (disk). In the case when there is only 1 solution, a fork is not necessary, the current state should simply continue with the expression set to the single concrete solution.

Before the PR you might see logs like this:

```
2017-11-14 15:56:09,994: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3, 0x4009d3)
2017-11-14 15:56:10,072: [107126] m.c.executor:INFO: load state 2
2017-11-14 15:56:10,171: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
2017-11-14 15:56:10,226: [107126] m.c.executor:INFO: load state 1
2017-11-14 15:56:10,313: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
2017-11-14 15:56:10,363: [107126] m.c.executor:INFO: load state 4
2017-11-14 15:56:10,451: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
2017-11-14 15:56:10,500: [107126] m.c.executor:INFO: load state 3
2017-11-14 15:56:10,597: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
2017-11-14 15:56:10,645: [107126] m.c.executor:INFO: load state 6
2017-11-14 15:56:10,733: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
2017-11-14 15:56:10,810: [107126] m.c.executor:INFO: load state 5
2017-11-14 15:56:10,909: [107126] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3)
```

After, it looks like this, forking only happens when necessary.

```
2017-11-14 15:56:45,503: [107235] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3, 0x4009d3)
2017-11-14 15:56:45,574: [107235] m.c.executor:INFO: load state 2
2017-11-14 15:56:56,815: [107235] m.c.executor:INFO: Forking, about to store. (policy: ALL, values: 0x4009e3, 0x4009d3)
2017-11-14 15:56:56,905: [107235] m.c.executor:INFO: load state 3
```