### PR TITLE
Helpers for serializing bytesN and function ABI types

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -296,7 +296,7 @@ class ABI(object):
             if not 0 < size <= 32:
                 raise ValueError('bytes<M>: binary type of M bytes, 0 < M <= 32.')
             if isinstance(value, (int, long)):
-                if not 0 <= value < (2 ** (size*8)):
+                if not 0 <= value < (2 ** (size * 8)):
                     raise Value("value '%s' exceeds size %s" % (hex(value), size))
                 self.sub_word = ABI.serialize_uint(value, size)
             elif isinstance(value, str) and value[:2] == '0x':
@@ -363,21 +363,24 @@ class ABI(object):
         Translates a Python object to its EVM ABI serialization.
         '''
         if isinstance(value, (str, tuple)):
-            return ABI.serialize_string(value)
-        if isinstance(value, (list)):
-            return ABI.serialize_array(value)
-        if isinstance(value, (int, long)):
-            return ABI.serialize_uint(value)
-        if isinstance(value, ABI.StaticBytes):
-            return value.serialize()
-        if isinstance(value, ABI.Address):
-            return value.serialize()
-        if isinstance(value, ABI.ExternalFunction):
-            return value.serialize()
-        if isinstance(value, ABI.SByte):
-            return ABI.serialize_uint(value.size) + (None,) * value.size + (('\x00',) * (32 - (value.size % 32)))
-        if value is None:
-            return (None,) * 32
+            result = ABI.serialize_string(value)
+        elif isinstance(value, (list)):
+            result = ABI.serialize_array(value)
+        elif isinstance(value, (int, long)):
+            result = ABI.serialize_uint(value)
+        elif isinstance(value, ABI.StaticBytes):
+            result = value.serialize()
+        elif isinstance(value, ABI.Address):
+            result = value.serialize()
+        elif isinstance(value, ABI.ExternalFunction):
+            result = value.serialize()
+        elif isinstance(value, ABI.SByte):
+            result = ABI.serialize_uint(value.size) + (None,) * value.size + (('\x00',) * (32 - (value.size % 32)))
+        elif value is None:
+            result = (None,) * 32
+        else:
+            raise TypeError
+        return result
 
     @staticmethod
     def serialize_uint(value, size=32):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -289,7 +289,8 @@ class ABI(object):
 
     @staticmethod
     def _tuple_bytes_to_long(tpl):
-        return reduce(lambda acc, b: (acc << 8) + ord(b), tpl, 0L)
+        from functools import reduce
+        return reduce(lambda acc, b: (acc << 8) + ord(b), tpl, 0)
 
     class StaticBytes(object):
         def __init__(self, value, size=32):
@@ -364,7 +365,7 @@ class ABI(object):
         '''
         if isinstance(value, (str, tuple)):
             result = ABI.serialize_string(value)
-        elif isinstance(value, (list)):
+        elif isinstance(value, list):
             result = ABI.serialize_array(value)
         elif isinstance(value, (int, long)):
             result = ABI.serialize_uint(value)
@@ -379,7 +380,7 @@ class ABI(object):
         elif value is None:
             result = (None,) * 32
         else:
-            raise TypeError
+            raise TypeError("ABI.serialize does not support type %s" % type(value))
         return result
 
     @staticmethod

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -227,6 +227,34 @@ class EthAbiTests(unittest.TestCase):
         self.assertEqual(name, func_name)
         self.assertEqual(args, (function_ref_data,))
 
+    def test_serialize_static_bytes(self):
+        sb1 = ABI.StaticBytes(0xdeadbeef, 4)
+        sb2 = ABI.StaticBytes('0xdeadbeef')
+        sb3 = ABI.StaticBytes(('\xde', '\xad', '\xbe', '\xef'))
+
+        self.assertEqual(sb1.serialize(), sb2.serialize())
+        self.assertEqual(sb2.serialize(), sb3.serialize())
+        self.assertEqual(sb1.serialize(), ABI.serialize(sb1))
+
+    def test_serialize_address(self):
+        addr = 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359
+        sb1 = ABI.Address(addr)
+        sb2 = ABI.Address('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359')
+        sb3 = ABI.Address(('\xfb','\x69','\x16','\x09','\x5c','\xa1','\xdf','\x60','\xbb','\x79','\xce','\x92','\xce','\x3e','\xa7','\x4c','\x37','\xc5','\xd3','\x59'))
+
+        self.assertEqual(sb1.serialize(), sb2.serialize())
+        self.assertEqual(sb2.serialize(), sb3.serialize())
+        self.assertEqual(sb1.serialize(), ABI.serialize(sb1))
+        self.assertEqual(sb1.serialize(), ABI.serialize(addr))
+
+    def test_serialize_external_function(self):
+        fn = ABI.ExternalFunction(ABI.Address('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'), ABI.StaticBytes('0xdeadbeef'))
+
+        self.assertEqual(fn.serialize(), ABI.serialize(fn))
+        self.assertEqual(ABI._tuple_bytes_to_long(fn.serialize()[:20]), 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359)
+        self.assertEqual(ABI._tuple_bytes_to_long(fn.serialize()[20:24]), 0xdeadbeef)
+        self.assertEqual(ABI._tuple_bytes_to_long(fn.serialize()[24:]), 0x0)
+
 
 class EthTests(unittest.TestCase):
     def test_emit_did_execute_end_instructions(self):


### PR DESCRIPTION
This is a followup to #874 and extends `ABI.serialize` to support statically sized bytes and external function references (`address` + `bytes4` function selector; special case of `bytes24`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/875)
<!-- Reviewable:end -->
