### PR TITLE
Added optional message parameter in ConcretizeMemory

### DIFF
--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -34,8 +34,10 @@ class ConcretizeMemory(MemoryException):
     Raised when a symbolic memory cell needs to be concretized.
     '''
 
-    def __init__(self, mem, address, size, policy='MINMAX'):
-        self.message = "Concretizing memory address {} size {}".format(address, size)
+    def __init__(self, mem, address, size, message=None, policy='MINMAX'):
+        self.message = message
+        if message is None:
+            self.message = "Concretizing memory address {} size {}".format(address, size)
         self.mem = mem
         self.address = address
         self.size = size


### PR DESCRIPTION
In some files (e.g. manticore/core/cpu/abstractcpu.py), ConcretizeMemory is invoked with a message but it is interpreted as the "policy" value now, causing a crash. This commit should fix that issue.