### PR TITLE
Fixes for issue 587

### DIFF
--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -789,7 +789,7 @@ class Cpu(Eventful):
         emu = UnicornEmulator(self)
         try:
             emu.emulate(insn)
-        except e:
+        except Exception as e:
             raise InstructionEmulationError(str(e))
         finally:
             # We have been seeing occasional Unicorn issues with it not clearing

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -799,7 +799,7 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def ADD(cpu, dest, src, add=None):
-        if add:
+        if add is not None:
             result, carry, overflow = cpu._ADD(src.read(), add.read())
         else:
             #support for the thumb mode version of adds <dest>, <immediate>
@@ -824,7 +824,7 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def SUB(cpu, dest, src, add=None):
-        if add:
+        if add is not None
             result, carry, overflow = cpu._ADD(src.read(), ~add.read(), 1)
         else:
             #support for the thumb mode version of sub <dest>, <immediate>

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -824,7 +824,7 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def SUB(cpu, dest, src, add=None):
-        if add is not None
+        if add is not None:
             result, carry, overflow = cpu._ADD(src.read(), ~add.read(), 1)
         else:
             #support for the thumb mode version of sub <dest>, <immediate>

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1370,6 +1370,10 @@ class Linux(Platform):
         logger.debug("GETPID, warning pid modeled as concrete 1000")
         return 1000
 
+    def sys_gettid(self, v):
+        logger.debug("GETTID, warning tid modeled as concrete 1000")
+        return 1000
+
     def sys_ARM_NR_set_tls(self, val):
         if hasattr(self, '_arm_tls_memory'):
             self.current.write_int(self._arm_tls_memory, val)


### PR DESCRIPTION
Fixes to the SUB, BLX, and MOV instruction implementations
Gettid syscall implementation