### PR TITLE
Incremental Linting

### DIFF
--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,3 +1,3 @@
-from .manticore import Manticore
-from .models import variadic
-from .utils.helpers import issymbolic
+from .manticore import Manticore # noqa
+from .models import variadic # noqa
+from .utils.helpers import issymbolic # noqa

--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,3 +1,3 @@
-from .manticore import Manticore # noqa
-from .models import variadic # noqa
-from .utils.helpers import issymbolic # noqa
+from .manticore import Manticore  # noqa
+from .models import variadic  # noqa
+from .utils.helpers import issymbolic  # noqa

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -121,7 +121,7 @@ def main():
 
     env = {key: val for key, val in map(lambda env: env[0].split('='), args.env)}
 
-    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace,  policy=args.policy, disasm=args.disasm, concrete_start=args.data)
+    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, disasm=args.disasm, concrete_start=args.data)
 
     # Fixme(felipe) remove this, move to plugin
     m.coverage_file = args.coverage

--- a/manticore/binary/__init__.py
+++ b/manticore/binary/__init__.py
@@ -14,6 +14,8 @@ But there are difference between format that makes it difficult to find a simple
 and common API.  interpreters? linkers? linked DLLs?
 
 '''
+from elftools.elf.elffile import ELFFile
+import StringIO
 
 
 class Binary(object):
@@ -38,10 +40,6 @@ class Binary(object):
 
     def threads(self):
         pass
-
-
-from elftools.elf.elffile import ELFFile
-import StringIO
 
 
 class CGCElf(Binary):

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -6,14 +6,11 @@ import string
 from functools import wraps
 from itertools import islice, imap
 
-import capstone as cs
 import unicorn
 
 from .disasm import init_disassembler
-from ..smtlib import Expression, Bool, BitVec, Array, Operators, Constant
-from ..memory import (
-    ConcretizeMemory, InvalidMemoryAccess, MemoryException, FileMap, AnonMap
-)
+from ..smtlib import BitVec, Operators, Constant
+from ..memory import ConcretizeMemory, InvalidMemoryAccess
 from ...utils.helpers import issymbolic
 from ...utils.emulate import UnicornEmulator
 from ...utils.event import Eventful
@@ -27,6 +24,7 @@ register_logger = logging.getLogger('{}.registers'.format(__name__))
 
 class CpuException(Exception):
     ''' Base cpu exception '''
+
 
 class DecodeException(CpuException):
     '''

--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -7,13 +7,12 @@ import capstone as cs
 
 from .abstractcpu import (
     Abi, SyscallAbi, Cpu, RegisterFile, Operand, instruction,
-    ConcretizeRegister, ConcretizeRegister, ConcretizeArgument, Interruption,
-    Syscall, DivideByZeroError
+    ConcretizeRegister, Interruption, Syscall, DivideByZeroError
 )
 
 
 from ..smtlib import Operators, BitVec, Bool, BitVecConstant, operator, visitors
-from ..memory import MemoryException, ConcretizeMemory
+from ..memory import ConcretizeMemory
 from ...utils.helpers import issymbolic
 from functools import reduce
 
@@ -606,6 +605,7 @@ class AMD64RegFile(RegisterFile):
 
     def sizeof(self, reg):
         return self._table[reg].size
+
 
 # Operand Wrapper
 class AMD64Operand(Operand):

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -6,7 +6,7 @@ import signal
 
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils.event import Eventful
-from .smtlib import solver, Z3Solver, Expression, SolverException
+from .smtlib import Z3Solver, Expression, SolverException
 from .state import Concretize, TerminateState
 
 from .workspace import Workspace

--- a/manticore/core/parser/parser.py
+++ b/manticore/core/parser/parser.py
@@ -1,7 +1,7 @@
 # Minimal INTEL assembler expression calculator
 import ply.yacc as yacc
 import copy
