### PR TITLE
Array value configurable. 8,16,32..256 bits (not prefixed to 8)

### DIFF
--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -208,13 +208,13 @@ class ConstraintSet(object):
 
     def new_array(self, index_bits=32, name='A', index_max=None, value_bits=8, taint=frozenset()):
         ''' Declares a free symbolic array of 8 bits long bitvectors in the constraint store.
-            :param index_bit_size: size in bits for the array indexes one of [32, 64]
+            :param index_bits: size in bits for the array indexes one of [32, 64]
+            :param value_bits: size in bits for the array values
             :param name: try to assign name to internal variable representation,
                          if not uniq a numeric nonce will be appended
             :param index_max: upper limit for indexes on ths array (#FIXME)
-            :return: a fresh BitVecVariable
+            :return: a fresh ArrayProxy
         '''
-        assert index_bits in (8, 16, 32, 64, 128, 256)
         name = self._get_new_name(name)
         return ArrayProxy(ArrayVariable(index_bits, index_max, value_bits, name, taint=taint))
 

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -206,7 +206,7 @@ class ConstraintSet(object):
         name = self._get_new_name(name)
         return BitVecVariable(size, name, taint=taint)
 
-    def new_array(self, index_bits=32, name='A', index_max=None, taint=frozenset()):
+    def new_array(self, index_bits=32, name='A', index_max=None, value_bits=8, taint=frozenset()):
         ''' Declares a free symbolic array of 8 bits long bitvectors in the constraint store.
             :param index_bit_size: size in bits for the array indexes one of [32, 64]
             :param name: try to assign name to internal variable representation,
@@ -216,6 +216,6 @@ class ConstraintSet(object):
         '''
         assert index_bits in (8, 16, 32, 64, 128, 256)
         name = self._get_new_name(name)
-        return ArrayProxy(ArrayVariable(index_bits, index_max, name, taint=taint))
+        return ArrayProxy(ArrayVariable(index_bits, index_max, value_bits, name, taint=taint))
 
 

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -110,7 +110,7 @@ class ConstraintSet(object):
 
         constraint_str = translator.pop()
         while constraint_str is not None:
-            if not constraint_str is 'true':
+            if constraint_str != 'true':
                 result += '(assert %s)\n' % constraint_str
             constraint_str = translator.pop()
 
@@ -181,7 +181,7 @@ class ConstraintSet(object):
             buf += d.declaration + '\n'
         for constraint in self.constraints:
             constraint_str = translate_to_smtlib(constraint, use_bindings=True)
-            if not constraint_str is 'true':
+            if constraint_str != 'true':
                 buf += '(assert %s)\n' % constraint_str
         return buf
 

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -170,7 +170,7 @@ class ConstraintSet(object):
 
         constraint_str = translator.pop()
         while constraint_str is not None:
-            if not constraint_str is 'true':
+            if constraint_str != 'true':
                 result += '(assert %s)\n' % constraint_str
             constraint_str = translator.pop()
 

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -561,7 +561,7 @@ class Array(Expression):
 
     def __len__(self):
         if self.index_max is None:
-            raise Exception()
+            raise Exception("Array max index not set")
         return self.index_max
 
     @property
@@ -643,7 +643,7 @@ class ArrayProxy(Array):
             super(ArrayProxy, self).__init__(array.index_bits, array.index_max, array.value_bits)
             self._array = array
             while not isinstance(array, ArrayVariable):
-                array=array.array
+                array = array.array
             self._name = array.name
             
             

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -181,7 +181,6 @@ class BoolITE(BoolOperation):
 class BitVec(Expression):
     ''' This adds a bitsize to the Expression class '''
     def __init__(self, size, *operands, **kwargs):
-        #assert size in (1, 8, 16, 32, 64, 128, 256)
         super(BitVec, self).__init__(*operands, **kwargs)
         self.size = size
 
@@ -553,6 +552,8 @@ class Array(Expression):
         return index
 
     def cast_value(self, value):
