### PR TITLE
Fix evm state handling regression

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -253,7 +253,7 @@ class Executor(Eventful):
         '''
         #save the state to secondary storage
         state_id = self._workspace.save_state(state)
-        self._put(state_id)
+        self.put(state_id)
         self._publish('did_enqueue_state', state_id, state)
         return state_id
 
@@ -304,7 +304,7 @@ class Executor(Eventful):
     ###############################################
     # Priority queue
     @sync
-    def _put(self, state_id):
+    def put(self, state_id):
         ''' Enqueue it for processing '''
         self._states.append(state_id)
         self._lock.notify_all()

--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -15,6 +15,7 @@ from multiprocessing.managers import SyncManager
 
 from .smtlib import solver
 from .smtlib.solver import SolverException
+from .state import State
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +390,7 @@ class Workspace(object):
         :return: New state id
         :rtype: int
         """
+        assert isinstance(state, State)
         id_ = self._get_id()
         self._store.save_state(state, '{}{:08x}{}'.format(self._prefix, id_, self._suffix))
         return id_

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -922,7 +922,7 @@ class ManticoreEVM(Manticore):
             assert len(self._executor.list()) == 0
 
             for state_id in context['_saved_states']:
-                self._executor.enqueue(state_id)
+                self._executor.put(state_id)
             context['_saved_states'] = []
 
         #A callback will use _pending_transaction and issue the transaction 


### PR DESCRIPTION
#724 introduced a regression in handling of queue and states. It is caused by an incorrect assumption that Executor.put and Executor.enqueue are the same, I forgot to check that arguments both of those are supposed to take.

This quick fix reverts the breaking change, however it would be nice to refactor ManticoreEVM to not access `Executor._workspace`, which is a private member. Ideally `Executor` should offer external APIs for managing the state queue.

Fixes #735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/741)
<!-- Reviewable:end -->
