### PR TITLE
Changing linux ret code to int from uint

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1753,6 +1753,8 @@ class Linux(Platform):
         self.sched()
         self.running.remove(procid)
         #self.procs[procid] = None
+        if(error_code & 0x8000000000000000):
+            error_code = -0x10000000000000000 + error_code
         logger.debug("EXIT_GROUP PROC_%02d %s", procid, error_code)
         if len(self.running) == 0 :
             raise TerminateState("Program finished with exit status: %r" % error_code, testcase=True)


### PR DESCRIPTION
Earlier the return code was unsigned int, so for a simple program returning -1 the behaviour was :

```
2017-11-19 09:23:38,389: [4237] m.manticore:INFO: Loading program try
2017-11-19 09:23:40,020: [4237] m.manticore:INFO: Starting 1 processes.
2017-11-19 09:25:57,083: [4237] m.manticore:INFO: Generated testcase No. 0 - Program finished with exit status: 18446744073709551615L
2017-11-19 09:25:57,098: [4237] m.manticore:INFO: Results in /home/vignesh/Documents/projects/tests/mcore_iQ8OSr
2017-11-19 09:25:57,098: [4237] m.manticore:INFO: Total time: 137.078702927
```

Current behaviour after changing the Linux return code to signed int :
```
2017-11-19 09:53:06,173: [5852] m.manticore:INFO: Loading program try
2017-11-19 09:53:07,768: [5852] m.manticore:INFO: Starting 1 processes.
2017-11-19 09:55:21,266: [5852] m.manticore:INFO: Generated testcase No. 0 - Program finished with exit status: -1L
2017-11-19 09:55:21,280: [5852] m.manticore:INFO: Results in /home/vignesh/Documents/projects/tests/mcore_UaIYVR
2017-11-19 09:55:21,281: [5852] m.manticore:INFO: Total time: 133.512251854
```