### PR TITLE
output the actual exit status when finalizing evm states

### DIFF
--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -689,7 +689,8 @@ class ManticoreEVM(Manticore):
                 seth_context['_saved_states'] = lst
 
         state = self.load(state_id)
-        self._generate_testcase_callback(state, 'test', 'Still Running')
+        last_exc = state.context['last_exception']
+        self._generate_testcase_callback(state, 'test', last_exc.message)
 
         if state_id == -1:
             state_id = self.save(state, final=True)

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -962,7 +962,7 @@ class ManticoreEVM(Manticore):
         state.context['last_exception'] = e
         # TODO(mark): This will break if we ever change the message text. Use a less
         # brittle check.
-        if e.message not in {'REVERT', 'Not Enough Funds for transaction'}:
+        if e.message not in {'REVERT', 'THROW', 'Not Enough Funds for transaction'}:
             # if not a revert we save the state for further transactioning
             state.context['processed'] = False
             if e.message == 'RETURN':

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -837,7 +837,7 @@ class ManticoreEVM(Manticore):
         with self.locked_context('seth') as context:
             context['_completed_transactions'] = context['_completed_transactions'] + 1
 
-        logger.info("Finished symbolic transaction: %d | Code Coverage: %d%% | Reverted States: %d | Alive States: %d", self.completed_transactions, self.global_coverage(address), len(self.terminated_state_ids), len(self.running_state_ids))
+        logger.info("Finished symbolic transaction: %d | Code Coverage: %d%% | Terminated States: %d | Alive States: %d", self.completed_transactions, self.global_coverage(address), len(self.terminated_state_ids), len(self.running_state_ids))
 
         return status
 


### PR DESCRIPTION

- output exit status
- terminate throw states

looks like this now, note the "STOP" at the bottom, instead of "Still Running"
 

```
[I] mark ubuntu /m/h/c/m/e/evm (dev-alive-state-status) ❯ manticore two_tx_ovf.sol
2017-12-22 12:26:06,538: [83605] m.main:INFO: Beginning analysis
2017-12-22 12:26:06,622: [83605] m.seth:INFO: Starting symbolic transaction: 1
2017-12-22 12:26:06,958: [83605] m.seth:INFO: Generated testcase No. 0 - REVERT
2017-12-22 12:26:10,269: [83605] m.seth:INFO: Generated testcase No. 1 - REVERT
2017-12-22 12:26:13,939: [83605] m.seth:INFO: Generated testcase No. 2 - REVERT
2017-12-22 12:26:17,839: [83605] m.seth:INFO: Generated testcase No. 3 - REVERT
2017-12-22 12:26:21,489: [83605] m.seth:INFO: Finished symbolic transaction: 1 | Code Coverage: 54% | Terminated States: 4 | Alive States: 1
2017-12-22 12:26:21,491: [83605] m.seth:INFO: Starting symbolic transaction: 2
2017-12-22 12:26:21,882: [83605] m.seth:INFO: Generated testcase No. 4 - REVERT
2017-12-22 12:26:26,945: [83605] m.seth:WARNING: Integer overflow at ADD instruction
2017-12-22 12:26:27,052: [83605] m.seth:INFO: Generated testcase No. 5 - REVERT
2017-12-22 12:26:32,703: [83605] m.seth:INFO: Generated testcase No. 6 - REVERT
2017-12-22 12:26:38,816: [83605] m.seth:INFO: Generated testcase No. 7 - REVERT
2017-12-22 12:26:43,989: [83605] m.seth:INFO: Finished symbolic transaction: 2 | Code Coverage: 100% | Terminated States: 8 | Alive States: 2
2017-12-22 12:26:44,008: [83605] m.seth:INFO: Generated testcase No. 8 - STOP
2017-12-22 12:26:49,609: [83605] m.seth:INFO: Generated testcase No. 9 - STOP
2017-12-22 12:26:55,410: [83605] m.seth:INFO: Results in /mnt/hgfs/code/manticore/examples/evm/mcore_acc6lf

```