### PR TITLE
Added support to analyze solidity source code with multiple contracts using the --contract command line option

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -64,7 +64,8 @@ def parse_arguments():
                          help='Show program version information')
     parser.add_argument('--txlimit', type=positive,
                         help='Maximum number of symbolic transactions to run (positive integer) (Ethereum only)')
-
+    parser.add_argument('--contract', type=str,
+                        help='Contract name to analyze in case of multiple ones (Ethereum only)')
 
     parsed = parser.parse_args(sys.argv[1:])
     if parsed.procs <= 0:
@@ -91,7 +92,7 @@ def ethereum_cli(args):
 
     logger.info("Beginning analysis")
 
-    m.multi_tx_analysis(args.argv[0], args.txlimit)
+    m.multi_tx_analysis(args.argv[0], args.contract, args.txlimit)
 
 def main():
     log.init_logging()

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -870,7 +870,7 @@ class ManticoreEVM(Manticore):
 
         return status
 
-    def multi_tx_analysis(self, solidity_filename, contract_name, tx_limit=None):
+    def multi_tx_analysis(self, solidity_filename, contract_name=None, tx_limit=None):
         with open(solidity_filename) as f:
             source_code = f.read()
 


### PR DESCRIPTION
To test, use multi.sol:

```
contract C1 { }
contract C2 { }
```

and the manticore cli:

```
$ manticore multi.sol --contract C1
2018-01-15 09:08:23,503: [17455] m.main:INFO: Beginning analysis
2018-01-15 09:08:23,523: [17455] m.ethereum:INFO: Starting symbolic transaction: 1
2018-01-15 09:08:23,654: [17455] m.ethereum:INFO: Generated testcase No. 0 - REVERT
2018-01-15 09:08:24,945: [17455] m.ethereum:INFO: Generated testcase No. 1 - REVERT
2018-01-15 09:08:27,154: [17455] m.ethereum:INFO: Finished symbolic transaction: 1 | Code Coverage: 100% | Terminated States: 2 | Alive States: 0
2018-01-15 09:08:27,170: [17455] m.ethereum:INFO: Results in /home/gustavo/projects/DevContest/mcore_QWzfbr
$ manticore multi.sol --contract C2
2018-01-15 09:08:30,541: [17566] m.main:INFO: Beginning analysis
2018-01-15 09:08:30,562: [17566] m.ethereum:INFO: Starting symbolic transaction: 1
2018-01-15 09:08:30,707: [17566] m.ethereum:INFO: Generated testcase No. 0 - REVERT
2018-01-15 09:08:31,774: [17566] m.ethereum:INFO: Generated testcase No. 1 - REVERT
2018-01-15 09:08:33,852: [17566] m.ethereum:INFO: Finished symbolic transaction: 1 | Code Coverage: 100% | Terminated States: 2 | Alive States: 0
2018-01-15 09:08:33,858: [17566] m.ethereum:INFO: Results in /home/gustavo/projects/DevContest/mcore_dfhEPI
```