### PR TITLE
incremental py3: print statements, octals, and more

### DIFF
--- a/manticore/binary/__init__.py
+++ b/manticore/binary/__init__.py
@@ -14,6 +14,7 @@ But there are difference between format that makes it difficult to find a simple
 and common API.  interpreters? linkers? linked DLLs?
 
 '''
+from __future__ import print_function
 
 
 class Binary(object):
@@ -138,5 +139,5 @@ Binary.magics = {'\x7fCGC': CGCElf,
 
 if __name__ == '__main__':
     import sys
-    print list(Binary(sys.argv[1]).threads())
-    print list(Binary(sys.argv[1]).maps())
+    print(list(Binary(sys.argv[1]).threads()))
+    print(list(Binary(sys.argv[1]).maps()))

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -423,7 +423,7 @@ class SyscallAbi(Abi):
             if ret > min_hex_expansion:
                 ret_s = ret_s + '(0x{:x})'.format(ret)
 
-            platform_logger.debug('%s(%s) -> %s', model.im_func.func_name, args_s, ret_s)
+            platform_logger.debug('%s(%s) -> %s', model.__func__.__name__, args_s, ret_s)
 
 ############################################################################
 # Abstract cpu encapsulating common cpu methods used by platforms and executor.

--- a/manticore/core/parser/parser.py
+++ b/manticore/core/parser/parser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Minimal INTEL assembler expression calculator
 import ply.yacc as yacc
 import copy
@@ -116,7 +117,7 @@ t_ignore = ' \t'
 
 
 def t_error(t):
-    print "Illegal character '%s'" % t.value[0]
+    print("Illegal character '%s'" % t.value[0])
     t.lexer.skip(1)
 
 
@@ -296,7 +297,7 @@ def p_expression_ge(p):
 
 # Error rule for syntax errors
 def p_error(p):
-    print "Syntax error in input:", p
+    print("Syntax error in input:", p)
 
 # Build the parser
 
@@ -345,4 +346,4 @@ if __name__ == '__main__':
         if not s:
             continue
         result = parse(s)
-        print result
+        print(result)

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 ###############################################################################
 # Solver
 # A solver maintains a companion smtlib capable process connected via stdio.

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -171,7 +171,7 @@ class Z3Solver(Solver):
         try:
             self._proc = Popen(self._command.split(' '), stdin=PIPE, stdout=PIPE)
         except OSError as e:
-            print e, "Probably too  much cached expressions? visitors._cache..."
+            print(e, "Probably too  much cached expressions? visitors._cache...")
             # Z3 was removed from the system in the middle of operation
             raise Z3NotFoundError  # TODO(mark) don't catch this exception in two places
 

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -746,8 +746,8 @@ class Decree(Platform):
         if cpu.EAX not in syscalls.keys():
             raise TerminateState("32 bit DECREE system call number {} Not Implemented".format(cpu.EAX))
         func = syscalls[cpu.EAX]
-        logger.debug("SYSCALL32: %s (nargs: %d)", func.func_name, func.func_code.co_argcount)
-        nargs = func.func_code.co_argcount
+        logger.debug("SYSCALL32: %s (nargs: %d)", func.__name__, func.__code__.co_argcount)
+        nargs = func.__code__.co_argcount
         args = [cpu, cpu.EBX, cpu.ECX, cpu.EDX, cpu.ESI, cpu.EDI, cpu.EBP]
         cpu.EAX = func(*args[:nargs - 1])
 

--- a/manticore/utils/iterpickle.py
+++ b/manticore/utils/iterpickle.py
@@ -639,7 +639,7 @@ class Pickler:
             tmp = []
             for i in r:
                 try:
-                    x = items.next()
+                    x = next(items)
                     tmp.append(x)
                 except StopIteration:
                     items = None
@@ -687,7 +687,7 @@ class Pickler:
             tmp = []
             for i in r:
                 try:
-                    tmp.append(items.next())
+                    tmp.append(next(items))
                 except StopIteration:
                     items = None
                     break
@@ -904,7 +904,7 @@ class Unpickler:
     def load_proto(self):
         proto = ord(self.read(1))
         if not 0 <= proto <= 2:
-            raise ValueError, "unsupported pickle protocol: %d" % proto
+            raise ValueError("unsupported pickle protocol: %d" % proto)
     dispatch[PROTO] = load_proto
 
     def load_persid(self):
@@ -984,11 +984,11 @@ class Unpickler:
         for q in "\"'":  # double or single quote
             if rep.startswith(q):
                 if len(rep) < 2 or not rep.endswith(q):
-                    raise ValueError, "insecure string pickle"
+                    raise ValueError("insecure string pickle")
                 rep = rep[len(q):-len(q)]
                 break
         else:
-            raise ValueError, "insecure string pickle"
+            raise ValueError("insecure string pickle")
         self.append(rep.decode("string-escape"))
     dispatch[STRING] = load_string
 
@@ -1245,7 +1245,7 @@ class Unpickler:
                 d = inst.__dict__
                 try:
                     for k, v in state.iteritems():
-                        d[intern(k)] = v
+                        d[sys.intern(k)] = v
                 # keys in state don't have to be strings
                 # don't blow up, but don't go out of our way
                 except TypeError:

--- a/manticore/utils/iterpickle.py
+++ b/manticore/utils/iterpickle.py
@@ -23,6 +23,7 @@ Misc variables:
     compatible_formats
 
 """
+from __future__ import print_function
 
 __version__ = "$Revision: 72223 $"       # Code version
 
@@ -1080,8 +1081,8 @@ class Unpickler:
             try:
                 value = klass(*args)
             except TypeError as err:
-                raise TypeError, "in constructor for %s: %s" % (
-                    klass.__name__, str(err)), sys.exc_info()[2]
+                raise TypeError("in constructor for %s: %s" % (
+                    klass.__name__, str(err)), sys.exc_info()[2])
         self.append(value)
 
     def load_inst(self):

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,12 +1,13 @@
+from __future__ import print_function
 from manticore import Manticore
 from sys import argv, exit
 
 def display(results):
     for line in str(results).split('\n'):
-        print "  " + line
+        print("  " + line)
 
 def benchmark(program):
-    print "[*] Benchmarking program \"{}\"".format(program)
+    print("[*] Benchmarking program \"{}\"".format(program))
 
     m = Manticore(program)
     m.should_profile = True
@@ -14,7 +15,7 @@ def benchmark(program):
 
     results = m._executor.dump_stats()
     if results is None:
-        print "[*] Failed to collect stats for program {}".format(program)
+        print("[*] Failed to collect stats for program {}".format(program))
         return
 
     display(results)
@@ -24,7 +25,7 @@ if __name__ == "__main__":
     args = argv[1:]
 
     if len(args) == 0:
-        print "usage: python {} PROGRAM1 PROGRAM2...".format(argv[0])
+        print("usage: python {} PROGRAM1 PROGRAM2...".format(argv[0]))
         exit()
 
     first_program = args[0]
@@ -40,5 +41,5 @@ if __name__ == "__main__":
             overall_results.loading_time += results.loading_time
             overall_results.saving_time += results.saving_time
             
-        print "Overall:"
+        print("Overall:")
         display(overall_results)

--- a/scripts/follow_trace.py
+++ b/scripts/follow_trace.py
@@ -4,6 +4,7 @@
 A simple trace following execution driver script. Only supports passing symbolic arguments via argv.
 
 '''
