### PR TITLE
Generate symbolic file testcases

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -62,13 +62,11 @@ class File(object):
         # read/write to the state
         mode = mode_from_flags(flags)
         self.file = file(path, mode)
-        self.path = path
 
     def __getstate__(self):
         state = {}
         state['name'] = self.name
         state['mode'] = self.mode
-        state['path'] = self.path
         try:
             state['pos'] = self.tell()
         except IOError:
@@ -81,7 +79,6 @@ class File(object):
         mode = state['mode']
         pos = state['pos']
         self.file = file(name, mode)
-        self.path = state['path']
         if pos is not None:
             self.seek(pos)
 
@@ -2718,6 +2715,6 @@ class SLinux(Linux):
                 continue
             fdata = StringIO.StringIO()
             solve_to_fd(f.array, fdata)
-            ret[f.path] = fdata.getvalue()
+            ret[f.name] = fdata.getvalue()
 
         return ret

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1426,7 +1426,7 @@ class Linux(Platform):
             logger.debug("Opening file %s for real fd %d",
                          filename, f.fileno())
         except IOError as e:
-            logger.info("Could not open file %s. Reason: %s", filename, str(e))
+            logger.warning("Could not open file %s. Reason: %s", filename, str(e))
             return -e.errno if e.errno is not None else -errno.EINVAL
 
         return self._open(f)


### PR DESCRIPTION
When manticore generates a testcase, it creates workspace files with concrete input, for example for stdin. It should do this for input coming from symbolic files, but it didn't used to -- this PR adds it.

Also corrects a bug where the `__getstate__/__setstate__` methods of SymbolicFile didn't call the parent methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/928)
<!-- Reviewable:end -->
