### PR TITLE
Fix Linux initialization

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -439,7 +439,7 @@ class Linux(Platform):
 
         in_fd = self._open(stdin)
         out_fd = self._open(stdout)
-        err_fd =  self._open(stderr)
+        err_fd = self._open(stderr)
 
         assert (in_fd, out_fd, err_fd) == (0, 1, 2)
 

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -437,9 +437,11 @@ class Linux(Platform):
         self.input.peer = stdin
         # A receive on stdout or stderr will return no data (rx_bytes: 0)
 
-        assert self._open(stdin) == 0
-        assert self._open(stdout) == 1
-        assert self._open(stderr) == 2
+        in_fd = self._open(stdin)
+        out_fd = self._open(stdout)
+        err_fd =  self._open(stderr)
+
+        assert (in_fd, out_fd, err_fd) == (0, 1, 2)
 
     def _init_cpu(self, arch):
         # create memory and CPU

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -409,7 +409,7 @@ class ABITest(unittest.TestCase):
         def test(prefix, extracted):
             raise ConcretizeArgument(cpu, 0)
 
-        if not sys.flags.optimize:
+        if __debug__:
             with self.assertRaises(AssertionError) as cr:
                 cpu.func_abi.invoke(test, prefix_args=(1,))
 

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -409,8 +409,9 @@ class ABITest(unittest.TestCase):
         def test(prefix, extracted):
             raise ConcretizeArgument(cpu, 0)
 
-        with self.assertRaises(AssertionError) as cr:
-            cpu.func_abi.invoke(test, prefix_args=(1,))
+        if not sys.flags.optimize:
+            with self.assertRaises(AssertionError) as cr:
+                cpu.func_abi.invoke(test, prefix_args=(1,))
 
     def test_funcall_method(self):
         cpu = self._cpu_x86

--- a/tests/test_armv7rf.py
+++ b/tests/test_armv7rf.py
@@ -30,7 +30,7 @@ class Armv7RFTest(unittest.TestCase):
         self.assertEqual(self.r.read('APSR_Z'), False)
 
     def test_bad_reg_name(self):
-        if not sys.flags.optimize:
+        if __debug__:
             exception = AssertionError
         else:
             exception = KeyError

--- a/tests/test_armv7rf.py
+++ b/tests/test_armv7rf.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from manticore.core.cpu.arm import Armv7RegisterFile as RF
@@ -29,7 +30,11 @@ class Armv7RFTest(unittest.TestCase):
         self.assertEqual(self.r.read('APSR_Z'), False)
 
     def test_bad_reg_name(self):
-        with self.assertRaises(AssertionError):
+        if not sys.flags.optimize:
+            exception = AssertionError
+        else:
+            exception = KeyError
+        with self.assertRaises(exception):
             nonexistant_reg = "Pc"
             self.r.read(nonexistant_reg)
 


### PR DESCRIPTION
The Linux platform initialization opens `stdin`, `stdout`, and `stderr` and ensures that they get assigned the correct fd values (0, 1, and 2). This is done inline inside an `assert`. If running with optimizations enabled (e.g. `PYTHONOPTIMIZE` is set), those fd's will not be opened and `__setstate__`/`__getstate__` will fail.

This makes sure we open them correctly regardless of optimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/894)
<!-- Reviewable:end -->
