### PR TITLE
Add dedicated files for ARGV/ENVP in report

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -388,6 +388,8 @@ class Linux(Platform):
         # Many programs to support SLinux
         self.programs = program
         self.disasm = disasm
+        self.envp = envp
+        self.argv = argv
 
         # dict of [int -> (int, int)] where tuple is (soft, hard) limits
         self._rlimits = {
@@ -513,6 +515,8 @@ class Linux(Platform):
         state['twait'] = self.twait
         state['timers'] = self.timers
         state['syscall_trace'] = self.syscall_trace
+        state['argv'] = self.argv
+        state['envp'] = self.envp
         state['base'] = self.base
         state['elf_bss'] = self.elf_bss
         state['end_code'] = self.end_code
@@ -565,6 +569,8 @@ class Linux(Platform):
         self.clocks = state['clocks']
 
         self.syscall_trace = state['syscall_trace']
+        self.argv = state['argv']
+        self.envp = state['envp']
         self.base = state['base']
         self.elf_bss = state['elf_bss']
         self.end_code = state['end_code']
@@ -826,7 +832,10 @@ class Linux(Platform):
                 continue
             interpreter_filename = elf_segment.data()[:-1]
             logger.info('Interpreter filename: %s', interpreter_filename)
-            interpreter = ELFFile(file(interpreter_filename))
+            try:
+                interpreter = ELFFile(file(interpreter_filename))
+            except:
+                pass
             break
         if interpreter is not None:
             assert interpreter.get_machine_arch() == elf.get_machine_arch()
@@ -2608,6 +2617,8 @@ class SLinux(Linux):
         inn = StringIO.StringIO()
         err = StringIO.StringIO()
         net = StringIO.StringIO()
+        argIO = StringIO.StringIO()
+        envIO = StringIO.StringIO()
 
         for name, fd, data in self.syscall_trace:
             if name in ('_transmit', '_write'):
@@ -2620,8 +2631,18 @@ class SLinux(Linux):
             if name in ('_receive', '_read') and fd == 0:
                 solve_to_fd(data, inn)
 
+        for a in self.argv:
+            solve_to_fd(a, argIO)
+            argIO.write("\n")
+
+        for e in self.envp:
+            solve_to_fd(e, envIO)
+            envIO.write("\n")
+
         ret = {
             'syscalls': repr(self.syscall_trace),
+            'argv': argIO.getvalue(),
+            'env': envIO.getvalue(),
             'stdout': out.getvalue(),
             'stdin': inn.getvalue(),
             'stderr': err.getvalue(),

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -832,10 +832,8 @@ class Linux(Platform):
                 continue
             interpreter_filename = elf_segment.data()[:-1]
             logger.info('Interpreter filename: %s', interpreter_filename)
-            try:
-                interpreter = ELFFile(file(interpreter_filename))
-            except:
-                pass
+            if os.path.exists(interpreter_filename.decode('utf-8')):
+                interpreter = ELFFile(open(interpreter_filename, 'rb'))
             break
         if interpreter is not None:
             assert interpreter.get_machine_arch() == elf.get_machine_arch()

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -88,9 +88,13 @@ class LinuxTest(unittest.TestCase):
         print ''.join(platform.current.read_bytes(stat, 100)).encode('hex')
 
     def test_linux_workspace_files(self):
-        files = self.symbolic_linux.generate_workspace_files()
+        platform = self.symbolic_linux
+        platform.argv = ["arg1", "arg2"]
+
+        files = platform.generate_workspace_files()
         self.assertIn('syscalls', files)
         self.assertIn('argv', files)
+        self.assertEquals(files['argv'], "arg1\narg2\n")
         self.assertIn('env', files)
         self.assertIn('stdout', files)
         self.assertIn('stdin', files)

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -90,6 +90,8 @@ class LinuxTest(unittest.TestCase):
     def test_linux_workspace_files(self):
         files = self.symbolic_linux.generate_workspace_files()
         self.assertIn('syscalls', files)
+        self.assertIn('argv', files)
+        self.assertIn('env', files)
         self.assertIn('stdout', files)
         self.assertIn('stdin', files)
         self.assertIn('stderr', files)


### PR DESCRIPTION
Fixes #169

Is this exhaustive ?
Is `repr` ok for the reports ?
Do you need tests for this ?

Example 
`manticore -v --env "var1=value1" binary arg1 arg2`
Then
`cat mcore_FgaI4o/test_00000000.argv `gives`['arg1', 'arg2']`
`cat mcore_FgaI4o/test_00000000.env `gives`['lol=oui']`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/863)
<!-- Reviewable:end -->
