### PR TITLE
Let the Python interpreter be specified externally

### DIFF
--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -1,6 +1,7 @@
 CC=gcc
 CFLAGS=-O3 -static
 NOSTDLIBFLAGS=-fno-builtin -static -nostdlib -fomit-frame-pointer
+PYTHON=python
 
 EXAMPLES=basic sindex  strncmp  arguments ibranch sendmail crackme indexhell  helloworld simple_copy simpleassert
 OTHER_EXAMPLES=nostdlib
@@ -29,5 +30,5 @@ simpleassert: simpleassert.c
 
 # crackme needs to be generated
 crackme.c: crackme.py
-	python crackme.py > $@
+	$(PYTHON) crackme.py > $@
 


### PR DESCRIPTION
This is a trivial change to help build the "linux" example without having to modify the Makefile. It is necessary if the Python interpreter has a different name (or place) than simply `python`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/774)
<!-- Reviewable:end -->
