### PR TITLE
Add assertion msg when target file is not present

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -168,10 +168,13 @@ class Manticore(Eventful):
         self.forward_events_from(self._executor)
 
         if isinstance(path_or_state, str):
-            assert os.path.isfile(path_or_state)
+            if not os.path.isfile(path_or_state):
+                raise Exception('{} is not an existing regular file'.format(path_or_state))
             self._initial_state = make_initial_state(path_or_state, argv=argv, **kwargs)
         elif isinstance(path_or_state, State):
             self._initial_state = path_or_state
+        else:
+            raise TypeError('path_or_state must be either a str or State, not {}'.format(type(path_or_state).__name__))
 
         if not isinstance(self._initial_state, State):
             raise TypeError("Manticore must be intialized with either a State or a path to a binary")


### PR DESCRIPTION
Its just better to have a clear message intead of pure `AssertionError` with code:
```
mant(angr) [dc@dc:~]$ manticore asd
Traceback (most recent call last):
  File "/home/dc/.virtualenvs/angr/bin/manticore", line 11, in <module>
    load_entry_point('manticore', 'console_scripts', 'manticore')()
  File "/home/dc/Projects/manticore/manticore/__main__.py", line 110, in main
    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm)
  File "/home/dc/Projects/manticore/manticore/manticore.py", line 171, in __init__
    assert os.path.isfile(path_or_state), "The file or state %s doesn't exist" % path_or_state
AssertionError: The file or state asd doesn't exist
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/778)
<!-- Reviewable:end -->
