### PR TITLE
Add --tx flag to control symbolic tx

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -62,8 +62,8 @@ def parse_arguments():
                               "(default mcore_?????)"))
     parser.add_argument('--version', action='version', version='Manticore 0.1.5',
                          help='Show program version information')
-    parser.add_argument('--tx', type=check_positive,
-                        help='Number of symbolic transactions to run (positive integer) (Ethereum only)')
+    parser.add_argument('--txlimit', type=check_positive,
+                        help='Maximum number of symbolic transactions to run (positive integer) (Ethereum only)')
 
 
     parsed = parser.parse_args(sys.argv[1:])
@@ -91,7 +91,7 @@ def ethereum_cli(args):
 
     logger.info("Beginning analysis")
 
-    m.multi_tx_analysis(args.argv[0], args.tx)
+    m.multi_tx_analysis(args.argv[0], args.txlimit)
 
 def main():
     log.init_logging()

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -63,7 +63,7 @@ def parse_arguments():
     parser.add_argument('--version', action='version', version='Manticore 0.1.5',
                          help='Show program version information')
     parser.add_argument('--tx', type=check_positive,
-                        help='Set number of symbolic transactions (Ethereum only)')
+                        help='Number of symbolic transactions to run (positive integer) (Ethereum only)')
 
 
     parsed = parser.parse_args(sys.argv[1:])

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -13,7 +13,7 @@ sys.setrecursionlimit(10000)
 
 
 def parse_arguments():
-    def check_positive(value):
+    def positive(value):
         ivalue = int(value)
         if ivalue <= 0:
             raise argparse.ArgumentTypeError("Argument must be positive")
@@ -62,7 +62,7 @@ def parse_arguments():
                               "(default mcore_?????)"))
     parser.add_argument('--version', action='version', version='Manticore 0.1.5',
                          help='Show program version information')
-    parser.add_argument('--txlimit', type=check_positive,
+    parser.add_argument('--txlimit', type=positive,
                         help='Maximum number of symbolic transactions to run (positive integer) (Ethereum only)')
 
 

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -13,8 +13,12 @@ sys.setrecursionlimit(10000)
 
 
 def parse_arguments():
-    ###########################################################################
-    # parse arguments
+    def check_positive(value):
+        ivalue = int(value)
+        if ivalue <= 0:
+            raise argparse.ArgumentTypeError("Argument must be positive")
+        return ivalue
+
     parser = argparse.ArgumentParser(description='Dynamic binary analysis tool')
     parser.add_argument('--assertions', type=str, default=None,
                         help=argparse.SUPPRESS)
@@ -58,6 +62,9 @@ def parse_arguments():
                               "(default mcore_?????)"))
     parser.add_argument('--version', action='version', version='Manticore 0.1.5',
                          help='Show program version information')
+    parser.add_argument('--tx', type=check_positive,
+                        help='Set number of symbolic transactions (Ethereum only)')
+
 
     parsed = parser.parse_args(sys.argv[1:])
     if parsed.procs <= 0:
@@ -84,7 +91,7 @@ def ethereum_cli(args):
 
     logger.info("Beginning analysis")
 
-    m.multi_tx_analysis(args.argv[0])
+    m.multi_tx_analysis(args.argv[0], args.tx)
 
 def main():
     log.init_logging()

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -841,7 +841,7 @@ class ManticoreEVM(Manticore):
 
         return status
 
-    def multi_tx_analysis(self, solidity_filename, tx_count):
+    def multi_tx_analysis(self, solidity_filename, tx_count=None):
         with open(solidity_filename) as f:
             source_code = f.read()
 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -841,7 +841,7 @@ class ManticoreEVM(Manticore):
 
         return status
 
-    def multi_tx_analysis(self, solidity_filename):
+    def multi_tx_analysis(self, solidity_filename, tx_count):
         with open(solidity_filename) as f:
             source_code = f.read()
 
@@ -849,25 +849,32 @@ class ManticoreEVM(Manticore):
         contract_account = self.solidity_create_contract(source_code, owner=user_account)
         attacker_account = self.create_account(balance=1000)
 
-        prev_coverage = 0
-        current_coverage = 0
-
-        while current_coverage < 100:
-
+        def run_symbolic_tx():
             symbolic_data = self.make_symbolic_buffer(320)
             symbolic_value = self.make_symbolic_value()
 
             self.transaction(caller=attacker_account,
-                          address=contract_account,
-                          data=symbolic_data,
-                          value=symbolic_value )
+                             address=contract_account,
+                             data=symbolic_data,
+                             value=symbolic_value )
 
-            prev_coverage = current_coverage
-            current_coverage = self.global_coverage(contract_account)
-            found_new_coverage = prev_coverage < current_coverage
+        if tx_count is None:
+            prev_coverage = 0
+            current_coverage = 0
 
-            if not found_new_coverage:
-                break
+            while current_coverage < 100:
+                run_symbolic_tx()
+
+                prev_coverage = current_coverage
+                current_coverage = self.global_coverage(contract_account)
+                found_new_coverage = prev_coverage < current_coverage
+
+                if not found_new_coverage:
+                    break
+        else:
+            while tx_count:
+                run_symbolic_tx()
+                tx_count -= 1
 
         self.finalize()
 


### PR DESCRIPTION
Currently, the manticore ethereum cli uses coverage based logic for determining when to stop running symbolic transactions. This can be somewhat faulty currently due to bugs in coverage computation. It can be useful to manually be able to control the number of symbolic tx, for example, to limit unnecessary state exploration.

This adds a `--txlimit` flag to the CLI, whose argument must be a positive integer.