### PR TITLE
Fix Issue #869

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -436,7 +436,10 @@ class ABI(object):
 
         new_offset = offset + 32
 
-        if ty.startswith('uint'):
+        if ty == u'':
+            new_offset = offset
+            result = None
+        elif ty.startswith('uint'):
             size = ABI._parse_size(ty[4:]) // 8
             result = ABI.get_uint(data, size, offset)
 
@@ -447,13 +450,10 @@ class ABI(object):
             value = -(value & mask) + (value & ~mask)
             result = value
 
-        elif ty in (u'bool'):
+        elif ty == u'bool':
             result = ABI.get_uint(data, 1, offset)
         elif ty == u'address':
             result = ABI.get_uint(data, 20, offset)
-        elif ty == u'':
-            new_offset = offset
-            result = None
         elif ty in (u'bytes', u'string'):
             dyn_offset = ABI.get_uint(data, 32, offset)
             size = ABI.get_uint(data, 32, dyn_offset)

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -202,6 +202,11 @@ class EthAbiTests(unittest.TestCase):
             parsed = ABI.parse('uint{}'.format(i), data)
             self.assertEqual(parsed, 2**i - 1)
 
+    def test_empty_types(self):
+        name, args = ABI.parse('func()', '\0'*32)
+        self.assertEqual(name, 'func')
+        self.assertEqual(args, tuple())
+
 
 class EthTests(unittest.TestCase):
     def test_emit_did_execute_end_instructions(self):


### PR DESCRIPTION
Bug introduced in https://github.com/trailofbits/manticore/commit/0fc4bba9ad8ef61f9e1f23bc6d0a88b7a05aa385#diff-6cf4568b5e8712514d226faa04e417fbR450

- Move empty string up to the beginning of the if-else chain.
- Correct test for bool type case

Test `tests/test_eth.py:EthAbiTests.test_empty_types` added in https://github.com/trailofbits/manticore/commit/317d4277452e48ddb569eaddbf616fd41f99f4b9 and now passes.

fixes #869

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/872)
<!-- Reviewable:end -->
