### PR TITLE
Partially implement chroot(2)

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2621,6 +2621,9 @@ class SLinux(Linux):
 
         return super(SLinux, self).sys_getrandom(buf, size, flags)
 
+    def sys_chroot(self, buf):
+        return -errno.EPERM
+
     def generate_workspace_files(self):
         def solve_to_fd(data, fd):
             try:

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1557,6 +1557,25 @@ class Linux(Platform):
 
         return newfd
 
+    def sys_chroot(self, path):
+        '''
+        An implementation of chroot that does perform some basic error checking,
+        but does not actually chroot.
+
+        :param path: Path to chroot
+        '''
+        if path not in self.current.memory:
+            return -errno.EFAULT
+
+        path_s = self.current.read_string(path)
+        if not os.path.exists(path_s):
+            return -errno.ENOENT
+
+        if not os.path.isdir(path_s):
+            return -errno.ENOTDIR
+
+        return -errno.EPERM
+
     def sys_close(self, fd):
         '''
         Closes a file descriptor
@@ -2620,9 +2639,6 @@ class SLinux(Linux):
             raise ConcretizeArgument(self, 2)
 
         return super(SLinux, self).sys_getrandom(buf, size, flags)
-
-    def sys_chroot(self, buf):
-        return -errno.EPERM
 
     def generate_workspace_files(self):
         def solve_to_fd(data, fd):


### PR DESCRIPTION
Really this return EPERM (permission denied), which seems to be absolutely fine
since a non-privileged user is currently assumed. This is what would normally
be returned in this scenario.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/891)
<!-- Reviewable:end -->
