### PR TITLE
Update CALLDATACOPY semantics

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1645,6 +1645,10 @@ class EVM(Eventful):
         if issymbolic(size):
             raise ConcretizeStack(3, policy='ALL')
 
+        if not issymbolic(data_offset):
+            data_offset = min(data_offset, len(self.data))
+            size = min(len(self.data) - data_offset, size)
+
         for i in range(size):
             c = Operators.ITEBV(8, data_offset + i < len(self.data), Operators.ORD(self.data[data_offset + i]), 0)
             self._store(mem_offset + i, c)


### PR DESCRIPTION
Currently, `CALLDATACOPY` reads `offset` and `size` from the stack and tries to copy data using those offsets. In the case of symbolic `data_offset`, it is correctly constrained in the implementation before attempting to copy data. However, in the concrete case, there's nothing to set bounds on `[data_offset, data_offset+size]` causing an indexing exception in case of out-of-bounds index.

This PR makes sure to limit copy offsets to valid ranges. This is exactly how the official `go-ethereum` implementation handles it.[1][2]

It might make sense to create a similar helper and use it wherever we need to index into data.

[1] calldatacopy implementation: https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L447
[2] the getDataBig helper: https://github.com/ethereum/go-ethereum/blob/master/core/vm/common.go#L49