### PR TITLE
evm: Make 'not enough funds' states finalized states

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -97,8 +97,8 @@ def ethereum_cli(args):
         print "[+] There are %d reverted states now"% len(m.terminated_state_ids)
         print "[+] There are %d alive states now"% len(m.running_state_ids)
 
-    for state in m.all_states:
-        print str(state.context['last_exception'])
+        for state in m.all_states:
+            print str(state.context['last_exception'])
 
     # for state in seth.all_states:
     #     blockchain = state.platform

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -97,8 +97,8 @@ def ethereum_cli(args):
         print "[+] There are %d reverted states now"% len(m.terminated_state_ids)
         print "[+] There are %d alive states now"% len(m.running_state_ids)
 
-        for state in m.all_states:
-            print str(state.context['last_exception'])
+    for state in m.all_states:
+        print str(state.context['last_exception'])
 
     # for state in seth.all_states:
     #     blockchain = state.platform

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -656,7 +656,7 @@ class ManticoreEVM(Manticore):
             our private list 
         '''
         state.context['last_exception'] = e
-        if e.message != 'REVERT':
+        if e.message != 'REVERT' and 'und' not in e.message:
             # if not a revert we save the state for further transactioning
             state.context['processed'] = False
             if e.message == 'RETURN':

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -656,7 +656,9 @@ class ManticoreEVM(Manticore):
             our private list 
         '''
         state.context['last_exception'] = e
-        if e.message != 'REVERT' and 'und' not in e.message:
+        # TODO(mark): This will break if we ever change the message text. Use a less
+        # brittle check.
+        if e.message not in {'REVERT', 'Not Enough Funds for transaction'}:
             # if not a revert we save the state for further transactioning
             state.context['processed'] = False
             if e.message == 'RETURN':


### PR DESCRIPTION
Currently, when we terminate a state because there were not enough funds in the sender's balance for the transaction,  we keep that state alive, causing it to produce new states when another transaction is executed. This results in redundant states. We can safely terminate a 'not enough funds' state because it has no effect on blockchain state.