### PR TITLE
Implement initial evm workspace, fix small bugs

### DIFF
--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -32,7 +32,7 @@ class Tracer(Plugin):
     def will_start_run_callback(self, state):
         state.context['trace'] = []
 
-    def will_execute_instruction_callback(self, state, pc, instruction):
+    def did_execute_instruction_callback(self, state, pc, target_pc, instruction):
         state.context['trace'].append(pc)
 
 class ExtendedTracer(Plugin):

--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -32,7 +32,7 @@ class Tracer(Plugin):
     def will_start_run_callback(self, state):
         state.context['trace'] = []
 
-    def did_execute_instruction_callback(self, state, pc, target_pc, instruction):
+    def will_execute_instruction_callback(self, state, pc, instruction):
         state.context['trace'].append(pc)
 
 class ExtendedTracer(Plugin):

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2399,13 +2399,10 @@ class EVMWorld(Platform):
             data = {
                 'to': tx.address,
                 'from': tx.caller,
-                'data': tx.data,
-                'solveddata': solve_data(tx.data).encode('hex'),
-                # 'data': tx.data,
-                # 'data': ''.join(tx.data),
-                'value': tx.value
-
+                'data': solve_data(tx.data).encode('hex'),
+                'value': tx.value if not issymbolic(tx.value) else '{symbolic!}'
             }
-            print data
+            import json
+            ret[name] = json.dumps(data, indent=4)
 
         return ret

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2384,22 +2384,13 @@ class EVMWorld(Platform):
         self.current.pc += self.current.instruction.size
 
     def generate_workspace_files(self):
-        def solve_data(data):
-            ret = ''
-            try:
-                for c in data:
-                    ret += chr(solver.get_value(self.constraints, c))
-            except SolverException:
-                ret += '{ SolverException :( }'
-            return ret
-
         ret = {}
         for i, tx in enumerate(self.transactions):
             name = 'tx.{}'.format(i)
             data = {
                 'to': tx.address,
                 'from': tx.caller,
-                'data': solve_data(tx.data).encode('hex'),
+                'data': solver.get_value(self.constraints, tx.data).encode('hex'),
                 'value': tx.value if not issymbolic(tx.value) else '{symbolic!}'
             }
             import json

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -402,6 +402,7 @@ class ManticoreEVM(Manticore):
         self._executor.subscribe('did_read_code', self._did_read_code)
         self._executor.subscribe('on_symbolic_sha3', self._symbolic_sha3)
         self._executor.subscribe('on_concrete_sha3', self._concrete_sha3)
+        self._executor.subscribe('will_generate_testcase', self._will_generate_testcase_callback)
 
     @property
     def world(self):
@@ -1001,4 +1002,10 @@ class ManticoreEVM(Manticore):
         output += "Total assembler lines visited: %d\n"% count
         output += "Coverage: %2.2f%%\n"%  (count*100.0/total)
         return output
+
+    def _will_generate_testcase_callback(self, state, name, message):
+        print 111111, state, name, message
+        print self._output
+        print map(hex, state.context['trace'])
+        pass
 

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -402,7 +402,6 @@ class ManticoreEVM(Manticore):
         self._executor.subscribe('did_read_code', self._did_read_code)
         self._executor.subscribe('on_symbolic_sha3', self._symbolic_sha3)
         self._executor.subscribe('on_concrete_sha3', self._concrete_sha3)
-        self._executor.subscribe('will_generate_testcase', self._will_generate_testcase_callback)
 
     @property
     def world(self):
@@ -1002,10 +1001,3 @@ class ManticoreEVM(Manticore):
         output += "Total assembler lines visited: %d\n"% count
         output += "Coverage: %2.2f%%\n"%  (count*100.0/total)
         return output
-
-    def _will_generate_testcase_callback(self, state, name, message):
-        print 111111, state, name, message
-        print self._output
-        print map(hex, state.context['trace'])
-        pass
-

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -499,6 +499,7 @@ class ManticoreEVM(Manticore):
         '''
 
         name, source_code, init_bytecode, metadata, metadata_runtime, hashes, abi = self._compile(source_code)
+        self._output.store.save_value('contract.bytecode', init_bytecode)
         address = self.create_contract(owner=owner, address=address, balance=balance, init=tuple(init_bytecode)+tuple(ABI.make_function_arguments(*args)))
         self.metadata[address] = SolidityMetadata(name, source_code, init_bytecode, metadata, metadata_runtime, hashes, abi)
         return EVMAccount(address, self, default_caller=owner)

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -347,7 +347,7 @@ class ManticoreEVM(Manticore):
     @staticmethod
     def compile(source_code):
         ''' Get initialization bytecode from a solidity source code '''
-        name, source_code, bytecode, srcmap, srcmap_runtime, hashes = ManticoreEVM._compile(source_code)
+        name, source_code, bytecode, srcmap, srcmap_runtime, hashes, abi = ManticoreEVM._compile(source_code)
         return bytecode
 
     @staticmethod


### PR DESCRIPTION
- Fixes a bug in tuple size in sol compile helper
- generate .tx.# files for tx in each state
- save the compiled bytecode in workspace as a convenience, if solidity was compiled.