### PR TITLE
Seth: Fix uninitialized address in _generate_testcase_callback

### DIFF
--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -1015,10 +1015,11 @@ class ManticoreEVM(Manticore):
         with testcase.open_stream('summary') as summary:            
             summary.write("Last exception: %s\n" %state.context['last_exception'])
 
+            address, offset = state.context['seth.trace'][-1]
+            
             #Last instruction
             metadata = self.get_metadata(blockchain.transactions[-1].address)
             if metadata is not None:
-                address, offset = state.context['seth.trace'][-1]
                 summary.write('Last instruction at contract %x offset %x\n' %(address, offset))
                 at_runtime = blockchain.transactions[-1].sort != 'Create'
                 summary.write(metadata.get_source_for(offset, at_runtime))


### PR DESCRIPTION
Fix the following bug:
`address` is used at line [seth.py#L1055](https://github.com/trailofbits/manticore/blob/591d7b81d56dae88c441975e955fece9f489ff58/manticore/seth.py#L1055), but is uninitialized if `metadata` is `None`