### PR TITLE
Partially implement fork(2)

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1280,6 +1280,12 @@ class Linux(Platform):
 
         return len(data)
 
+    def sys_fork(self):
+        '''
+        We don't support forking, but do return a valid error code to client binary.
+        '''
+        return -errno.ENOSYS
+
     def sys_access(self, buf, mode):
         '''
         Checks real user's permissions for a file
@@ -2620,9 +2626,6 @@ class SLinux(Linux):
             raise ConcretizeArgument(self, 2)
 
         return super(SLinux, self).sys_getrandom(buf, size, flags)
-
-    def sys_fork(self):
-        return -errno.ENOSYS
 
     def generate_workspace_files(self):
         def solve_to_fd(data, fd):

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2621,6 +2621,9 @@ class SLinux(Linux):
 
         return super(SLinux, self).sys_getrandom(buf, size, flags)
 
+    def sys_fork(self):
+        return -errno.ENOSYS
+
     def generate_workspace_files(self):
         def solve_to_fd(data, fd):
             try:


### PR DESCRIPTION
Really this return ENOSYS (not implemented), which allows sub-processes to
detect the condition and continue to run (or crash on their own if they did not
expect fork() to fail).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/892)
<!-- Reviewable:end -->
