### PR TITLE
Use p.communicate() to read stdout and stderr

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -915,11 +915,11 @@ class ManticoreEVM(Manticore):
             filename
         ]
         p = Popen(solc_invocation, stdout=PIPE, stderr=PIPE, cwd=working_folder)
-        with p.stdout as stdout, p.stderr as stderr:
-            try:
-                return json.loads(stdout.read()), stderr.read()
-            except ValueError:
-                raise Exception('Solidity compilation error:\n\n{}'.format(stderr.read()))
+        stdout, stderr = p.communicate()
+        try:
+            return json.loads(stdout), stderr
+        except ValueError:
+            raise Exception('Solidity compilation error:\n\n{}'.format(stderr))
 
     @staticmethod
     def _compile(source_code, contract_name, libraries=None):


### PR DESCRIPTION
Use communicate() instead of `stdout.read` and `stderr.read`, as they can result in deadlocks. This can occur if manticore tries to compile a solidity contract that has enough errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/920)
<!-- Reviewable:end -->