+        if isinstance(value, str) and len(value) == 1:
+            value = ord(value)
         if isinstance(value, (int, long)):
             return BitVecConstant(self.value_bits, value)
         assert isinstance(value, BitVec) and value.size == self.value_bits
@@ -729,7 +730,7 @@ class ArraySelect(BitVec, Operation):
     def __init__(self, array, index, *args, **kwargs):
         assert isinstance(array, Array)
         assert isinstance(index, BitVec) and index.size == array.index_bits
-        super(ArraySelect, self).__init__(8, array, index, *args, **kwargs)
+        super(ArraySelect, self).__init__(array.value_bits, array, index, *args, **kwargs)
 
     @property
     def array(self):

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -452,20 +452,6 @@ class Z3Solver(Solver):
             The current set of assertions must be sat.
             :param val: an expression or symbol '''
         if not issymbolic(expression):
-            if expression is None:
-                return
-            if isinstance(expression, str):
-                if len(expression) == 1:
-                    expression = ord(expression)
-                else:
-                    expression = map(ord, expression)  
-            if isinstance(expression, (list, tuple)):
-                if len(expression) == 0:
-                    return expression
-                arr = constraints.new_array(index_max=len(expression))
-                for i in range(len(expression)):
-                    arr[i] = expression[i]
-                return self.get_value(constraints, arr)
             return expression
         assert isinstance(expression, (Bool, BitVec, Array))
         with constraints as temp_cs:
@@ -477,7 +463,7 @@ class Z3Solver(Solver):
                 var = []
                 result = ''
                 for i in xrange(expression.index_max):
-                    subvar = temp_cs.new_bitvec(8)
+                    subvar = temp_cs.new_bitvec(expression.value_bits)
                     var.append(subvar)
                     temp_cs.add(subvar==expression[i])
 

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -69,6 +69,8 @@ class Visitor(object):
         :param use_fixed_point: if True, it runs _methods until a fixed point is found
         :type use_fixed_point: Bool
         '''
+
+        #Special case. Need to get the unsleeved version of the array
         if isinstance(node, ArrayProxy):
             node = node.array
 

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -69,6 +69,9 @@ class Visitor(object):
         :param use_fixed_point: if True, it runs _methods until a fixed point is found
         :type use_fixed_point: Bool
         '''
+        if isinstance(node, ArrayProxy):
+            node = node.array
+
         cache = self._cache
 
         visited = set()

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -202,7 +202,7 @@ class State(Eventful):
         '''
         label = options.get('label', 'buffer')
         taint = options.get('taint', frozenset())
-        expr = self._constraints.new_array(name=label, index_max=nbytes, taint=taint)
+        expr = self._constraints.new_array(name=label, index_max=nbytes, value_bits=8, taint=taint)
         self._input_symbols.append(expr)
 
         if options.get('cstring', False):

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1111,6 +1111,9 @@ class EVM(Eventful):
         self._constraints = constraints
         self.memory.constraints = constraints
 
+    @property
+    def gas(self):
+        return self._gas
 
     def __getstate__(self):
         state = super(EVM, self).__getstate__()

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1068,6 +1068,7 @@ class EVM(Eventful):
         :param bytecode: the byte array that is the machine code to be executed.
         :param header: the block header of the present block.
         :param depth: the depth of the present message-call or contract-creation (i.e. the number of CALLs or CREATEs being executed at present).
