### PR TITLE
Added --txaccount parameter to control the caller of the symbolic exploration of smart contracts

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -64,6 +64,10 @@ def parse_arguments():
                         help='Show program version information')
     parser.add_argument('--txlimit', type=positive,
                         help='Maximum number of symbolic transactions to run (positive integer) (Ethereum only)')
+
+    parser.add_argument('--txaccount', type=str, default="attacker",
+                        help='Account used as caller in the symbolic transactions, either "attacker" or "owner" (Ethereum only)')
+
     parser.add_argument('--contract', type=str,
                         help='Contract name to analyze in case of multiple ones (Ethereum only)')
 
@@ -92,7 +96,7 @@ def ethereum_cli(args):
 
     logger.info("Beginning analysis")
 
-    m.multi_tx_analysis(args.argv[0], args.contract, args.txlimit)
+    m.multi_tx_analysis(args.argv[0], args.contract, args.txlimit, args.txaccount)
 
 
 def main():

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -920,18 +920,25 @@ class ManticoreEVM(Manticore):
 
         return status
 
-    def multi_tx_analysis(self, solidity_filename, contract_name=None, tx_limit=None):
+    def multi_tx_analysis(self, solidity_filename, contract_name=None, tx_limit=None, tx_account="attacker"):
         with open(solidity_filename) as f:
             source_code = f.read()
 
-        user_account = self.create_account(balance=1000)
-        contract_account = self.solidity_create_contract(source_code, contract_name=contract_name, owner=user_account)
+        owner_account = self.create_account(balance=1000)
+        contract_account = self.solidity_create_contract(source_code, contract_name=contract_name, owner=owner_account)
         attacker_account = self.create_account(balance=1000)
+
+        if tx_account == "attacker":
+            tx_account = attacker_account
+        elif tx_account == "owner":
+            tx_account = owner_account
+        else:
+            raise Exception('The account to perform the symbolic exploration of the contract should be either "attacker" or "owner"')
 
         def run_symbolic_tx():
             symbolic_data = self.make_symbolic_buffer(320)
             symbolic_value = self.make_symbolic_value()
-            self.transaction(caller=attacker_account,
+            self.transaction(caller=tx_account,
                              address=contract_account,
                              data=symbolic_data,
                              value=symbolic_value)

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -933,7 +933,7 @@ class ManticoreEVM(Manticore):
         elif tx_account == "owner":
             tx_account = owner_account
         else:
-            raise Exception('The account to perform the symbolic exploration of the contract should be either "attacker" or "owner"')
+            raise EthereumError('The account to perform the symbolic exploration of the contract should be either "attacker" or "owner"')
 
         def run_symbolic_tx():
             symbolic_data = self.make_symbolic_buffer(320)


### PR DESCRIPTION
This addition will enable casual users to control how to test contracts using the manticore cli.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/819)
<!-- Reviewable:end -->