-from ..smtlib import Operators, Bool
+from ..smtlib import Operators
 # Lexer
 # ------------------------------------------------------------
 # calclex.py

--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -371,10 +371,6 @@ class ExamplePlugin(Plugin):
     def did_finish_run_callback(self):
         logger.info('did_finish_run')
 
-    def did_enqueue_state_callback(self, state_id, state):
-        ''' state was just got enqueued in the executor procesing list'''
-        logger.info('did_enqueue_state %r %r', state_id, state)
-
     def will_fork_state_callback(self, parent_state, expression, solutions, policy):
         logger.info('will_fork_state %r %r %r %r', parent_state, expression, solutions, policy)
 

--- a/manticore/core/smtlib/__init__.py
+++ b/manticore/core/smtlib/__init__.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import # noqa
-from .expression import Expression, Bool, BitVec, Array # noqa
-from .constraints import ConstraintSet # noqa
-from .solver import * # noqa
-from . import operators as Operators # noqa
+from __future__ import absolute_import  # noqa
+from .expression import Expression, Bool, BitVec, Array  # noqa
+from .constraints import ConstraintSet  # noqa
+from .solver import *  # noqa
+from . import operators as Operators  # noqa
 
 
 import logging

--- a/manticore/core/smtlib/__init__.py
+++ b/manticore/core/smtlib/__init__.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import
-from .expression import Expression, Bool, BitVec, Array
-from .constraints import ConstraintSet
-from .solver import *
-from . import operators as Operators
+from __future__ import absolute_import # noqa
+from .expression import Expression, Bool, BitVec, Array # noqa
+from .constraints import ConstraintSet # noqa
+from .solver import * # noqa
+from . import operators as Operators # noqa
 
 
 import logging

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from .expression import BitVecVariable, BoolVariable, ArrayVariable, Array, Bool, BitVec, BoolConstant, ArrayProxy, BoolEq, Variable, Constant
-from .visitors import GetDeclarations, TranslatorSmtlib, PrettyPrinter, pretty_print, translate_to_smtlib, get_depth, get_variables, simplify, replace
+from .visitors import GetDeclarations, TranslatorSmtlib, get_variables, simplify, replace
 import logging
 
 logger = logging.getLogger(__name__)

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -721,10 +721,6 @@ class ArraySlice(Array):
         return self._array.value_bits
 
     @property
-    def value_bits(self):
-        return self._array.value_bits
-
-    @property
     def taint(self):
         return self._array.taint
 
@@ -807,7 +803,7 @@ class ArrayProxy(Array):
             index = self.cast_index(index)
         if not isinstance(value, Expression):
             value = self.cast_value(value)
-        from manticore.core.smtlib.visitors import simplify, translate_to_smtlib
+        from manticore.core.smtlib.visitors import simplify
         index = simplify(index)
         if isinstance(index, Constant):
             self._concrete_cache[index.value] = value

--- a/manticore/core/smtlib/operators.py
+++ b/manticore/core/smtlib/operators.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
-from .expression import *
+from .expression import (
+    BitVec, BitVecExtract, BitVecSignExtend, BitVecZeroExtend, BitVecConstant, BitVecConcat, Bool, BitVecITE, BoolConstant, BoolITE
+)
 from ...utils.helpers import issymbolic, istainted
 import math
 

--- a/manticore/core/smtlib/operators.py
+++ b/manticore/core/smtlib/operators.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from .expression import (
     BitVec, BitVecExtract, BitVecSignExtend, BitVecZeroExtend, BitVecConstant, BitVecConcat, Bool, BitVecITE, BoolConstant, BoolITE
 )
-from ...utils.helpers import issymbolic, istainted
+from ...utils.helpers import issymbolic
 import math
 
 
@@ -219,16 +219,6 @@ def UDIV(dividend, divisor):
         return divisor.rudiv(dividend)
     assert dividend >= 0 or divisor > 0  # unsigned-es
     return dividend / divisor