+        :param gas: gas budget for this transaction.
 
         '''
         super(EVM, self).__init__(**kwargs)
@@ -1084,7 +1085,6 @@ class EVM(Eventful):
         self.bytecode = code
         self.suicides = set()
         self.logs = []
-        self.gas=gas
         #FIXME parse decode and mark invalid instructions
         #self.invalid = set()
 
@@ -1098,7 +1098,7 @@ class EVM(Eventful):
         #Machine state
         self.pc = 0
         self.stack = []
-        self.gas = gas
+        self._gas = gas
         self.global_storage = global_storage
         self.allocated = 0
 
@@ -1114,7 +1114,6 @@ class EVM(Eventful):
 
     def __getstate__(self):
         state = super(EVM, self).__getstate__()
-        state['gas'] = self.gas
         state['memory'] = self.memory
         state['global_storage'] = self.global_storage
         state['constraints'] = self.constraints
@@ -1130,7 +1129,7 @@ class EVM(Eventful):
         state['header'] = self.header
         state['pc'] = self.pc
         state['stack'] = self.stack
-        state['gas'] = self.gas
+        state['gas'] = self._gas
         state['allocated'] = self.allocated
         state['suicides'] = self.suicides
         state['logs'] = self.logs
@@ -1138,7 +1137,7 @@ class EVM(Eventful):
         return state
 
     def __setstate__(self, state):
-        self.gas = state['gas']
+        self._gas = state['gas']
         self.memory = state['memory']
         self.logs = state['logs'] 
         self.global_storage = state['global_storage']
@@ -1155,7 +1154,6 @@ class EVM(Eventful):
         self.header = state['header']
         self.pc = state['pc']
         self.stack = state['stack']
-        self.gas = state['gas']
         self.allocated = state['allocated']
         self.suicides = state['suicides']
         super(EVM, self).__setstate__(state)
@@ -1254,9 +1252,9 @@ class EVM(Eventful):
 
     def _consume(self, fee):
         assert fee>=0
-        if self.gas < fee:
+        if self._gas < fee:
             raise NotEnoughGas()
-        self.gas -= fee
+        self._gas -= fee
 
     #Execute an instruction from current pc
     def execute(self):
@@ -1711,7 +1709,7 @@ class EVM(Eventful):
     def GAS(self):
         '''Get the amount of available gas, including the corresponding reduction the amount of available gas'''
         #fixme calculate gas consumption
-        return self.gas
+        return self._gas
 
     def JUMPDEST(self):
         '''Mark a valid destination for jumps'''

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2418,9 +2418,13 @@ class SLinux(Linux):
 
     def generate_workspace_files(self):
         def solve_to_fd(data, fd):
+            def make_chr(c):
+                if isinstance(c, int):
+                    return chr(c)
+                return c
             try:
                 for c in data:
-                    fd.write(chr(solver.get_value(self.constraints, c)))
+                    fd.write(make_chr(solver.get_value(self.constraints, c)))
             except SolverException:
                 fd.write('{SolverException}')
 

--- a/tests/test_smtlibv2.py
+++ b/tests/test_smtlibv2.py
@@ -77,34 +77,73 @@ class ExpressionTest(unittest.TestCase):
         key = cs.new_bitvec(32)
 
         #assert that the array is 'A' at key position
-        cs.add(array[key] == 'A')
+        cs.add(array[key] == ord('A'))
         #lets restrict key to be greater than 1000
         cs.add(key.ugt(1000))
 
         with cs as temp_cs:
             #1001 position of array can be 'A'
-            temp_cs.add(array[1001] == 'A')
+            temp_cs.add(array[1001] == ord('A'))
             self.assertTrue(self.solver.check(temp_cs))
 
         with cs as temp_cs:
             #1001 position of array can also be 'B'
-            temp_cs.add(array[1001] == 'B')
+            temp_cs.add(array[1001] == ord('B'))
             self.assertTrue(self.solver.check(temp_cs))
 
 
         with cs as temp_cs:
             #but if it is 'B' ...
-            temp_cs.add(array[1001] == 'B')
+            temp_cs.add(array[1001] == ord('B'))
             #then key can not be 1001
             temp_cs.add(key == 1001)
             self.assertFalse(self.solver.check(temp_cs))
 
         with cs as temp_cs:
             #If 1001 position is 'B' ...
-            temp_cs.add(array[1001] == 'B')
+            temp_cs.add(array[1001] == ord('B'))
             #then key can be 1000 for ex..
             temp_cs.add(key == 1002)
             self.assertTrue(self.solver.check(temp_cs))
+
+
+    def testBasicArray256(self):
+        cs =  ConstraintSet()
+        #make array of 32->8 bits
+        array = cs.new_array(32, value_bits=256)
+        #make free 32bit bitvector
+        key = cs.new_bitvec(32)
+
+        #assert that the array is 1234567890.. at key position
+        cs.add(array[key] == 11111111111111111111111111111111111111111111)
+        #lets restrict key to be greater than 1000
+        cs.add(key.ugt(1000))
+
+        with cs as temp_cs:
+            #1001 position of array can be 'A'
+            temp_cs.add(array[1001] == 11111111111111111111111111111111111111111111)
+            self.assertTrue(self.solver.check(temp_cs))
+
+        with cs as temp_cs:
+            #1001 position of array can also be 'B'
+            temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
+            self.assertTrue(self.solver.check(temp_cs))
+
+
+        with cs as temp_cs:
+            #but if it is 'B' ...
+            temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
+            #then key can not be 1001
+            temp_cs.add(key == 1001)
+            self.assertFalse(self.solver.check(temp_cs))
+
+        with cs as temp_cs:
+            #If 1001 position is 'B' ...
+            temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
+            #then key can be 1000 for ex..
+            temp_cs.add(key == 1002)
+            self.assertTrue(self.solver.check(temp_cs))
+
 
     def testBasicArrayStore(self):
         name = "bitarray"
@@ -115,29 +154,29 @@ class ExpressionTest(unittest.TestCase):
         key = cs.new_bitvec(32)
 
         #assert that the array is 'A' at key position
-        array = array.store(key, 'A')
+        array = array.store(key, ord('A'))
         #lets restrict key to be greater than 1000
         cs.add(key.ugt(1000))
 
         #1001 position of array can be 'A'
-        self.assertTrue(self.solver.can_be_true(cs, array.select(1001) == 'A'))
+        self.assertTrue(self.solver.can_be_true(cs, array.select(1001) == ord('A')))
 
         #1001 position of array can be 'B'
-        self.assertTrue(self.solver.can_be_true(cs, array.select(1001) == 'B'))
+        self.assertTrue(self.solver.can_be_true(cs, array.select(1001) == ord('B')))
 
         #name is correctly proxied
         self.assertEqual(array.name, name + "_1")
 
         with cs as temp_cs:
             #but if it is 'B' ...
-            temp_cs.add(array.select(1001) == 'B')
+            temp_cs.add(array.select(1001) == ord('B'))
             #then key can not be 1001
             temp_cs.add(key == 1001)
             self.assertFalse(self.solver.check(temp_cs))
 
         with cs as temp_cs:
             #If 1001 position is 'B' ...
-            temp_cs.add(array.select(1001) == 'B')
+            temp_cs.add(array.select(1001) == ord('B'))
             #then key can be 1000 for ex..
             temp_cs.add(key != 1002)
             self.assertTrue(self.solver.check(temp_cs))
@@ -152,7 +191,7 @@ class ExpressionTest(unittest.TestCase):
         key = cs.new_bitvec(32)
 
         #assert that the array is 'A' at key position
-        array = array.store(key, 'A')
+        array = array.store(key, ord('A'))
         #lets restrict key to be greater than 1000
         cs.add(key.ugt(1000))
         cs = pickle.loads(pickle.dumps(cs))
@@ -214,8 +253,8 @@ class ExpressionTest(unittest.TestCase):
         a = cs.new_bitvec(32, name='VAR')
         self.assertEqual(get_depth(a), 1)
         cond = Operators.AND(a < 200, a > 100)
-        arr[0]='a'
-        arr[1]='b'
+        arr[0]=ord('a')
+        arr[1]=ord('b')
 
 
 


### PR DESCRIPTION
Expression expanded to handle arrays to arbitrary sized values (not just 8 bits)
Previously Array represented smtlib arrays from Bitvec(?) to Bitvec(8). 
With this patch you can now have Arrays of any to any bitsize.  (usable for EVM storage for example)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/732)
<!-- Reviewable:end -->
