### PR TITLE
Typo in ManticoreEVM#last_return

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -903,7 +903,7 @@ class ManticoreEVM(Manticore):
     def last_return(self, state_id=None):
         ''' Last returned buffer for state `state_id` '''
         state = self.load(state_id)
-        return state.platform.last_return
+        return state.platform.last_return_data
 
     def transactions(self, state_id=None):
         ''' Transactions list for state `state_id` '''

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2240,7 +2240,7 @@ class EVMWorld(Platform):
                 self.execute()
         except TerminateState as e:
             if self.depth == 0 and e.message == 'RETURN':
-                return self.last_return
+                return self.last_return_data
             raise e
 
     def create_account(self, address=None, balance=0, code='', storage=None):


### PR DESCRIPTION
Encountered the following trace:

```
Traceback (most recent call last):
  …, in <module>
    m.last_return()
  File "…/manticore/ethereum.py", line 906, in last_return
    return state.platform.last_return
AttributeError: 'EVMWorld' object has no attribute 'last_return'
```

It appears this bug was introduced in commit ed29a22f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/886)
<!-- Reviewable:end -->
