### PR TITLE
Add newlines in .trace file generation

### DIFF
--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -518,7 +518,7 @@ class ManticoreOutput(object):
             if 'trace' not in state.context:
                 return
             for entry in state.context['trace']:
-                f.write('0x{:x}'.format(entry))
+                f.write('0x{:x}\n'.format(entry))
 
     def save_constraints(self, state):
         # XXX(yan): We want to conditionally enable this check


### PR DESCRIPTION
Changed save_trace to do f.write('0x{:x}\n'.format(entry))