### PR TITLE
Fix incorrect number of transaction in certain states

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -253,7 +253,7 @@ class Executor(Eventful):
         '''
         #save the state to secondary storage
         state_id = self._workspace.save_state(state)
-        self.put(state_id)
+        self._put(state_id)
         self._publish('did_enqueue_state', state_id, state)
         return state_id
 
@@ -304,7 +304,7 @@ class Executor(Eventful):
     ###############################################
     # Priority queue
     @sync
-    def put(self, state_id):
+    def _put(self, state_id):
         ''' Enqueue it for processing '''
         self._states.append(state_id)
         self._lock.notify_all()

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -997,7 +997,7 @@ class ManticoreEVM(Manticore):
         state.context['last_exception'] = e
         # TODO(mark): This will break if we ever change the message text. Use a less
         # brittle check.
-        if e.message not in {'REVERT', 'THROW', 'Not Enough Funds for transaction'}:
+        if e.message not in {'REVERT', 'THROW', 'TXERROR'}:
             # if not a revert we save the state for further transactioning
             state.context['processed'] = False
             if e.message == 'RETURN':
@@ -1111,7 +1111,7 @@ class ManticoreEVM(Manticore):
             summary.write("Last exception: %s\n" %state.context['last_exception'])
 
             address, offset = state.context['seth.trace'][-1]
-            
+
             #Last instruction
             metadata = self.get_metadata(blockchain.transactions[-1].address)
             if metadata is not None:

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -919,7 +919,7 @@ class ManticoreEVM(Manticore):
             assert len(self._executor.list()) == 0
 
             for state_id in context['_saved_states']:
-                self._executor.put(state_id)
+                self._executor.enqueue(state_id)
             context['_saved_states'] = []
 
         #A callback will use _pending_transaction and issue the transaction 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2117,8 +2117,6 @@ class EVMWorld(Platform):
     def execute(self):
         self._process_pending_transaction()
         try:
-            if self.current is None:
-                raise TerminateState("Trying to execute an empty transaction", testcase=False)
             self.current.execute()
         except Create as ex:
             self.CREATE(ex.value, ex.data)
@@ -2260,11 +2258,6 @@ class EVMWorld(Platform):
                 pass
 
     def _process_pending_transaction(self):
-        def err():
-            if self.depth == 0:
-                raise TerminateState("Not Enough Funds for transaction", testcase=True)
-
-
         if self._pending_transaction is None:
             return
         assert self.current is None or self.current.last_exception is not None
@@ -2312,6 +2305,7 @@ class EVMWorld(Platform):
             if is_human_tx: #human transaction
                 tx = Transaction(ty, address, origin, price, data, caller, value, 'TXERROR', None)
                 self._transactions.append(tx)
+                raise TerminateState('TXERROR')
             else:
                 self.current._push(0)
                 return

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -142,7 +142,7 @@ class Eventful(object):
 
     def forward_events_from(self, source, include_source=False):
         if not isinstance(source, Eventful):
-            raise TypeError
+            raise TypeError('{} is not Eventful'.format(source.__class__.__name__))
         source.forward_events_to(self, include_source=include_source)
 
     def forward_events_to(self, sink, include_source=False):


### PR DESCRIPTION
Manticore considers whether a tx tries to transmit more value than the sender's balance. If there is not, we should terminate the state, which is currently not done. Because it is not done, we end up with incorrect transactions for the state.

Fixes #720

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/724)
<!-- Reviewable:end -->
