### PR TITLE
Raises exception for contract with a function without code. Issue #789

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -616,6 +616,10 @@ class ManticoreEVM(Manticore):
 
             assert(name is not None)
             name = name.split(':')[1]
+
+            if contract['bin'] == '':
+                raise Exception('Solidity failed to compile your contract.')
+                
             bytecode = contract['bin'].decode('hex')
             srcmap = contract['srcmap'].split(';')
             srcmap_runtime = contract['srcmap-runtime'].split(';')


### PR DESCRIPTION
contract['bin'] contains the bytecode for Ethereum contract. Solidity returns an empty string if it encounters a function without code.

If the contract is 
```
contract C {
	function f();
}
``` 
Solidity returns a '' in the contract['bin'] field. 

If the contract is 
```
contract C {
	function f() {
        }
}
``` 
Solidity returns bytecode in the contract['bin'] field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/797)
<!-- Reviewable:end -->
