### PR TITLE
Emit events for exception raising evm instructions

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1305,14 +1305,13 @@ class EVM(Eventful):
         self._publish('will_execute_instruction', self.pc, current)
         self._publish('will_evm_execute_instruction', current, arguments)
 
+        last_pc = self.pc
+        result = None
+
         def emit_did_execute_signals():
             self._publish('did_evm_execute_instruction', current, arguments, result)
             self._publish('did_execute_instruction', last_pc, self.pc, current)
 
-        last_pc = self.pc
-        result = None
-
-        #Execute
         try:
             result = implementation(*arguments)
             emit_did_execute_signals()

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2167,10 +2167,8 @@ class EVMWorld(Platform):
         try:
             self.current.execute()
         except EVMInstructionException as iex:
-            try:
-                handle_evm_instruction_exception(iex)
-            finally:
-                iex.on_handled()
+            iex.on_handled()
+            handle_evm_instruction_exception(iex)
         except EVMException as e:
             self.THROW()
         except Exception:

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2159,21 +2159,20 @@ class EVMWorld(Platform):
             if self.current is None:
                 raise TerminateState("Trying to execute an empty transaction", testcase=False)
             self.current.execute()
-        except EVMInstructionException as ex:
-            if isinstance(ex, Create):
-                self.CREATE(ex.value, ex.data)
-            elif isinstance(ex, Call):
-                self.CALL(ex.gas, ex.to, ex.value, ex.data)
-            elif isinstance(ex, Stop):
-                self.STOP()
-            elif isinstance(ex, Return):
-                self.RETURN(ex.data)
-            elif isinstance(ex, Revert):
-                self.REVERT(ex.data)
-            elif isinstance(ex, SelfDestruct):
-                self.SELFDESTRUCT(ex.to)
-            elif isinstance(ex, Sha3):
-                self.HASH(ex.data)
+        except Create as ex:
+            self.CREATE(ex.value, ex.data)
+        except Call as ex:
+            self.CALL(ex.gas, ex.to, ex.value, ex.data)
+        except Stop as ex:
+            self.STOP()
+        except Return as ex:
+            self.RETURN(ex.data)
+        except Revert as ex:
+            self.REVERT(ex.data)
+        except SelfDestruct as ex:
+            self.SELFDESTRUCT(ex.to)
+        except Sha3 as ex:
+            self.HASH(ex.data)
         except EVMException as e:
             self.THROW()
         except Exception:

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1328,7 +1328,7 @@ class EVM(Eventful):
             self.last_exception = e
 
             # Technically, this is not the right place to emit these events because the
-            # instruction hasn't execute yet; it executes in the EVM platform class (EVMWorld).
+            # instruction hasn't executed yet; it executes in the EVM platform class (EVMWorld).
             # However, when I tried that, in the event handlers, `state.platform.current`
             # ends up being None, which caused issues. So, as a pragmatic solution, we emit
             # the event before technically executing the instruction.

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1326,8 +1326,15 @@ class EVM(Eventful):
                                 policy=ex.policy)
         except EVMException as e:
             self.last_exception = e
+
+            # Technically, this is not the right place to emit these events because the
+            # instruction hasn't execute yet; it executes in the EVM platform class (EVMWorld).
+            # However, when I tried that, in the event handlers, `state.platform.current`
+            # ends up being None, which caused issues. So, as a pragmatic solution, we emit
+            # the event before technically executing the instruction.
             if isinstance(e, EVMInstructionException):
                 emit_did_execute_signals()
+
             raise
 
         #Check result (push)


### PR DESCRIPTION
Previously, `did_evm_execute_instruction` and other events did not fire for SELFDESTRUCT, RETURN, REVERT, etc, because these instructions raise exceptions as part of their implementation. They do now, which means our traces will be more complete, and detectors will be able to watch for these instructions also.

Fixes #690

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/722)
<!-- Reviewable:end -->
