### PR TITLE
Remove assertion on brk()

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1310,7 +1310,6 @@ class Linux(Platform):
                     - "Error in brk!" if there is any error allocating the memory
         '''
         if brk != 0 and brk != self.elf_brk:
-            assert brk > self.elf_brk
             mem = self.current.memory
             size = brk - self.elf_brk
             perms = mem.perms(self.elf_brk - 1)


### PR DESCRIPTION
Manticore assumed that new calls to brk(2) were always increasing the
size of the data segment. This is not always true, since programs may
decide to reduce it as well.

Tested with a static Linux/i386 program on macOS/amd64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/860)
<!-- Reviewable:end -->
