### PR TITLE
Install capstone from next branch, optional via pip --process-dependency-links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Install and try Manticore in a few shell commands (see an [asciinema](https://as
 sudo apt-get update && sudo apt-get install python-pip -y
 
 # Install manticore and its dependencies
+# Note you can pass --process-dependency-links flag to pip to install capstone from its latest next branch
+# (which can help if you are experiencing errors and unexpected "invalid memory access" testcases)
 sudo pip2 install manticore
 
 # Download and build the examples

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Install and try Manticore in a few shell commands (see an [asciinema](https://as
 sudo apt-get update && sudo apt-get install python-pip -y
 
 # Install manticore and its dependencies
-# Note you can pass --process-dependency-links flag to pip to install capstone from its latest next branch
-# (which can help if you are experiencing errors and unexpected "invalid memory access" testcases)
 sudo pip2 install manticore
 
 # Download and build the examples
@@ -82,6 +80,8 @@ sudo pip install manticore
 Once installed, the `manticore` CLI tool and Python API will be available.
 
 For installing a development version of Manticore, see our [wiki](https://github.com/trailofbits/manticore/wiki/Hacking-on-Manticore).
+
+> Note: If you are experiencing unanticipated errors when running Manticore on native binaries, you can try using the `--process-dependency-links` pip flag. This will install the development branch of our disassembler dependency, which may contain useful bug fixes.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
         'ply',
         'pysha3',
     ] + rtd_dependent_deps(),
+    dependency_links=[
+        'https://github.com/aquynh/capstone/archive/next.zip#egg=capstone-4&subdirectory=bindings/python',
+    ],
     extras_require={
         'dev': [
             'keystone-engine',


### PR DESCRIPTION
Re #881.

```
$ pip install ~/projects/manticore/
Processing /home/matiasb/projects/manticore
Collecting capstone>=3.0.5rc2 (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/fd/33/d1fc2d01b85572b88c9b4c359f36f88f8c32f2f0b9ffb2d21cd41bad2257/capstone-3.0.5rc2-py2-none-manylinux1_x86_64.whl
Collecting pyelftools (from manticore==0.1.9)
Collecting unicorn (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/7f/44/e6dd134bd7cc2dccc83e57ce435881b452a04ad5412836ba8a8e6db98dc0/unicorn-1.0.1-py2.py3-none-manylinux1_x86_64.whl
Collecting ply (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
Collecting pysha3 (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/c5/bb/7d793dfab828e01adb46e3c5976fe99acda12a954c728427cceb2acd7ee9/pysha3-1.0.2-cp27-cp27mu-manylinux1_x86_64.whl
Collecting z3-solver (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/e4/31/4d618b333be647c82adbcd9d3caf8d2d219ec1cd3781e3be6b70bc41fb88/z3_solver-4.5.1.0.post2-py2-none-manylinux1_x86_64.whl
Building wheels for collected packages: manticore
  Running setup.py bdist_wheel for manticore ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-BQSOi0/wheels/7b/9e/da/167b3b1bed92d4094f628a65c18818e555053602403f924e3e
Successfully built manticore
Installing collected packages: capstone, pyelftools, unicorn, ply, pysha3, z3-solver, manticore
Successfully installed capstone-3.0.5rc2 manticore-0.1.9 ply-3.11 pyelftools-0.24 pysha3-1.0.2 unicorn-1.0.1 z3-solver-4.5.1.0.post2
```

```
$ pip install --process-dependency-links ~/projects/manticore/
Processing /home/matiasb/projects/manticore
DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release.
Collecting capstone>=3.0.5rc2 (from manticore==0.1.9)
  Downloading https://github.com/aquynh/capstone/archive/next.zip (3.6MB)
    100% |████████████████████████████████| 3.6MB 2.8MB/s 
Collecting pyelftools (from manticore==0.1.9)
Collecting unicorn (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/7f/44/e6dd134bd7cc2dccc83e57ce435881b452a04ad5412836ba8a8e6db98dc0/unicorn-1.0.1-py2.py3-none-manylinux1_x86_64.whl
Collecting ply (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
Collecting pysha3 (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/c5/bb/7d793dfab828e01adb46e3c5976fe99acda12a954c728427cceb2acd7ee9/pysha3-1.0.2-cp27-cp27mu-manylinux1_x86_64.whl
Collecting z3-solver (from manticore==0.1.9)
  Using cached https://files.pythonhosted.org/packages/e4/31/4d618b333be647c82adbcd9d3caf8d2d219ec1cd3781e3be6b70bc41fb88/z3_solver-4.5.1.0.post2-py2-none-manylinux1_x86_64.whl
Building wheels for collected packages: manticore, capstone
  Running setup.py bdist_wheel for manticore ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-UMnPcV/wheels/7b/9e/da/167b3b1bed92d4094f628a65c18818e555053602403f924e3e
  Running setup.py bdist_wheel for capstone ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-UMnPcV/wheels/f8/1b/1c/1b1fd08e443d9b2a2476b4e0ba824ec53384ef054a537d034d
Successfully built manticore capstone
Installing collected packages: capstone, pyelftools, unicorn, ply, pysha3, z3-solver, manticore
Successfully installed capstone-4.0.0rc1 manticore-0.1.9 ply-3.11 pyelftools-0.24 pysha3-1.0.2 unicorn-1.0.1 z3-solver-4.5.1.0.post2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/896)
<!-- Reviewable:end -->
