### PR TITLE
Fix off by 1 error in codecopy

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1660,7 +1660,7 @@ class EVM(Eventful):
         self._consume(GCOPY * ceil32(size) // 32)
 
         for i in range(size):
-            if (code_offset + i >= len(self.bytecode)):
+            if code_offset + i >= len(self.bytecode):
                 self._store(mem_offset + i, 0)
             else:
                 self._store(mem_offset + i, Operators.ORD(self.bytecode[code_offset + i]))

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1660,7 +1660,7 @@ class EVM(Eventful):
         self._consume(GCOPY * ceil32(size) // 32)
 
         for i in range(size):
-            if (code_offset + i > len(self.bytecode)):
+            if (code_offset + i >= len(self.bytecode)):
                 self._store(mem_offset + i, 0)
             else:
                 self._store(mem_offset + i, Operators.ORD(self.bytecode[code_offset + i]))

--- a/tests/binaries/780.sol
+++ b/tests/binaries/780.sol
@@ -1,0 +1,5 @@
+contract C {
+    function C(bool x) {
+        return;
+    }
+}

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -128,7 +128,7 @@ class IntegrationTest(unittest.TestCase):
         self.assertTrue(len(actual) > 100 )
 
     def test_eth_regressions(self):
-        contracts = [676, 678, 701, 714, 735, 760]
+        contracts = [676, 678, 701, 714, 735, 760, 780]
         for contract in contracts:
             self._simple_cli_run('{}.sol'.format(contract))
 


### PR DESCRIPTION
Fixes #780 
Fixes #718
Off by one error in the code that checks if we are doing an out of bounds read. Previously, this code fell through to the `else` where it IndexErrored when it did a real out of bounds read on the underlying self.bytecode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/812)
<!-- Reviewable:end -->
