### PR TITLE
Hide legacy cli flags from cli help

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -42,7 +42,6 @@ def parse_arguments():
                         help='Number of parallel processes to spawn')
     parser.add_argument('argv', type=str, nargs='+',
                         help="Path to program, and arguments ('+' in arguments indicates symbolic byte).")
-    parser.add_argument('--size', type=str, help='Specify buffer full size')
     parser.add_argument('--timeout', type=int, default=0,
                         help='Timeout. Abort exploration aftr TIMEOUT seconds')
     parser.add_argument('-v', action='count', default=1,

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -42,8 +42,6 @@ def parse_arguments():
                         help='Number of parallel processes to spawn')
     parser.add_argument('argv', type=str, nargs='+',
                         help="Path to program, and arguments ('+' in arguments indicates symbolic byte).")
-    parser.add_argument('--replay', type=str, default=None,
-                        help=argparse.SUPPRESS)
     parser.add_argument('--size', type=str, help='Specify buffer full size')
     parser.add_argument('--timeout', type=int, default=0,
                         help='Timeout. Abort exploration aftr TIMEOUT seconds')

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -8,7 +8,7 @@ sys.setrecursionlimit(10000)
 def parse_arguments():
     ###########################################################################
     # parse arguments
-    parser = argparse.ArgumentParser(description='Symbolically analyze a program')
+    parser = argparse.ArgumentParser(description='Dynamic binary analysis tool')
     parser.add_argument('--assertions', type=str, default=None,
                         help=argparse.SUPPRESS)
     parser.add_argument('--buffer', type=str,

--- a/manticore/platforms/platform.py
+++ b/manticore/platforms/platform.py
@@ -28,18 +28,15 @@ class Platform(Eventful):
     '''
     def __init__(self, path, **kwargs):
         super(Platform, self).__init__(**kwargs)
-        self._path = path #Not clear why all platforms must have a "path"
 
     def invoke_model(self, model, prefix_args=None):
         self._function_abi.invoke(model, prefix_args)
 
     def __setstate__(self, state):
         super(Platform, self).__setstate__(state)
-        self._path = state['path']
 
     def __getstate__(self):
         state = super(Platform, self).__getstate__()
-        state['path'] = self._path
         return state
 
     def generate_workspace_files(self):


### PR DESCRIPTION
Added help=argparse.SUPPRESS to help arguements:

- assertions
- buffer
- context
- names
- offset

Removed --replay argument.

Fixes #617 