-
-
-def UREM(a, b):
-    if isinstance(a, BitVec):
-        return a.urem(b)
-    if isinstance(b, BitVec):
-        return b.rurem(a)
-    if a < 0 or b < 0:
-        raise "azaraza"
-    return a % b
 
 
 def SDIV(a, b):

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -22,7 +22,7 @@ import logging
 import re
 import time
 from .visitors import *
-from ...utils.helpers import issymbolic, istainted, memoized
+from ...utils.helpers import issymbolic
 import collections
 
 logger = logging.getLogger(__name__)

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -141,12 +141,6 @@ class GetDeclarations(Visitor):
         return self.variables
 
 
-def get_variables(expression):
-    visitor = GetDeclarations()
-    visitor.visit(expression)
-    return visitor.result
-
-
 class GetDepth(Visitor):
     ''' Simple visitor to collect all variables in an expression or set of
         expressions

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-from .smtlib import solver, Bool, ArrayProxy, Array
+from .smtlib import solver, Bool
 from ..utils.helpers import issymbolic
 from ..utils.event import Eventful
 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -4,7 +4,7 @@ import re
 import os
 from . import Manticore
 from .manticore import ManticoreError
-from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, istainted, Array, Expression, Constant, operators
+from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, istainted, Constant, operators
 from .core.smtlib.visitors import simplify
 from .core.plugin import FilterFunctions
 from .platforms import evm
@@ -28,12 +28,6 @@ logger = logging.getLogger(__name__)
 
 class EthereumError(ManticoreError):
     pass
-
-
-class DependencyError(EthereumError):
-    def __init__(self, lib_names):
-        super(DependencyError, self).__init__("You must pre-load and provide libraries addresses{ libname:address, ...} for %r" % lib_names)
-        self.lib_names = lib_names
 
 
 class DependencyError(EthereumError):
@@ -454,7 +448,7 @@ class ABI(object):
     @staticmethod
     def get_uint(data, nbytes, offset):
         """
-        Read a `nbytes` bytes long big endian unsigned integer from `data` starting at `offset` 
+        Read a `nbytes` bytes long big endian unsigned integer from `data` starting at `offset`
 
         :param data: sliceable buffer; symbolic buffer of Eth ABI encoded data
         :param offset: byte offset
@@ -673,7 +667,7 @@ class ManticoreEVM(Manticore):
             #Initialize user and contracts
             user_account = m.create_account(balance=1000)
             contract_account = m.solidity_create_contract(source_code, owner=user_account, balance=0)
-            contract_account.set(12345, value=100) 
+            contract_account.set(12345, value=100)
 
             seth.report()
             print seth.coverage(contract_account)
@@ -803,7 +797,7 @@ class ManticoreEVM(Manticore):
 
             :param source_code: solidity source as either a string or a file handle
             :param contract_name: a string with the name of the contract to analyze
-            :param libraries: an itemizable of pairs (library_name, address) 
+            :param libraries: an itemizable of pairs (library_name, address)
             :return: name, source_code, bytecode, srcmap, srcmap_runtime, hashes
             :return: name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi, warnings
         """

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -4,11 +4,12 @@ import re
 import os
 from . import Manticore
 from .manticore import ManticoreError
-from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, istainted, Constant, operators
+from .core.smtlib import ConstraintSet, Operators, solver, Constant, operators
 from .core.smtlib.visitors import simplify
 from .core.plugin import FilterFunctions
 from .platforms import evm
 from .core.state import State
+from .utils.helpers import istainted, issymbolic
 import tempfile
 from subprocess import Popen, PIPE, check_output
 from multiprocessing import Process, Queue

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -44,7 +44,7 @@ def make_binja(program, disasm, argv, env, symbolic_files, concrete_start=''):
     def _check_disassembler_present(disasm):
         if is_binja_disassembler(disasm):
             try:
-                import binaryninja
+                import binaryninja # noqa
             except ImportError:
                 err = ("BinaryNinja not found! You MUST own a BinaryNinja version"
                        " that supports GUI-less processing for this option"
@@ -72,7 +72,7 @@ def make_decree(program, concrete_start='', **kwargs):
     if concrete_start != '':
         logger.info('Starting with concrete input: {}'.format(concrete_start))
     platform.input.transmit(concrete_start)
-    platform.input.transmit(initial_state.symbolicate_buffer('+'*14, label='RECEIVE'))
+    platform.input.transmit(initial_state.symbolicate_buffer('+' * 14, label='RECEIVE'))
     return initial_state
 
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -44,7 +44,7 @@ def make_binja(program, disasm, argv, env, symbolic_files, concrete_start=''):
     def _check_disassembler_present(disasm):
         if is_binja_disassembler(disasm):
             try:
-                import binaryninja # noqa
+                import binaryninja  # noqa
             except ImportError:
                 err = ("BinaryNinja not found! You MUST own a BinaryNinja version"
                        " that supports GUI-less processing for this option"

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -382,10 +382,6 @@ class Manticore(Eventful):
 
     @property
     def running(self):
-        return self._executor._running.value
-
-    @property
-    def running(self):
         return self._executor.running
 
     def enqueue(self, state):
@@ -502,7 +498,6 @@ class Manticore(Eventful):
 
         # Imported straight from __main__.py; this will be re-written once the new
         # event code is in place.
-        from .core import cpu
         import importlib
         from . import platforms
 
@@ -708,8 +703,6 @@ class Manticore(Eventful):
         self._coverage_file = path
 
     def _did_finish_run_callback(self):
-        _shared_context = self.context
-
         with self._output.save_stream('command.sh') as f:
             f.write(' '.join(sys.argv))
 

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from . import cgcrandom
 # TODO use cpu factory
 from ..core.cpu.x86 import I386Cpu
-from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeRegister
+from ..core.cpu.abstractcpu import Interruption, ConcretizeRegister
 from ..core.memory import SMemory32
 from ..core.smtlib import *
 from ..core.executor import TerminateState

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1,16 +1,14 @@
 ''' Symbolic EVM implementation based on the yellow paper: http://gavwood.com/paper.pdf '''
