### PR TITLE
Rollback to old mini assembler only example

### DIFF
--- a/examples/evm/minimal.py
+++ b/examples/evm/minimal.py
@@ -1,4 +1,4 @@
-from manticore.ethereum import ManticoreEVM
+from manticore.ethereum import ManticoreEVM, evm
 ################ Script #######################
 
 m = ManticoreEVM()
@@ -23,10 +23,21 @@ contract NoDistpatcher {
 user_account = m.create_account(balance=1000)
 print "[+] Creating a user account", user_account
 
-contract_account = m.solidity_create_contract(source_code, owner=user_account)
-print "[+] Creating a contract account", contract_account
+init_bytecode = m.compile(source_code)
 print "[+] Source code:"
 print source_code
+
+print "[+] Init bytecode:", init_bytecode.encode('hex')
+print "[+] EVM init assembler:"
+for instr in evm.EVMAsm.disassemble_all(init_bytecode[:-44]):
+    print hex(instr.offset), instr
+
+
+
+contract_account = m.create_contract(owner=user_account,
+                                        init=init_bytecode)
+print "[+] Creating a contract account", contract_account
+
 
 print "[+] Now the symbolic values"
 symbolic_data = m.make_symbolic_buffer(320) 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1423,41 +1423,6 @@ class ManticoreEVM(Manticore):
         to a STOP or RETURN in the last symbolic transaction).
         """
 
-        # move runnign states to final states list
-        # and generate a testcase for each
-        q = Queue()
-        map(q.put, self.running_state_ids)
-
-        def f(q):
-            try:
-                while True:
-                    state_id = q.get_nowait()
-                    self.terminate_state_id(state_id)
-            except EmptyQueue:
-                pass
-
-        ps = []
-
-        for _ in range(self._config_procs):
-            p = Process(target=f, args=(q,))
-            p.start()
-            ps.append(p)
-
-        for p in ps:
-            p.join()
-
-        # delete actual streams from storage
-        for state_id in self.all_state_ids:
-            # state_id -1 is always only on memory
-            if state_id != -1:
-                self._executor._workspace.rm_state(state_id)
-
-        # clean up lists
-        with self.locked_context('seth') as seth_context:
-            seth_context['_saved_states'] = []
-        with self.locked_context('seth') as seth_context:
-            seth_context['_final_states'] = []
-
         #global summary
         with self._output.save_stream('global.summary') as global_summary:
             # (accounts created by contract code are not in this list )
@@ -1536,6 +1501,41 @@ class ManticoreEVM(Manticore):
                     for o in sorted(visited):
                         f.write('0x%x\n' % o)
 
+        # move running states to final states list
+        # and generate a testcase for each
+        q = Queue()
+        map(q.put, self.running_state_ids)
+
+        def f(q):
+            try:
+                while True:
+                    state_id = q.get_nowait()
+                    self.terminate_state_id(state_id)
+            except EmptyQueue:
+                pass
+
+        ps = []
+
+        for _ in range(self._config_procs):
+            p = Process(target=f, args=(q,))
+            p.start()
+            ps.append(p)
+
+        for p in ps:
+            p.join()
+
+        # delete actual streams from storage
+        for state_id in self.all_state_ids:
+            # state_id -1 is always only on memory
+            if state_id != -1:
+                self._executor._workspace.rm_state(state_id)
+
+        # clean up lists
+        with self.locked_context('seth') as seth_context:
+            seth_context['_saved_states'] = []
+        with self.locked_context('seth') as seth_context:
+            seth_context['_final_states'] = []
+
         logger.info("Results in %s", self.workspace)
 
     def global_coverage(self, account_address):
@@ -1549,13 +1549,13 @@ class ManticoreEVM(Manticore):
         world = None
         for state_id in self.all_state_ids:
             world = self.get_world(state_id)
-            if account_address in world.storage:
+            if account_address in world.contract_accounts:
                 break
 
         with self.locked_context('runtime_coverage') as coverage:
             seen = coverage
-        #runtime_bytecode = world.storage[account_address]['code']
-        runtime_bytecode = self.get_metadata(account_address).runtime_bytecode
+        runtime_bytecode = world.get_code(account_address)[:-44]
+        #runtime_bytecode = self.get_metadata(account_address).runtime_bytecode
 
         count, total = 0, 0
         for i in evm.EVMAsm.disassemble_all(runtime_bytecode):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1554,16 +1554,9 @@ class ManticoreEVM(Manticore):
         with self.locked_context('runtime_coverage') as coverage:
             seen = coverage
 
-        #fixme use this https://github.com/trailofbits/manticore/blob/a98902c81adfa59a86b35e116869609ad1774cdc/manticore/ethereum.py#L173-L179
-        runtime_bytecode = world.get_code(account_address)[:-44]
+        runtime_bytecode = world.get_code(account_address)
+        return calculate_coverage(runtime_bytecode, seen)
 
-        count, total = 0, 0
-        for i in evm.EVMAsm.disassemble_all(runtime_bytecode):
-            if (account_address, i.offset) in seen:
-                count += 1
-            total += 1
-
-        return count * 100.0 / total
 
     # TODO: Find a better way to suppress execution of Manticore._did_finish_run_callback
     # We suppress because otherwise we log it many times and it looks weird.

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1557,7 +1557,6 @@ class ManticoreEVM(Manticore):
         runtime_bytecode = world.get_code(account_address)
         return calculate_coverage(runtime_bytecode, seen)
 
-
     # TODO: Find a better way to suppress execution of Manticore._did_finish_run_callback
     # We suppress because otherwise we log it many times and it looks weird.
     def _did_finish_run_callback(self):


### PR DESCRIPTION
Refactor report generator to handle bytecode only contracts (no metadata) again. RFC/WIP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/889)
<!-- Reviewable:end -->
