### PR TITLE
Inode number is encoded with 64 bits

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2337,22 +2337,22 @@ class Linux(Platform):
             return struct.pack('<LL', int(ts), int(ts % 1 * 1e9))
 
         bufstat = add(8, stat.st_dev)        # unsigned long long      st_dev;
-        bufstat += add(4, 0)                  # unsigned char   __pad0[4];
-        bufstat += add(8, stat.st_ino)        # unsigned long   __st_ino;
+        bufstat += add(8, stat.st_ino)        # unsigned long long   __st_ino;
         bufstat += add(4, stat.st_mode)       # unsigned int    st_mode;
         bufstat += add(4, stat.st_nlink)      # unsigned int    st_nlink;
         bufstat += add(4, stat.st_uid)        # unsigned long   st_uid;
         bufstat += add(4, stat.st_gid)        # unsigned long   st_gid;
         bufstat += add(8, stat.st_rdev)       # unsigned long long st_rdev;
-        bufstat += add(4, 0)                  # unsigned char   __pad3[4];
-        bufstat += add(4, 0)                  # unsigned char   __pad3[4];
+        bufstat += add(8, 0)                  # unsigned long long __pad1;
         bufstat += add(8, stat.st_size)       # long long       st_size;
-        bufstat += add(8, stat.st_blksize)    # unsigned long   st_blksize;
+        bufstat += add(4, stat.st_blksize)    # int   st_blksize;
+        bufstat += add(4, 0)                  # int   __pad2;
         bufstat += add(8, stat.st_blocks)     # unsigned long long st_blocks;
         bufstat += to_timespec(stat.st_atime)  # unsigned long   st_atime;
         bufstat += to_timespec(stat.st_mtime)  # unsigned long   st_mtime;
         bufstat += to_timespec(stat.st_ctime)  # unsigned long   st_ctime;
-        bufstat += add(8, stat.st_ino)        # unsigned long long      st_ino;
+        bufstat += add(4, 0)                   # unsigned int __unused4;
+        bufstat += add(4, 0)                   # unsigned int __unused5;
 
         self.current.write_bytes(buf, bufstat)
         return 0

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2338,7 +2338,7 @@ class Linux(Platform):
 
         bufstat = add(8, stat.st_dev)        # unsigned long long      st_dev;
         bufstat += add(4, 0)                  # unsigned char   __pad0[4];
-        bufstat += add(4, stat.st_ino)        # unsigned long   __st_ino;
+        bufstat += add(8, stat.st_ino)        # unsigned long   __st_ino;
         bufstat += add(4, stat.st_mode)       # unsigned int    st_mode;
         bufstat += add(4, stat.st_nlink)      # unsigned int    st_nlink;
         bufstat += add(4, stat.st_uid)        # unsigned long   st_uid;

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -868,7 +868,7 @@ class Linux(Platform):
                 for mpath in env['LD_LIBRARY_PATH'].split(":"):
                     interpreter_path_filename = os.path.join(mpath, os.path.basename(interpreter_filename))
                     logger.info("looking for interpreter %s", interpreter_path_filename)
-                    if os.path.exists(interpreter_filename):
+                    if os.path.exists(interpreter_path_filename):
                         interpreter = ELFFile(open(interpreter_path_filename))
                         break
             break


### PR DESCRIPTION
Fixes #824 

Inode number from stat is either encoded on 32 or 64 bits
Since this is function `sys_fstat64`, I suggest that we use 64 bits.

Do you see any other way to get `sizeof(ino_t)` ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/897)
<!-- Reviewable:end -->
