### PR TITLE
Fix metadata setting race

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -2,7 +2,7 @@ import string
 
 from . import Manticore
 from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, Array, Expression, Constant
-from .core.smtlib.visitors import arithmetic_simplifier
+from .core.smtlib.visitors import arithmetanticore/core/smtlib/solver.pyic_simplifier
 from .platforms import evm
 from .core.state import State
 import tempfile
@@ -763,7 +763,7 @@ class ManticoreEVM(Manticore):
         init_bytecode = compile_results[2]
 
         if address is None:
-            address = self.world._new_address()
+            address = self.world.new_address()
 
         #FIXME different states "could"(VERY UNLIKELY) have different contracts 
         # asociated with the same address
@@ -792,7 +792,7 @@ class ManticoreEVM(Manticore):
             assert context['_pending_transaction'] is None
         assert init is not None
         if address is None:
-            address = self.world._new_address()
+            address = self.world.new_address()
         with self.locked_context('seth') as context:
             context['_pending_transaction'] = ('CREATE_CONTRACT', owner, address, balance, init)
 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -2,7 +2,7 @@ import string
 
 from . import Manticore
 from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, Array, Expression, Constant
-from .core.smtlib.visitors import arithmetanticore/core/smtlib/solver.pyic_simplifier
+from .core.smtlib.visitors import arithmetic_simplifier
 from .platforms import evm
 from .core.state import State
 import tempfile

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -9,7 +9,6 @@ import tempfile
 from subprocess import Popen, PIPE
 import sha3
 import json
-import types
 import logging
 import StringIO
 import cPickle as pickle
@@ -443,6 +442,10 @@ class EVMAccount(object):
     def address(self):
         return self._address
 
+    def _null_func():
+        pass
+
+
     def _init_hashes(self):
         #initializes self._hashes lazy
         if self._hashes is None and self._seth is not None:
@@ -452,7 +455,8 @@ class EVMAccount(object):
                 for signature, func_id in md.hashes.items():
                     func_name = str(signature.split('(')[0])
                     self._hashes[func_name] = signature, func_id
-            self._init_hashes = types.MethodType(lambda *args: None, self)
+            #It was successful, no need to re-run. _init_hashes disabled
+            self._init_hashes = self._null_func
 
     def __getattribute__(self, name):
         ''' If this is a contract account of which we know the functions hashes,

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -578,7 +578,6 @@ class ManticoreEVM(Manticore):
             abi = json.loads(contract['abi'])
             runtime = contract['bin-runtime'].decode('hex')
             warnings = p.stderr.read()
-
             return name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi, warnings
 
     def __init__(self, procs=1):
@@ -755,14 +754,17 @@ class ManticoreEVM(Manticore):
         compile_results = self._compile(source_code)
         init_bytecode = compile_results[2]
 
+        if address is None:
+            address = self.world._new_address()
+
+        #FIXME different states "could"(VERY UNLIKELY) have different contracts 
+        # asociated with the same address
+        self.metadata[address] = SolidityMetadata(*compile_results)
+
         account = self.create_contract(owner=owner,
                                        balance=balance,
                                        address=address,
                                        init=tuple(init_bytecode)+tuple(ABI.make_function_arguments(*args)))
-
-        #FIXME different states "could"(VERY UNLIKELY) have different contracts 
-        # asociated with the same address
-        self.metadata[account.address] = SolidityMetadata(*compile_results)
 
         return account
 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2097,11 +2097,11 @@ class EVMWorld(Platform):
     def depth(self):
         return len(self._callstack)
 
-    def _new_address(self):
+    def new_address(self):
         ''' create a fresh 160bit address '''
         new_address = random.randint(100, pow(2, 160))
         if new_address in self._global_storage.keys():
-            return self._new_address()
+            return self.new_address()
         return new_address
 
     def execute(self):
@@ -2144,7 +2144,7 @@ class EVMWorld(Platform):
         storage = {} if storage is None else storage
 
         if address is None:
-            address = self._new_address()
+            address = self.new_address()
         assert address not in self.storage.keys(), 'The account already exists'
         self.storage[address] = {}
         self.storage[address]['nonce'] = 0L


### PR DESCRIPTION
Set Solitidty Metadata before EVMAccount constructor.
Make EVMAccount name solver lazy

This pull request fixes #674