### PR TITLE
evm: add per state trace file

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -129,9 +129,8 @@ class UninitializedStorage(Detector):
         state.context.setdefault('seth.detectors.initialized_storage', set()).add(offset)
 
 
-def calculate_coverage(code, seen):
-    ''' Calculates what percentage of code has been seen '''
-    runtime_bytecode = code
+def calculate_coverage(runtime_bytecode, seen):
+    ''' Calculates what percentage of runtime_bytecode has been seen '''
     end = None
     if ''.join(runtime_bytecode[-44: -34]) == '\x00\xa1\x65\x62\x7a\x7a\x72\x30\x58\x20' \
             and ''.join(runtime_bytecode[-2:]) == '\x00\x29':

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1272,6 +1272,12 @@ class ManticoreEVM(Manticore):
                 logger.debug("Using iterpickle to dump state")
                 statef.write(iterpickle.dumps(state, 2))
 
+        with testcase.open_stream('trace') as f:
+            for contract, pc in state.context['seth.trace']:
+                if pc == 0:
+                    f.write('---\n')
+                ln = '0x{:x} 0x{:x}\n'.format(contract, pc)
+                f.write(ln)
     def finalize(self):
         # move runnign states to final states list
         # and generate a testcase for each

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1276,8 +1276,9 @@ class ManticoreEVM(Manticore):
             for contract, pc in state.context['seth.trace']:
                 if pc == 0:
                     f.write('---\n')
-                ln = '0x{:x} 0x{:x}\n'.format(contract, pc)
+                ln = '0x{:x}:0x{:x}\n'.format(contract, pc)
                 f.write(ln)
+
     def finalize(self):
         # move runnign states to final states list
         # and generate a testcase for each

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1091,6 +1091,8 @@ class ManticoreEVM(Manticore):
             coverage.add((state.platform.current.address, state.platform.current.pc))
 
     def _did_execute_instruction_callback(self, state, prev_pc, pc, instruction):
+        # TODO(mark): here and above, we need a cleaner way to determine, from this class,
+        # whether the EVM cpu is executing init or runtime bytecode
         if 'Call' in str(type(state.platform.current.last_exception)):
             trace_context_name = 'seth.rt.trace'
         else:

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1181,7 +1181,7 @@ class ManticoreEVM(Manticore):
                         is_something_symbolic = is_something_symbolic or is_storage_symbolic
 
                 runtime_code = blockchain.get_code(account_address)
-                if len(runtime_code):
+                if runtime_code:
                     summary.write("Code:\n")
                     fcode = StringIO.StringIO(runtime_code)
                     for chunk in iter(lambda: fcode.read(32), b''):


### PR DESCRIPTION
previously, we would report the 'visited.txt' which is the complete coverage that all states achieved, but it's often desirable to see what trace a particular state took. this implements some changes to the workspace files. we now emit a `.init.trace` and `.rt.trace` for the init and runtime traces for the state.

open to aesthetic suggestions for the divider. the '---' helps separate the individual traces of the various tranasactions within the file.

the colon delimiter was specifically chosen as it is ethersplay compatible https://github.com/trailofbits/ethersplay/blob/8c8934a03b4dc50ec6145573f7c35583d1213918/ethersplay/coverage.py#L17

this pr was expanded to also correct bugs in the trace recording (it was missing the last instruction of a trace (return/stop/revert)), and adds a test to ensure the trace files include those last instructions


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/817)
<!-- Reviewable:end -->