-import time
 import random
 import copy
 import inspect
 from functools import wraps
 from ..utils.helpers import issymbolic, memoized
 from ..platforms.platform import *
-from ..core.smtlib import solver, TooManySolutions, Expression, Bool, BitVec, Array, Operators, Constant, BitVecConstant, ConstraintSet, SolverException
-from ..core.state import ForkState, TerminateState
-from ..utils.event import Eventful
-from ..core.smtlib.visitors import pretty_print, translate_to_smtlib, simplify
+from ..core.smtlib import solver, BitVec, Array, Operators, Constant
 from ..core.state import Concretize, TerminateState
+from ..utils.event import Eventful
+from ..core.smtlib.visitors import simplify
 import logging
 import sys
 from collections import namedtuple
@@ -355,11 +353,6 @@ class EVMAsm(object):
         def writes_to_stack(self):
             ''' True if the instruction writes to the stack '''
             return self.pushes > 0
-
-        @property
-        def reads_from_memory(self):
-            ''' True if the instruction reads from memory '''
-            return self.semantics in ('MLOAD', 'CREATE', 'CALL', 'CALLCODE', 'RETURN', 'DELEGATECALL', 'REVERT')
 
         @property
         def writes_to_memory(self):
@@ -2205,10 +2198,6 @@ class EVMWorld(Platform):
     @property
     def logs(self):
         return self._logs
-
-    @property
-    def deleted_accounts(self):
-        return self._deleted_accounts
 
     @property
     def constraints(self):

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -15,7 +15,6 @@ from elftools.elf.descriptions import describe_symbol_type
 
 from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeArgument
 from ..core.cpu.cpufactory import CpuFactory
