### PR TITLE
Fix duplicated armv7 test name

### DIFF
--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -20,7 +20,7 @@ from manticore.core.cpu.x86 import I386Cpu, AMD64Cpu, I386LinuxSyscallAbi, I386S
 from manticore.core.memory import SMemory32, Memory32, SMemory64
 from manticore.core.smtlib import ConstraintSet, Operators
 
-class ABITests(unittest.TestCase):
+class ABITest(unittest.TestCase):
     _multiprocess_can_split_ = True
     def setUp(self):
         mem32 = SMemory32(ConstraintSet())

--- a/tests/test_armv7_bitwise.py
+++ b/tests/test_armv7_bitwise.py
@@ -3,7 +3,7 @@ import unittest
 from manticore.core.cpu import bitwise
 
 
-class Armv7RF(unittest.TestCase):
+class BitwiseTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def test_mask(self):

--- a/tests/test_armv7rf.py
+++ b/tests/test_armv7rf.py
@@ -1,9 +1,7 @@
 import unittest
 
 from manticore.core.cpu.arm import Armv7RegisterFile as RF
-from manticore.core.cpu.arm import *
 
-from capstone.arm import *
 
 class Armv7RF(unittest.TestCase):
     _multiprocess_can_split_ = True
@@ -37,7 +35,7 @@ class Armv7RF(unittest.TestCase):
 
     def test_flag_wr_aspr(self):
         self.r.write('APSR', 0xffffffff)
-        self.assertEqual(self.r.read('APSR'), 0xf0000000) #4 more significant bits used
+        self.assertEqual(self.r.read('APSR'), 0xf0000000)  # 4 more significant bits used
         self.assertEqual(self.r.read('APSR_V'), True)
         self.assertEqual(self.r.read('APSR_C'), True)
         self.assertEqual(self.r.read('APSR_Z'), True)
@@ -56,9 +54,10 @@ class Armv7RF(unittest.TestCase):
         self.assertEqual(self.r.read('APSR'), 0x00000000)
 
     def test_register_independence_wr(self):
-        regs = ( 'R0', 'R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8',
-                          'R9', 'R10', 'R11', 'R12', 'R13', 'R14', 'R15' )
-        aliases = {'SB':'R9', 'SL':'R10', 'FP':'R11', 'IP': 'R12', 'STACK': 'R13', 'SP': 'R13', 'LR': 'R14', 'PC': 'R15' }
+        regs = ('R0', 'R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8',
+                'R9', 'R10', 'R11', 'R12', 'R13', 'R14', 'R15')
+        aliases = {'SB': 'R9', 'SL': 'R10', 'FP': 'R11', 'IP': 'R12', 'STACK': 'R13', 'SP': 'R13', 'LR': 'R14',
+                   'PC': 'R15'}
 
         for j in xrange(16):
             for i in xrange(16):
@@ -66,12 +65,11 @@ class Armv7RF(unittest.TestCase):
                     self.r.write(regs[i], 0x41424344)
                 else:
                     self.r.write(regs[i], 0)
-            for a,b in aliases.items():
-                    self.assertEqual(self.r.read(a), self.r.read(b))
+            for a, b in aliases.items():
+                self.assertEqual(self.r.read(a), self.r.read(b))
 
             for i in xrange(16):
                 if i == j:
-                    self.assertEqual(self.r.read(regs[i]), 0x41424344 )
+                    self.assertEqual(self.r.read(regs[i]), 0x41424344)
                 else:
-                    self.assertEqual(self.r.read(regs[i]), 0x00000000 )
-
+                    self.assertEqual(self.r.read(regs[i]), 0x00000000)

--- a/tests/test_armv7rf.py
+++ b/tests/test_armv7rf.py
@@ -35,7 +35,7 @@ class Armv7RF(unittest.TestCase):
             nonexistant_reg = "Pc"
             self.r.read(nonexistant_reg)
 
-    def test_flag_wr(self):
+    def test_flag_wr_aspr(self):
         self.r.write('APSR', 0xffffffff)
         self.assertEqual(self.r.read('APSR'), 0xf0000000) #4 more significant bits used
         self.assertEqual(self.r.read('APSR_V'), True)

--- a/tests/test_armv7rf.py
+++ b/tests/test_armv7rf.py
@@ -3,7 +3,7 @@ import unittest
 from manticore.core.cpu.arm import Armv7RegisterFile as RF
 
 
-class Armv7RF(unittest.TestCase):
+class Armv7RFTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -12,7 +12,7 @@ import time
 from manticore import Manticore, issymbolic
 from manticore.core.smtlib import BitVecVariable
 
-class ManticoreDriver(unittest.TestCase):
+class ManticoreDriverTest(unittest.TestCase):
     _multiprocess_can_split_ = True
     def setUp(self):
         # Create a temporary directory

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -31,7 +31,7 @@ class EthDetectorsIntegrationTest(unittest.TestCase):
         self.assertIn('overflow at MUL', all_findings)
 
 
-class EthDetectors(unittest.TestCase):
+class EthDetectorsTest(unittest.TestCase):
     def setUp(self):
         self.io = IntegerOverflow()
         self.state = self.make_mock_evm_state()
@@ -165,7 +165,7 @@ class EthTests(unittest.TestCase):
             contract_account.f(m.SValue)  # no alive states, but try to run a tx anyway
 
 
-class EthHelpers(unittest.TestCase):
+class EthHelpersTest(unittest.TestCase):
     def setUp(self):
         self.bv = BitVec(256)
 


### PR DESCRIPTION
The `Armv7RF` class has 8 tests while only 7 were launched during test runs.

The problem was that we had two tests with the same name: `test_flag_wr`.
The first one can be found few lines above the second https://github.com/trailofbits/manticore/compare/master...disconnect3d:fix-duplicated-armv7-test-name?expand=1#diff-a4f83ac12d210376031ccbf8e84c0294R23

I have also refactored the file in 2nd commit (and removed unused imports).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/833)
<!-- Reviewable:end -->
