### PR TITLE
port ethereum tests to individual files (issue #809)

### DIFF
--- a/tests/binaries/799.sol
+++ b/tests/binaries/799.sol
@@ -1,0 +1,2 @@
+contract X { function X(address x) {} }
+contract C { function C(address x) { new X(x); } }

--- a/tests/binaries/807.sol
+++ b/tests/binaries/807.sol
@@ -1,0 +1,11 @@
+contract X {
+  mapping(address => uint) private balance;
+  function f(address z) returns (uint) { return balance[z]; }
+}
+contract C {
+  X y;
+  function C() {
+    y = new X();
+    uint z = y.f(0);
+  }
+}

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -31,7 +31,7 @@ class IntegrationTest(unittest.TestCase):
 
         return set(vitems)
 
-    def _simple_cli_run(self, filename):
+    def _simple_cli_run(self, filename, contract=None):
         """
         Simply run the Manticore command line with `filename`
         :param filename: Name of file inside the `tests/binaries` directory
@@ -39,7 +39,14 @@ class IntegrationTest(unittest.TestCase):
         """
         dirname = os.path.dirname(__file__)
         filename = '{}/binaries/{}'.format(dirname, filename)
-        subprocess.check_call(['python', '-m', 'manticore', filename], stdout=subprocess.PIPE)
+        command = ['python', '-m', 'manticore']
+
+        if contract:
+            command.append('--contract')
+            command.append(contract)
+        command.append(filename)
+
+        subprocess.check_call(command, stdout=subprocess.PIPE)
 
     def _runWithTimeout(self, procargs, logfile, timeout=1200):
 
@@ -128,9 +135,22 @@ class IntegrationTest(unittest.TestCase):
         self.assertTrue(len(actual) > 100 )
 
     def test_eth_regressions(self):
-        contracts = [676, 678, 701, 714, 735, 760, 780, 795]
-        for contract in contracts:
-            self._simple_cli_run('{}.sol'.format(contract))
+        issues = [
+            {'number': 676, 'contract': None},
+            {'number': 678, 'contract': None},
+            {'number': 701, 'contract': None},
+            {'number': 714, 'contract': None},
+            {'number': 735, 'contract': None},
+            {'number': 760, 'contract': None},
+            {'number': 780, 'contract': None},
+            {'number': 795, 'contract': None},
+            {'number': 799, 'contract': 'C'},
+            {'number': 807, 'contract': 'C'},
+        ]
+
+        for issue in issues:
+            self._simple_cli_run('{}.sol'.format(issue['number']),
+                                 contract=issue['contract'])
 
     def test_eth_705(self):
         # This test needs to run inside tests/binaries because the contract imports a file

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -117,39 +117,6 @@ class EthTests(unittest.TestCase):
         with self.assertRaises(NoAliveStates):
             contract_account.f(m.SValue)  # no alive states, but try to run a tx anyway
 
-    def test_can_create(self):
-        mevm = ManticoreEVM()
-        source_code = """
-        contract X { function X(address x) {} }
-        contract C { function C(address x) { new X(x); }
-        }
-        """
-        # Make sure that we can can call CREATE without raising an exception
-        owner = mevm.create_account(balance=1000)
-        x = mevm.create_account(balance=0)
-        contract_account = mevm.solidity_create_contract(source_code,
-                contract_name="C", owner=owner, args=[x])
-
-    def test_writebuffer_doesnt_raise(self):
-        mevm = ManticoreEVM()
-        source_code = """
-	contract X {
-	    mapping(address => uint) private balance;
-	    function f(address z) returns (uint) { return balance[z]; }
-	}
-	contract C {
-	  X y;
-	  function C() {
-	    y = new X();
-	    uint z = y.f(0);
-	  }
-	}"""
-        # Make sure that write_buffer (used by RETURN) succeeds without errors
-        owner = mevm.create_account(balance=1000)
-        x = mevm.create_account(balance=0)
-        contract_account = mevm.solidity_create_contract(source_code,
-                contract_name="C", owner=owner, args=[x])
-
 
 class EthHelpers(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Hi! I am new to the codebase, and this is my first PR.

My proposed change removes two tests that use inline contracts from `tests/test_eth.py`, and rolls them into the `test_eth_regressions()` method in `tests/test_binaries.py`.

I added a `contract` keyword argument to the `_simple_cli_run()` method, so that `.sol` files with multiple contracts can be run.

I believe this fixes [issue 809](https://github.com/trailofbits/manticore/issues/809). Please let me know if there is more to be done, or if my PR should be improved, for that issue to be satisfied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/820)
<!-- Reviewable:end -->
