### PR TITLE
Rm unused evm workspace function

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2459,18 +2459,3 @@ class EVMWorld(Platform):
             
         self.current._push(value)
         self.current.pc += self.current.instruction.size
-
-    def generate_workspace_files(self):
-        ret = {}
-        for i, tx in enumerate(self.transactions):
-            name = 'tx.{}'.format(i)
-            data = {
-                'to': tx.address,
-                'from': tx.caller,
-                'data': solver.get_value(self.constraints, tx.data).encode('hex'),
-                'value': tx.value if not issymbolic(tx.value) else '{symbolic!}'
-            }
-            import json
-            ret[name] = json.dumps(data, indent=4)
-
-        return ret

--- a/manticore/seth.py
+++ b/manticore/seth.py
@@ -1065,6 +1065,8 @@ class ManticoreEVM(Manticore):
         # each object knows its secrets, each class should be able to report its
         # final state
         #super(ManticoreEVM, self)._generate_testcase_callback(state, name, message)
+        # TODO(mark): Refactor ManticoreOutput to let the platform be more in control
+        #  so this function can be fully ported to EVMWorld.generate_workspace_files.
         def flagged(flag):
             return '(*)' if flag else '' 
         testcase = self._output.testcase()


### PR DESCRIPTION
Since this func was added, _generate_testcase_callback was overrided in ManticoreEVM totally bypassing this function, which is now unused.