### PR TITLE
Fix pos CALL/DELEGATECALL/STATICCALL/CALLCODE

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1932,7 +1932,6 @@ class EVM(Eventful):
 
         return self.world.last_transaction.return_value
 
-
     @transact
     @concretized_args(in_offset='SAMPLED', in_size='SAMPLED')
     def CALLCODE(self, gas, _ignored_, value, in_offset, in_size, out_offset, out_size):
@@ -1981,8 +1980,6 @@ class EVM(Eventful):
             self.write_buffer(out_offset, data[:size])
 
         return self.world.last_transaction.return_value
-
-
 
     @transact
     @concretized_args(in_offset='SAMPLED', in_size='SAMPLED')

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1924,14 +1924,14 @@ class EVM(Eventful):
 
     @CALL.pos
     def CALL(self, gas, address, value, in_offset, in_size, out_offset, out_size):
-        data = self.world.current_transaction.return_data
-
+        data = self.world.last_transaction.return_data
         if data is not None:
             data_size = len(data)
             size = Operators.ITEBV(256, Operators.ULT(out_size, data_size), out_size, data_size)
-            self.current_vm.write_buffer(out_offset, data[:size])
+            self.write_buffer(out_offset, data[:size])
 
         return self.world.last_transaction.return_value
+
 
     @transact
     @concretized_args(in_offset='SAMPLED', in_size='SAMPLED')
@@ -1945,14 +1945,13 @@ class EVM(Eventful):
                                      gas=self.gas)
         raise StartTx()
 
-    @CALL.pos
-    def CALLCODE(self, gas, _ignored_, value, in_offset, in_size, out_offset, out_size):
-        data = self.world.current_transaction.return_data
-
+    @CALLCODE.pos
+    def CALLCODE(self, gas, address, value, in_offset, in_size, out_offset, out_size):
+        data = self.world.last_transaction.return_data
         if data is not None:
             data_size = len(data)
             size = Operators.ITEBV(256, Operators.ULT(out_size, data_size), out_size, data_size)
-            self.current_vm.write_buffer(out_offset, data[:size])
+            self.write_buffer(out_offset, data[:size])
 
         return self.world.last_transaction.return_value
 
@@ -1975,20 +1974,21 @@ class EVM(Eventful):
 
     @DELEGATECALL.pos
     def DELEGATECALL(self, gas, address, in_offset, in_size, out_offset, out_size):
-        data = self.world.current_transaction.return_data
-
+        data = self.world.last_transaction.return_data
         if data is not None:
             data_size = len(data)
             size = Operators.ITEBV(256, Operators.ULT(out_size, data_size), out_size, data_size)
-            self.current_vm.write_buffer(out_offset, data[:size])
+            self.write_buffer(out_offset, data[:size])
 
         return self.world.last_transaction.return_value
+
+
 
     @transact
     @concretized_args(in_offset='SAMPLED', in_size='SAMPLED')
     def STATICCALL(self, gas, address, in_offset, in_size, out_offset, out_size):
         '''Message-call into an account'''
-        self.world.start_transaction('DELEGATECALL',
+        self.world.start_transaction('STATICCALL',
                                      address,
                                      data=self.read_buffer(in_offset, in_size),
                                      caller=self.address,
@@ -1998,12 +1998,11 @@ class EVM(Eventful):
 
     @STATICCALL.pos
     def STATICCALL(self, gas, address, in_offset, in_size, out_offset, out_size):
-        data = self.world.current_transaction.return_data
-
+        data = self.world.last_transaction.return_data
         if data is not None:
             data_size = len(data)
             size = Operators.ITEBV(256, Operators.ULT(out_size, data_size), out_size, data_size)
-            self.current_vm.write_buffer(out_offset, data[:size])
+            self.write_buffer(out_offset, data[:size])
 
         return self.world.last_transaction.return_value
 


### PR DESCRIPTION
Fixes issue #912. Recursive calls now work.
```from manticore.ethereum import ManticoreEVM

m = ManticoreEVM(workspace_url="bug")
m.verbosity(3)
owner_account = m.create_account(balance=1000)

c = '''
contract C1 { 
  function f() returns (uint) {
    return 1;
  }
}

contract C2 { 
  address c;
  function C2(address x) {
    c = x;
  }
  function f() returns (uint) {
    return C1(c).f();
  }
}
'''

c1 = m.solidity_create_contract(c, owner=owner_account, contract_name='C1')
c2 = m.solidity_create_contract(c, owner=owner_account, contract_name='C2', args=[c1.address])
c2.f();
c2.f();```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/917)
<!-- Reviewable:end -->
