### PR TITLE
Added KeyError Exception for offsets not in srcmap. Issue #832

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -230,7 +230,10 @@ class SolidityMetadata(object):
         else:
             srcmap = self.srcmap
 
-        beg, size, _, _ = srcmap[asm_offset]
+        try:
+            beg, size, _, _ = srcmap[asm_offset]
+        except KeyError:
+            return ''
 
         output = ''
         nl = self.source_code.count('\n')


### PR DESCRIPTION
If **asm_offset** is not present in the srcmap, a KeyError is raised. The KeyError is caught and an empty string is returned.

If **asm_offset** is present in the srcmap, the appropriate source code is written to summary as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/839)
<!-- Reviewable:end -->
