### PR TITLE
install z3-solver in our install script so it's available

### DIFF
--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -8,5 +8,6 @@ function install_solc {
 install_solc
 
 pip install -U pip
+pip install -U z3-solver
 pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 pip install --no-binary keystone-engine -e .[dev]  # ks can have pip install issues


### PR DESCRIPTION
The current test suite passes because at some point in the past the z3 solver was installed into the environment and the result was cached by travis. If, for whatever reason, travis fails to load the cache, tests fail since the current install scripts do not install z3.

This adds z3 to the installer to fix that issue. I would have added it to the actual dependencies of manticore itself, but since z3 is obtained via subprocess presumably we don't want to define a specific way that users have it installed and rather just want to document that it must be available on `PATH`.

Extracted from #905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/906)
<!-- Reviewable:end -->