-from ..core.cpu.binja import BinjaCpu
 from ..core.memory import SMemory32, SMemory64, Memory32, Memory64
 from ..core.smtlib import Operators, ConstraintSet, SolverException, solver
 from ..core.cpu.arm import *

--- a/manticore/platforms/platform.py
+++ b/manticore/platforms/platform.py
@@ -1,5 +1,5 @@
-
 from manticore.utils.event import Eventful
+
 
 class OSException(Exception):
     pass

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -1,6 +1,6 @@
 import logging
 
-from ..core.memory import MemoryException, FileMap, AnonMap
+from ..core.memory import MemoryException
 
 from .helpers import issymbolic
 ######################################################################

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 from ..core.smtlib import Expression
 
 
@@ -26,9 +27,6 @@ def istainted(arg, taint=None):
     if taint is None:
         return len(arg.taint) != 0
     return taint in arg.taint
-
-
-import functools
 
 
 class memoized(object):

--- a/manticore/utils/iterpickle.py
+++ b/manticore/utils/iterpickle.py
@@ -33,6 +33,7 @@ import marshal
 import sys
 import struct
 import re
+import binascii as _binascii
 
 __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
            "Unpickler", "dump", "dumps", "load", "loads"]
@@ -1284,9 +1285,6 @@ class _EmptyClass:
     pass
 
 # Encode/decode longs in linear time.
-
-
-import binascii as _binascii
 
 
 def encode_long(x):

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,14 @@ from setuptools import setup, find_packages
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
+
 def rtd_dependent_deps():
     # RTD tries to build z3, ooms, and fails to build.
     if on_rtd:
         return []
     else:
         return []
+
 
 setup(
     name='manticore',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,18 @@ deps = .[dev]
 commands = nosetests
 install_command = pip install --no-binary keystone-engine {opts} {packages}
 
+[testenv:pep8]
+basepython = python2.7
+deps = flake8
+commands =
+    flake8 .
+
 [pep8]
 ignore = E265,E501
 max-line-length = 160
 exclude = docs/,examples/,scripts/,tests/
+
+[flake8]
+ignore = E265,E501
+max-line-length = 160
+exclude = .tox,.*.egg,.git,docs/,examples/,scripts/,tests/

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,6 @@ max-line-length = 160
 exclude = docs/,examples/,scripts/,tests/
 
 [flake8]
-ignore = E265,E501
+ignore = E265,E501,F403,F405,E266,E712,F841,E741,E722,E731
 max-line-length = 160
 exclude = .tox,.*.egg,.git,docs/,examples/,scripts/,tests/


### PR DESCRIPTION
This is the beginning of getting to a lint-clean codebase (As discussed here: https://github.com/trailofbits/manticore/pull/904#issuecomment-393189013). The flake8 configuration I used has been added to the `tox.ini`, but there are a few caveats:

* We're not clean even under this restricted set at the moment. Some of that is because we're not done, but some of it appears to be code that may not actually work right now and hasn't been caught since it isn't tested. We'll have to figure that out later.
* Many of the disabled checks should be re-enabled eventually, but we'll fix those in future PRs.
* No linting has been performed against the scripts or tests (for now).

So what was actually done in this PR?

* Several duplicate function/class definitions were removed.
* Imports in `__init__` were marked as `# noqa` to tell the linter to ignore them even though they are not "used". We may consider switching to exporting them via `__all__` so that we explicitly handle the case where someone types `from package import *` in the future.
* Various new lines were added and spacing/whitespace was changed.
* Unused imports were removed.
* A few unused variables were removed (although not all of them, the linter has that check disabled for now as there are quite a few instances of that).
* Imports at module scope were hoisted to the top of the module.


Once we can get to a point where we're actually lint clean we should update the docs around linting and turn on a gate. That may take the form of the codeclimate config or possibly a second travis job that just runs `tox -e pep8`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/911)
<!-- Reviewable:end -->
