### PR TITLE
Fix z3 install regression

### DIFF
--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -8,6 +8,5 @@ function install_solc {
 install_solc
 
 pip install -U pip
-pip install -U z3-solver
 pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 pip install --no-binary keystone-engine -e .[dev]  # ks can have pip install issues

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def rtd_dependent_deps():
     if on_rtd:
         return []
     else:
-        return []
+        return ['z3-solver']
 
 
 setup(


### PR DESCRIPTION
#843 accidentally removed the z3-solver dependency from our setup.py. This PR adds it back, and removes the manual install line that was added.

https://github.com/trailofbits/manticore/pull/843/files#diff-2eeaed663bd0d25b7e608891384b7298R11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/923)
<!-- Reviewable:end -->
