### PR TITLE
Added exception for Solidity compiler not installed. Fixes Issue #867

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -668,7 +668,11 @@ class ManticoreEVM(Manticore):
 
         #check solc version
         supported_versions = ('0.4.18', '0.4.21')
-        installed_version_output = check_output([solc, "--version"])
+
+        try:
+            installed_version_output = check_output([solc, "--version"])
+        except OSError:
+            raise Exception("Solidity compiler not installed.")
 
         m = re.match(r".*Version: (?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<build>\d+))\+(?P<commit>[^\s]+).*", installed_version_output, re.DOTALL | re.IGNORECASE)
 


### PR DESCRIPTION
OSError thrown by subprocess.py is caught to alert the user that Solidity complier has not been installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/877)
<!-- Reviewable:end -->
