### PR TITLE
Fix for issue 556 and 591

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -53,6 +53,8 @@ def parse_arguments():
     parser.add_argument('--workspace', type=str, default=None,
                         help=("A folder name for temporaries and results."
                               "(default mcore_?????)"))
+    parser.add_argument('--version', action='version', version='Manticore 0.1.5',
+                         help='Show program version information')
 
     parsed = parser.parse_args(sys.argv[1:])
     if parsed.procs <= 0:

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -789,7 +789,7 @@ class Cpu(Eventful):
         emu = UnicornEmulator(self)
         try:
             emu.emulate(insn)
-        except e:
+        except Exception as e:
             raise InstructionEmulationError(str(e))
         finally:
             # We have been seeing occasional Unicorn issues with it not clearing


### PR DESCRIPTION
Fixes #556 
Fixes #591 

**Summary:** Add a --version cli argument in main.py

**Fix:**
* A "version" argument is included in the argument handler in main.py
  - Version hardcoded in the code which should be updated every release
  - Outputs the version information and exits the program
  - Performed test in the dev environment

**Further Discussion:**
* Methods to access version variable from setup.py without causing any malfunction