+from __future__ import print_function
 
 import sys
 import time
@@ -33,8 +34,8 @@ class TraceReceiver(Plugin):
 
         instructions, writes = _partition(lambda x: x['type'] == 'regs', self._trace)
         total = len(self._trace)
-        print 'Recorded concrete trace: {}/{} instructions, {}/{} writes'.format(
-            len(instructions), total, len(writes), total)
+        print('Recorded concrete trace: {}/{} instructions, {}/{} writes'.format(
+            len(instructions), total, len(writes), total))
 
 
 class Follower(Plugin):
@@ -82,7 +83,7 @@ class Follower(Plugin):
 def main():
     parser = argparse.ArgumentParser(description='Follow a concrete trace')
     parser.add_argument('-f', '--explore_from', help='Value of PC from which to explore symbolically', type=str)
-    parser.add_argument('-t', '--explore_to', type=str, default=sys.maxint,
+    parser.add_argument('-t', '--explore_to', type=str, default=sys.maxsize,
                         help="Value of PC until which to explore symbolically. (Probably don't want this set)")
     parser.add_argument('--verbose', '-v', action='count', help='Increase verbosity')
     parser.add_argument('cmd', type=str, nargs='+',

--- a/scripts/gdb.py
+++ b/scripts/gdb.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import traceback
 import os
@@ -123,6 +124,6 @@ def get_arch():
     elif 'elf32-littlearm' in infotarget:
         _arch = 'armv7'
     else:
-        print infotarget
+        print(infotarget)
         raise NotImplemented
     return _arch

--- a/scripts/qemu.py
+++ b/scripts/qemu.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import traceback
 import os
@@ -82,7 +83,7 @@ def start(arch, argv, port=1234, va_size=0xc0000000, stack_size=0x20000):
     stats = parse_mmu_debug_output(mmu_debug_output)
     for m in stats['maps']:
         start,  end, size, perms = m
-        print '{:x}-{:x}, {}, {}'.format(*m)
+        print('{:x}-{:x}, {}, {}'.format(*m))
 
 def correspond(text):
     """Communicate with the child process without closing stdin."""

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, os, cPickle, argparse
 #Process the data of a workspace and prints out some global information
 
@@ -40,16 +41,16 @@ for filename in saved_states:
                 edges.setdefault(lastpc,[]).append(pc)
                 lastpc=pc
     except Exception as e:
-        print "#Failed to load saved state %s (%s)"%(filename,e)
+        print("#Failed to load saved state %s (%s)"%(filename,e))
 
 if args.pcfreq :
-    print '#PC:  frequency'
+    print('#PC:  frequency')
     for pc, freq in sorted(db.items(), key=lambda x: -x[1]):
-        print '%x: %d'%(pc,freq)
+        print('%x: %d'%(pc,freq))
 elif args.visited:
-    print '#PC'
+    print('#PC')
     for pc in db.keys():
-        print '%x'%pc
+        print('%x'%pc)
 elif args.bbs:
     assert len(set(edges['ROOT'])) == 1, "Something is wrong it should be only one root"
     bbs = set()
@@ -57,7 +58,7 @@ elif args.bbs:
         if len(set(targets)) > 1:
             [ bbs.add(x) for x in set(targets) ]
     bbs.add('ROOT')
-    print '#BBs'
+    print('#BBs')
     for origin in bbs:
         if origin not in edges:
             targets = set()
@@ -74,6 +75,6 @@ elif args.bbs:
         def p(x):
             return isinstance(x, (int, long)) and hex(x) or x
         
-        print '%s -> [%s]'%(p(origin), ', '.join(map(p, targets)) )
+        print('%s -> [%s]'%(p(origin), ', '.join(map(p, targets)) ))
     
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from manticore import Manticore
 from manticore.platforms import linux_syscalls
 
@@ -30,7 +31,7 @@ def dump_gdb(cpu, addr, count):
     for offset in range(addr, addr+count, 4):
         val = int(gdb.getM(offset)  & 0xffffffff)
         val2 = int(cpu.read_int(offset))
-        print '{:x}: g{:08x} m{:08x}'.format(offset, val, val2)
+        print('{:x}: g{:08x} m{:08x}'.format(offset, val, val2))
 
 def cmp_regs(cpu, should_print=False):
     '''
@@ -139,7 +140,7 @@ def sync_svc(state):
             return
     except ValueError:
         for reg in state.cpu.canonical_registers:
-            print '{}: {:x}'.format(reg, state.cpu.read_register(reg))
+            print('{}: {:x}'.format(reg, state.cpu.read_register(reg)))
         raise
 
 def initialize(state):
@@ -227,7 +228,7 @@ if __name__ == "__main__":
     args = argv[1:]
 
     if len(args) == 0:
-        print "usage: python {} PROGRAM1 ...".format(argv[0])
+        print("usage: python {} PROGRAM1 ...".format(argv[0]))
         exit()
 
     verify(args)

--- a/tests/auto/make_dump.py
+++ b/tests/auto/make_dump.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import traceback
 import os
@@ -100,7 +101,7 @@ class Gdb(subprocess.Popen):
             self._arch = 'amd64'
             return 'amd64'
         else:
-            print infotarget
+            print(infotarget)
             raise NotImplementedError()
 
 
@@ -166,14 +167,14 @@ while True:
         instruction = next(md.disasm(text, pc))
 
         if instruction.insn_name().upper() in ['CPUID', 'RDTSC', 'NOP', 'SYSCALL', 'INT', 'SYSENTER']:
-            print "#Skiping:, ", instruction.insn_name().upper()
+            print("#Skiping:, ", instruction.insn_name().upper())
             stepped=True
             gdb.stepi()
             continue
 
         #print instruction
         disassembly = "0x%x:\t%s\t%s" %(instruction.address, instruction.mnemonic, instruction.op_str)
-        print "#INSTRUCTION:", disassembly
+        print("#INSTRUCTION:", disassembly)
         groups = map(instruction.group_name, instruction.groups)
 
 
@@ -385,7 +386,7 @@ while True:
         if instruction.mnemonic.upper() in flags:
             for fl in flags[instruction.mnemonic.upper()]['defined']:
                 if 'OF' in registers and instruction.insn_name().upper() in ['ROL','RCL','ROR','RCR']:
-                    print instruction.insn_name().upper(), read_operand(instruction.operands[1])
+                    print(instruction.insn_name().upper(), read_operand(instruction.operands[1]))
                     del registers['OF']
                     continue
                 registers[fl] = (EFLAGS&flags_maks[fl]) != 0
@@ -399,14 +400,14 @@ while True:
         test['pos']['registers'] = registers
 
         if not 'int' in groups:
-            print test 
+            print(test) 
 
         count += 1
 
         #check if exit
         if instruction.insn_name().upper() in ['SYSCALL', 'INT', 'SYSENTER']:
             if "The program has no registers now." in gdb.correspond("info registers \n"):
-                print "done" 
+                print("done") 
                 break
     except Exception as e:
         if "The program has no registers now." in gdb.correspond("info registers\n"):
@@ -416,10 +417,10 @@ while True:
         #print '-'*60
         #import pdb
         #pdb.set_trace()
-        print "# Exception", e
+        print("# Exception", e)
         if not stepped:
             gdb.stepi()
 
-print "# Processed %d instructions." % count
+print("# Processed %d instructions." % count)
 
 

--- a/tests/auto/make_evmtests.py
+++ b/tests/auto/make_evmtests.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pprint import pformat
 from cStringIO import StringIO
 
@@ -70,7 +71,7 @@ def gen_test(testcase, testname, skip):
         try:
             header[_key] = i(env[key])
         except:
-            print "XXXXXX" , key, env[key]
+            print("XXXXXX" , key, env[key])
     output += '        header =' + pprint (header, indent=18) +'\n'
 
     pre = testcase['pre']
@@ -189,7 +190,7 @@ if __name__ == '__main__':
 
     assert filename.endswith('.json')
 
-    print '''
+    print('''
 import struct
 import unittest
 import json
@@ -202,7 +203,7 @@ import os
 class EVMTest_%s(unittest.TestCase):
     _multiprocess_can_split_ = True
     maxDiff=None 
-'''%  os.path.split(sys.argv[1][:-5])[1] 
+'''%  os.path.split(sys.argv[1][:-5])[1]) 
 
     js = file(filename).read()
     tests = dict(json.loads(js))
@@ -241,8 +242,8 @@ class EVMTest_%s(unittest.TestCase):
         #print filename, test_name, tests[test_name]    
         name = 'test_%s_%s'%(filename[:-5],test_name)
         name = str(name.replace('.', '_'))
-        print gen_test(testcase, test_name, skip)
+        print(gen_test(testcase, test_name, skip))
 
-    print '''
+    print('''
 if __name__ == '__main__':
-    unittest.main()'''
+    unittest.main()''')

--- a/tests/auto/make_tests.py
+++ b/tests/auto/make_tests.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, random
 tests = []
 tests_str = file(sys.argv[1], 'r').read().split('\n')
@@ -21,12 +22,12 @@ for test in tests:
         op_count[test['mnemonic']] = cnt+1
         test_dic["%s_%d"%(test['mnemonic'], op_count[test['mnemonic']])] = test
     except Exception as e:
-        print "EX", e, test
+        print("EX", e, test)
         pass
 
 
 
-print """
+print("""
 import unittest
 import functools
 from manticore.core.cpu.x86 import *
@@ -74,7 +75,7 @@ class CPUTest(unittest.TestCase):
         def write(self, value):
             self.value = value & ((1<<self.size)-1)
             return self.value
-"""
+""")
 
 
 def isFlag(x):
@@ -129,7 +130,7 @@ for test_name in sorted(test_dic.keys()):
     bits = {'i386': 32, 'amd64': 64}[test['arch']]
     pc = {'i386': 'EIP', 'amd64': 'RIP'}[test['arch']]
 
-    print """
+    print("""
     def test_%(test_name)s(self):
         ''' Instruction %(test_name)s
             Groups: %(groups)s
@@ -141,30 +142,30 @@ for test_name in sorted(test_dic.keys()):
                                         'disassembly': test['disassembly'],
                                         'bits': bits,
                                         'arch': test['arch'],
-                                        'cpu': {64:'AMD64Cpu', 32:'I386Cpu'}[bits], }
+                                        'cpu': {64:'AMD64Cpu', 32:'I386Cpu'}[bits], })
 
     for addr, size in get_maps(test):
-        print '''        mem.mmap(0x%08x, 0x%x, 'rwx')''' % (addr, size)
+        print('''        mem.mmap(0x%08x, 0x%x, 'rwx')''' % (addr, size))
 
 
 
     for addr, byte in test['pre']['memory'].items():
-        print '''        mem[0x%08x] = %r''' % (addr, byte)
+        print('''        mem[0x%08x] = %r''' % (addr, byte))
 
     for reg_name, value in test['pre']['registers'].items():
         if isFlag(reg_name):
-            print """        cpu.%s = %r"""%(reg_name, value)
+            print("""        cpu.%s = %r"""%(reg_name, value))
         else:
-            print """        cpu.%s = 0x%x"""%(reg_name, value)
+            print("""        cpu.%s = 0x%x"""%(reg_name, value))
 
-    print """        cpu.execute()
-    """
+    print("""        cpu.execute()
+    """)
 
     for addr, byte in test['pos']['memory'].items():
-        print """        self.assertEqual(mem[0x%x], %r)"""%(addr, byte)
+        print("""        self.assertEqual(mem[0x%x], %r)"""%(addr, byte))
 
     for reg_name, value in test['pos']['registers'].items():
-        print """        self.assertEqual(cpu.%s, %r)"""%(reg_name, value)
+        print("""        self.assertEqual(cpu.%s, %r)"""%(reg_name, value))
 
 for test_name in sorted(test_dic.keys()):
 
@@ -172,7 +173,7 @@ for test_name in sorted(test_dic.keys()):
     bits = {'i386': 32, 'amd64': 64}[test['arch']]
     pc = {'i386': 'EIP', 'amd64': 'RIP'}[test['arch']]
 
-    print """
+    print("""
     def test_%(test_name)s_symbolic(self):
         ''' Instruction %(test_name)s
             Groups: %(groups)s
@@ -185,41 +186,41 @@ for test_name in sorted(test_dic.keys()):
                                         'disassembly': test['disassembly'],
                                         'bits': bits,
                                         'arch': test['arch'],
-                                        'cpu': {64:'AMD64Cpu', 32:'I386Cpu'}[bits] }
+                                        'cpu': {64:'AMD64Cpu', 32:'I386Cpu'}[bits] })
 
     for addr, size in get_maps(test):
-        print '''        mem.mmap(0x%08x, 0x%x, 'rwx')''' % (addr, size)
+        print('''        mem.mmap(0x%08x, 0x%x, 'rwx')''' % (addr, size))
 
 
     ip = test['pre']['registers'][pc]
     text_size = len(test['text'])
     for addr, byte in test['pre']['memory'].items():
         if addr >= ip and addr <= ip+text_size:
-            print """        mem[0x%x] = %r"""%(addr, byte)
+            print("""        mem[0x%x] = %r"""%(addr, byte))
             continue
 
-        print '''        addr = cs.new_bitvec(%d)''' %bits
-        print '''        cs.add(addr == 0x%x)''' % addr
-        print '''        value = cs.new_bitvec(8)'''
-        print '''        cs.add(value == 0x%x)''' % ord(byte)
-        print '''        mem[addr] = value'''
+        print('''        addr = cs.new_bitvec(%d)''' %bits)
+        print('''        cs.add(addr == 0x%x)''' % addr)
+        print('''        value = cs.new_bitvec(8)''')
+        print('''        cs.add(value == 0x%x)''' % ord(byte))
+        print('''        mem[addr] = value''')
 
 
 
     for reg_name, value in test['pre']['registers'].items():
         if reg_name in ('EIP', 'RIP'):
-            print """        cpu.%s = 0x%x"""%(reg_name, value)
+            print("""        cpu.%s = 0x%x"""%(reg_name, value))
             continue
         if isFlag(reg_name):
-            print """        cpu.%s = cs.new_bool()"""%reg_name
-            print """        cs.add(cpu.%s == %r)"""%(reg_name, value)
+            print("""        cpu.%s = cs.new_bool()"""%reg_name)
+            print("""        cs.add(cpu.%s == %r)"""%(reg_name, value))
         else:
-            print """        cpu.%s = cs.new_bitvec(%d)"""%(reg_name, regSize(reg_name))
-            print """        cs.add(cpu.%s == 0x%x)"""%(reg_name, value)
+            print("""        cpu.%s = cs.new_bitvec(%d)"""%(reg_name, regSize(reg_name)))
+            print("""        cs.add(cpu.%s == 0x%x)"""%(reg_name, value))
 
 
     pc_reg = 'RIP' if 'RIP' in test['pre']['registers'] else 'EIP'
-    print """
+    print("""
         done = False
         while not done:
             try:
@@ -232,8 +233,8 @@ for test_name in sorted(test_dic.keys()):
                 setattr(cpu, e.reg_name, values[0])
                 setattr(cpu, '{PC}', {PC_VAL})""".format(
                         PC=pc_reg,
-                        PC_VAL=hex(test['pre']['registers'][pc_reg]))
-    print """
+                        PC_VAL=hex(test['pre']['registers'][pc_reg])))
+    print("""
             except ConcretizeMemory as e:
                 symbol = getattr(cpu, '{FRAME_BASE}')
                 if isinstance(symbol, Expression):
@@ -249,31 +250,31 @@ for test_name in sorted(test_dic.keys()):
                 setattr(cpu, '{PC}', {PC_VAL})""".format(
                         FRAME_BASE='RBP' if 'RBP' in test['pre']['registers'] else 'EBP',
                         PC=pc_reg,
-                        PC_VAL=hex(test['pre']['registers'][pc_reg]))
+                        PC_VAL=hex(test['pre']['registers'][pc_reg])))
 
 
-    print """
-        condition = True"""
+    print("""
+        condition = True""")
 
     for addr, byte in test['pos']['memory'].items():
-        print """        condition = Operators.AND(condition, cpu.read_int(0x%x, 8)== ord(%r))"""%(addr, byte)
+        print("""        condition = Operators.AND(condition, cpu.read_int(0x%x, 8)== ord(%r))"""%(addr, byte))
     for reg_name, value in test['pos']['registers'].items():
         if isFlag(reg_name):
-            print """        condition = Operators.AND(condition, cpu.%s == %r)"""%(reg_name, value)
+            print("""        condition = Operators.AND(condition, cpu.%s == %r)"""%(reg_name, value))
         else:
-            print """        condition = Operators.AND(condition, cpu.%s == 0x%x)"""%(reg_name, value)
+            print("""        condition = Operators.AND(condition, cpu.%s == 0x%x)"""%(reg_name, value))
 
 
-    print """
+    print("""
         with cs as temp_cs:
             temp_cs.add(condition)
             self.assertTrue(solver.check(temp_cs))
         with cs as temp_cs:
             temp_cs.add(condition == False)
             self.assertFalse(solver.check(temp_cs))
-          """
+          """)
 
-print """
+print("""
 if __name__ == '__main__':
     unittest.main()
-"""
+""")

--- a/tests/auto/trace.py
+++ b/tests/auto/trace.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import sys
 import sys
@@ -52,8 +53,8 @@ class Gdb(subprocess.Popen):
         try:
             return long(self.correspond('x/xg %s\n'%m).split("\t")[-1].split("0x")[-1].split("\n")[0],16)
         except Exception as e:
-            print 'x/xg %s\n'%m
-            print self.correspond('x/xg %s\n'%m)
+            print('x/xg %s\n'%m)
+            print(self.correspond('x/xg %s\n'%m))
             raise e
             return 0
     def getPid(self):
@@ -61,7 +62,7 @@ class Gdb(subprocess.Popen):
     def getStack(self):
         maps = file("/proc/%s/maps"%self.correspond('info proc\n').split("\n")[0].split(" ")[-1]).read().split("\n")
         i,o = [ int(x,16) for x in maps[-3].split(" ")[0].split('-')]
-        print self.correspond('dump mem lala 0x%x 0x%x\n'%(i,o))
+        print(self.correspond('dump mem lala 0x%x 0x%x\n'%(i,o)))
     def getByte(self, m):
         arch = self.get_arch()
         mask = {'i386': 0xffffffff, 'amd64': 0xffffffffffffffff}[arch]
@@ -82,7 +83,7 @@ class Gdb(subprocess.Popen):
             self._arch = 'amd64'
             return 'amd64'
         else:
-            print infotarget
+            print(infotarget)
             raise NotImplementedError()
 
 
@@ -119,11 +120,11 @@ while True:
     try:
         stepped = False
         pc = gdb.getR({'i386': 'EIP', 'amd64': 'RIP'}[arch]) 
-        print hex(pc)
+        print(hex(pc))
         gdb.stepi()
-        print gdb.correspond('info registers\n')
+        print(gdb.correspond('info registers\n'))
     except Exception as e:
-        print e
-print "# Processed %d instructions." % count
+        print(e)
+print("# Processed %d instructions." % count)
 
 

--- a/tests/test_armv7_bitwise.py
+++ b/tests/test_armv7_bitwise.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 
 from manticore.core.cpu import bitwise
@@ -24,7 +25,7 @@ class BitwiseTest(unittest.TestCase):
     def test_lsl_carry(self):
         val = 0x80000000
         result, carry = bitwise.LSL_C(val, 1, 32)
-        print hex(result), "", hex(carry)
+        print(hex(result), "", hex(carry))
         self.assertEqual(result, 0)
         self.assertEqual(carry , 1)
 
@@ -55,14 +56,14 @@ class BitwiseTest(unittest.TestCase):
     def test_ror_nocarry(self):
         val = 0x00F0
         result, carry = bitwise.ROR_C(val, 4, 32)
-        print hex(result)
+        print(hex(result))
         self.assertEqual(result, 0xF)
         self.assertEqual(carry, 0)
 
     def test_ror_carry(self):
         val = 0x0003
         result, carry = bitwise.ROR_C(val, 1, 32)
-        print hex(result)
+        print(hex(result))
         self.assertEqual(result, 0x80000001)
         self.assertEqual(carry, 1)
 
@@ -75,7 +76,7 @@ class BitwiseTest(unittest.TestCase):
     def test_rrx_carry(self):
         val = 0x0001
         result, carry = bitwise.RRX_C(val, 1, 32)
-        print hex(result)
+        print(hex(result))
         self.assertEqual(result, 0x80000000)
         self.assertEqual(carry, 1)
 

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
 import struct
 import unittest
 from manticore.core.cpu.x86 import *
 from manticore.core.smtlib import Operators
 from manticore.core.memory import *
-import mockmem
+from . import mockmem
+from functools import reduce
 
 class ROOperand(object):
     ''' Mocking class for operand ronly '''

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import
 import struct
 import unittest
 from manticore.core.cpu.x86 import *
 from manticore.core.smtlib import Operators
 from manticore.core.memory import *
-from . import mockmem
+import mockmem
 from functools import reduce
 
 class ROOperand(object):

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import struct
 import unittest
 from manticore.core.cpu.x86 import *
 from manticore.core.smtlib import Operators
 from manticore.core.memory import *
-import mockmem
+from tests import mockmem
 from functools import reduce
 
 class ROOperand(object):

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import shutil
 import struct
 import tempfile
@@ -384,12 +385,12 @@ class EthTests(unittest.TestCase):
                         func_name, args = ABI.parse("is_symbolic(uint256)", state.platform.current_transaction.data)
                         try:
                             arg = to_constant(args[0])
-                        except Exception,e:
+                        except Exception as e:
                             raise Return(TRUE)
                         raise Return(FALSE)
                     elif func_id == ABI.make_function_id("shutdown(string)"):
                         func_name, args = ABI.parse("shutdown(string)", state.platform.current_transaction.data)
-                        print "Shutdown", to_constant(args[0])
+                        print("Shutdown", to_constant(args[0]))
                         self.manticore.shutdown()
                     elif func_id == ABI.make_function_id("can_be_true(bool)"):
                         func_name, args = ABI.parse("can_be_true(bool)", state.platform.current_transaction.data)

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import errno
 import shutil
@@ -76,7 +77,7 @@ class LinuxTest(unittest.TestCase):
 
         # open a file
         filename = platform.current.push_bytes('/bin/true\x00')
-        fd = platform.sys_open(filename, os.O_RDONLY, 0600)
+        fd = platform.sys_open(filename, os.O_RDONLY, 0o600)
 
         stat = platform.current.SP - 0x100
         platform.current.R0 = fd
@@ -86,7 +87,7 @@ class LinuxTest(unittest.TestCase):
 
         platform.syscall()
 
-        print ''.join(platform.current.read_bytes(stat, 100)).encode('hex')
+        print(''.join(platform.current.read_bytes(stat, 100)).encode('hex'))
 
     def test_linux_workspace_files(self):
         platform = self.symbolic_linux
@@ -126,7 +127,7 @@ class LinuxTest(unittest.TestCase):
         platform.current.subscribe('did_execute_instruction', r.did_exec)
 
         filename = platform.current.push_bytes('/bin/true\x00')
-        fd = platform.sys_open(filename, os.O_RDONLY, 0600)
+        fd = platform.sys_open(filename, os.O_RDONLY, 0o600)
 
         stat = platform.current.SP - 0x100
         platform.current.R0 = fd
@@ -157,14 +158,14 @@ class LinuxTest(unittest.TestCase):
 
         # open a file + directory
         dirname = platform.current.push_bytes(dir_path+'\x00')
-        dirfd = platform.sys_open(dirname, os.O_RDONLY, 0700)
+        dirfd = platform.sys_open(dirname, os.O_RDONLY, 0o700)
         filename = platform.current.push_bytes(file_name+'\x00')
 
         stat = platform.current.SP - 0x100
         platform.current.R0 = dirfd
         platform.current.R1 = filename
         platform.current.R2 = os.O_RDONLY
-        platform.current.R3 = 0700
+        platform.current.R3 = 0o700
         platform.current.R7 = nr_openat
         self.assertEquals(linux_syscalls.armv7[nr_openat], 'sys_openat')
 


### PR DESCRIPTION
print statements, octal literals, and various small changes to support identical calling between py2 and py3. Plus a few missed exception syntax, etc. There will surely be more...

refs #904 

(This may not pass until it gets rebased against #907 but if it does then it's good to review/merge)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/908)
<!-- Reviewable:end -->
