### PR TITLE
Improve evm cli output

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -90,7 +90,7 @@ def ethereum_cli(args):
     contract_account = m.solidity_create_contract(source_code, owner=user_account)
     attacker_account = m.create_account(balance=1000)
 
-    logger.info("Starting with %d processes", args.procs)
+    logger.info("Beginning analysis")
 
     last_coverage = None
     new_coverage = 0

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -82,6 +82,7 @@ def ethereum_cli(args):
     m.register_detector(UnitializedStorage())
     m.register_detector(UnitializedMemory())
 
+    logger.info("Beginning analysis")
 
     with open(args.argv[0]) as f:
         source_code = f.read()
@@ -89,8 +90,6 @@ def ethereum_cli(args):
     user_account = m.create_account(balance=1000)
     contract_account = m.solidity_create_contract(source_code, owner=user_account)
     attacker_account = m.create_account(balance=1000)
-
-    logger.info("Beginning analysis")
 
     last_coverage = None
     new_coverage = 0

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -32,7 +32,7 @@ class Detector(Plugin):
 
         with self.manticore.locked_context('seth.global_findings', set) as global_findings:
             global_findings.add((address, pc, finding))
-        logger.info(finding)
+        logger.warning(finding)
 
     def _get_src(self, address, pc):
         return self.manticore.get_metadata(address).get_source_for(pc)

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -803,14 +803,14 @@ class ManticoreEVM(Manticore):
         with self.locked_context('seth') as context:
             context['_pending_transaction'] = ('CALL', caller, address, value, data)
 
+        logger.info("Starting symbolic transaction: %d", self.completed_transactions + 1)
+
         status = self.run(procs=self._config_procs)
 
         with self.locked_context('seth') as context:
             context['_completed_transactions'] = context['_completed_transactions'] + 1
 
-        logger.info("Coverage after %d transactions: %d%%", self.completed_transactions, self.global_coverage(address))
-        logger.info("There are %d reverted states now", len(self.terminated_state_ids))
-        logger.info("There are %d alive states now", len(self.running_state_ids))
+        logger.info("Finished symbolic transaction: %d | Code Coverage: %d%% | Reverted States: %d | Alive States: %d", self.completed_transactions, self.global_coverage(address), len(self.terminated_state_ids), len(self.running_state_ids))
 
         return status
 

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -1240,7 +1240,7 @@ class ManticoreEVM(Manticore):
                         f.write('0x%x\n'%o)
 
 
-        logger.info("Look for results in %s", self.workspace )
+        logger.info("Results in %s", self.workspace )
 
     def global_coverage(self, account_address):
         ''' Returns code coverage for the contract on `account_address`.

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -1270,7 +1270,8 @@ class ManticoreEVM(Manticore):
 
         return count*100.0/total
 
-    #TODO: find a better way to suppress execution of Manticore._did_finish_run_callback    
+    # TODO: Find a better way to suppress execution of Manticore._did_finish_run_callback
+    # We suppress because otherwise we log it many times and it looks weird.
     def _did_finish_run_callback(self):
-        _shared_context = self.context
+        pass
 


### PR DESCRIPTION
looks like this now.
should the code coverage/reverted/alive states be on different lines?

```
[I] mark ubuntu /m/h/c/m/e/evm (dev-evm-output) ❯ manticore demo.sol
2017-12-19 13:16:17,972: [90830] m.main:INFO: Beginning analysis
2017-12-19 13:16:18,047: [90830] m.seth:INFO: Starting symbolic transaction: 1
2017-12-19 13:16:18,386: [90830] m.seth:INFO: Generated testcase No. 0 - REVERT
2017-12-19 13:16:21,811: [90830] m.seth:INFO: Generated testcase No. 1 - REVERT
2017-12-19 13:16:25,695: [90830] m.seth:INFO: Generated testcase No. 2 - REVERT
2017-12-19 13:16:29,769: [90830] m.seth:INFO: Generated testcase No. 3 - REVERT
2017-12-19 13:16:33,518: [90830] m.seth:INFO: Finished symbolic transaction: 1 | Code Coverage: 54% | Reverted States: 4 | Alive States: 1
2017-12-19 13:16:33,519: [90830] m.seth:INFO: Starting symbolic transaction: 2
2017-12-19 13:16:33,912: [90830] m.seth:INFO: Generated testcase No. 4 - REVERT
2017-12-19 13:16:39,186: [90830] m.seth:WARNING: Integer overflow at ADD instruction
2017-12-19 13:16:39,293: [90830] m.seth:INFO: Generated testcase No. 5 - REVERT
2017-12-19 13:16:45,309: [90830] m.seth:INFO: Generated testcase No. 6 - REVERT
2017-12-19 13:16:51,610: [90830] m.seth:INFO: Generated testcase No. 7 - REVERT
2017-12-19 13:16:57,043: [90830] m.seth:INFO: Finished symbolic transaction: 2 | Code Coverage: 100% | Reverted States: 8 | Alive States: 2
2017-12-19 13:16:57,063: [90830] m.seth:INFO: Generated testcase No. 8 - Still Running
2017-12-19 13:17:02,650: [90830] m.seth:INFO: Generated testcase No. 9 - Still Running
2017-12-19 13:17:08,509: [90830] m.seth:INFO: Results in /mnt/hgfs/code/manticore/examples/evm/mcore_hLOchY

```