### PR TITLE
Explicitly override __hash__ to use object.__hash__

### DIFF
--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -111,6 +111,9 @@ class Bool(Expression):
     def __eq__(self, other):
         return BoolEq(self, self.cast(other))
 
+    def __hash__(self):
+        return object.__hash__(self)
+
     def __ne__(self, other):
         return BoolNot(self == self.cast(other))
 
@@ -336,6 +339,9 @@ class BitVec(Expression):
 
     def __eq__(self, other):
         return Equal(self, self.cast(other))
+
+    def __hash__(self):
+        return object.__hash__(self)
 
     def __ne__(self, other):
         return BoolNot(Equal(self, self.cast(other)))


### PR DESCRIPTION
This fixes one of the issues that is causing test_armv7cpu.py to fail when tested under python3.5

In python3 there are changes to how you are supposed to handle
overrides of __eq__, as it relates to __hash__
(http://python3porting.com/preparing.html?highlight=hash#implementing-hash)

In python2 we changed __eq__, but did nothing for __hash__, so __hash__
kept using the default one provided by object. In python3 it automatically
sets __hash__ to None, so we need to explicitly emulate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/835)
<!-- Reviewable:end -->
