### PR TITLE
Speedup x86 execution by caching AMD64RegFile.all_registers

### DIFF
--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -450,9 +450,9 @@ class AMD64RegFile(RegisterFile):
         for name in ('AF', 'CF', 'DF', 'IF', 'OF', 'PF', 'SF', 'ZF'):
             self.write(name, False)
 
-        self._all_registers = tuple(self._table.keys()) + \
+        self._all_registers = tuple(self._table) + \
             ('FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'EFLAGS', 'RFLAGS') + \
-            tuple(self._aliases.keys())
+            tuple(self._aliases)
 
     @property
     def all_registers(self):

--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -450,10 +450,13 @@ class AMD64RegFile(RegisterFile):
         for name in ('AF', 'CF', 'DF', 'IF', 'OF', 'PF', 'SF', 'ZF'):
             self.write(name, False)
 
+        self._all_registers = tuple(self._table.keys()) + \
+            ('FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'EFLAGS', 'RFLAGS') + \
+            tuple(self._aliases.keys())
+
     @property
     def all_registers(self):
-        return tuple( self._table.keys() +
-                      ['FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7'] + ['EFLAGS', 'RFLAGS'] + self._aliases.keys() )
+        return self._all_registers
 
     @property
     def canonical_registers(self):


### PR DESCRIPTION
Hey,

This little change speeds up the execution of `manticore` on x86/x86-64 targets by around ~8% (a super clunky estimate, measured only on one simple example). 

This has been tested on a binary compiled as `gcc main.c` which source code looks like this:
```c
#include <stdio.h>

int main(int argc, char* argv[]) {
    if (argc < 2) {
        printf("Usage: %s <password>", argv[0]);
        return -1;
    }

    if ((argv[1][0] == 'a') && (argv[1][1] == 'b') && (argv[1][2] == 'c')) {
        puts("Good password!");
        return 0;
    }

    puts("Bad password!");
    return 1;
}
```

Then I have done the profiling as follows:
```
(angr) [dc@dc:aarch_playground]$ python -m cProfile -o profiler_out /home/dc/.virtualenvs/angr/bin/manticore ./a.out +++
2018-02-17 10:11:46,955: [13584] m.manticore:INFO: Loading program ./a.out
2018-02-17 10:13:55,767: [13584] m.manticore:INFO: Generated testcase No. 0 - Program finished with exit status: 1
2018-02-17 10:14:45,397: [13584] m.manticore:INFO: Generated testcase No. 1 - Program finished with exit status: 1
2018-02-17 10:15:34,757: [13584] m.manticore:INFO: Generated testcase No. 2 - Program finished with exit status: 0
2018-02-17 10:16:24,435: [13584] m.manticore:INFO: Generated testcase No. 3 - Program finished with exit status: 1
2018-02-17 10:16:24,440: [13584] m.manticore:INFO: Results in /home/dc/aarch_playground/mcore_yhkEXa
2018-02-17 10:16:24,440: [13584] m.manticore:INFO: Total time: 276.342200994


(angr) [dc@dc:aarch_playground]$ python -m cProfile -o profiler_out_before_change /home/dc/.virtualenvs/angr/bin/manticore ./a.out +++
2018-02-17 10:17:15,570: [15553] m.manticore:INFO: Loading program ./a.out
2018-02-17 10:19:32,604: [15553] m.manticore:INFO: Generated testcase No. 0 - Program finished with exit status: 1
2018-02-17 10:20:26,227: [15553] m.manticore:INFO: Generated testcase No. 1 - Program finished with exit status: 1
2018-02-17 10:21:19,933: [15553] m.manticore:INFO: Generated testcase No. 2 - Program finished with exit status: 0
2018-02-17 10:22:13,779: [15553] m.manticore:INFO: Generated testcase No. 3 - Program finished with exit status: 1
2018-02-17 10:22:13,790: [15553] m.manticore:INFO: Results in /home/dc/aarch_playground/mcore_zJm_wm
2018-02-17 10:22:13,790: [15553] m.manticore:INFO: Total time: 297.102720976
```

The generated profiles can be then analyzed e.g. in IPython:

Before the proposed change:
```
In [1]: import pstats

In [2]: s = pstats.Stats('./profiler_out_before_change')

In [3]: s.sort_stats('cumulative').print_stats()
Sat Feb 17 10:22:13 2018    ./profiler_out_before_change

         599298498 function calls (553404479 primitive calls) in 298.484 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001  298.485  298.485 /home/dc/.virtualenvs/angr/bin/manticore:3(<module>)
        1    0.000    0.000  298.238  298.238 /home/dc/Projects/manticore/manticore/__main__.py:97(main)
        1    0.000    0.000  297.108  297.108 /home/dc/Projects/manticore/manticore/manticore.py:613(run)
        1    0.002    0.002  297.094  297.094 /home/dc/Projects/manticore/manticore/manticore.py:382(_start_workers)
        1    0.476    0.476  297.093  297.093 /home/dc/Projects/manticore/manticore/core/executor.py:413(run)
   338291    0.672    0.000  276.786    0.001 /home/dc/Projects/manticore/manticore/core/state.py:124(execute)
   338291    0.743    0.000  275.954    0.001 /home/dc/Projects/manticore/manticore/platforms/linux.py:2117(execute)
   338291    4.912    0.000  274.885    0.001 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:796(execute)
11345063/11344735    8.999    0.000  167.748    0.000 /home/dc/Projects/manticore/manticore/utils/event.py:115(_publish)
56656157/11344735   67.622    0.000  139.415    0.000 /home/dc/Projects/manticore/manticore/utils/event.py:121(_publish_impl)
  3224447    4.023    0.000  124.504    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:526(__getattr__)
   337698    1.297    0.000  123.021    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:917(new_method)
  3702279    4.899    0.000  116.336    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:512(read_register)
  1851200    2.581    0.000   54.587    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:537(__setattr__)
  1357591    1.921    0.000   50.550    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:499(write_register)
 56656157   29.140    0.000   37.446    0.000 /usr/lib64/python2.7/weakref.py:407(items)
   441990    0.876    0.000   30.028    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:646(read)
  5075585    9.870    0.000   28.530    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:462(__contains__)
 56656173   20.402    0.000   25.515    0.000 /home/dc/Projects/manticore/manticore/utils/event.py:96(_get_signal_bucket)
   338273    0.887    0.000   25.246    0.000 /home/dc/Projects/manticore/manticore/core/cpu/abstractcpu.py:841(_publish_instruction_as_executed)
 11345063   14.141    0.000   19.335    0.000 /home/dc/Projects/manticore/manticore/utils/event.py:101(_check_event)
    73057    0.083    0.000   18.980    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:2508(MOV)
  5075585   15.009    0.000   18.660    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:453(all_registers)
    44423    0.042    0.000   17.312    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:1192(ADD)
```

The most interesting spots are probably the one where `tottime` is high ([`tottime` is the total time spent in the function alone. `cumtime` is the total time spent in the function plus all functions that this function called.](https://stackoverflow.com/questions/40404007/what-is-the-difference-between-tottime-and-cumtime-in-a-python-script-profiled-w)). Here for example, we spent 15 seconds (!) on the `all_registers` property:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  5075585   15.009    0.000   18.660    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:453(all_registers)
```

After this change, we spent there just 0.8s in total:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  5075585    0.835    0.000    0.835    0.000 /home/dc/Projects/manticore/manticore/core/cpu/x86.py:457(all_registers)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/755)
<!-- Reviewable:end -->
