### PR TITLE
Add UTXH to arm instructions

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -754,7 +754,7 @@ class Armv7Cpu(Cpu):
 
         :param ARMv7Operand dest: the destination register; register
         :param ARMv7Operand dest: the source register; register
-        :param int src_width: bit to consider of the src operand
+        :param int src_width: bits to consider of the src operand
         """
         val = GetNBits(src.read(), src_width)
         word = Operators.ZEXTEND(val, cpu.address_bit_size)

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -748,6 +748,18 @@ class Armv7Cpu(Cpu):
         status.write(0)
         return cpu._STR(cpu.address_bit_size, *args)
 
+    def _UXT(cpu, dest, src, src_width):
+        """
+        Helper for UXT* family of instructions.
+
+        :param ARMv7Operand dest: the destination register; register
+        :param ARMv7Operand dest: the source register; register
+        :param int src_width: bit to consider of the src operand
+        """
+        val = GetNBits(src.read(), src_width)
+        word = Operators.ZEXTEND(val, cpu.address_bit_size)
+        dest.write(word)
+
     @instruction
     def UXTB(cpu, dest, src):
         """
@@ -757,9 +769,7 @@ class Armv7Cpu(Cpu):
         :param ARMv7Operand dest: the destination register; register
         :param ARMv7Operand dest: the source register; register
         """
-        val = GetNBits(src.read(), 8)
-        word = Operators.ZEXTEND(val, cpu.address_bit_size)
-        dest.write(word)
+        cpu._UXT(dest, src, 8)
 
     @instruction
     def UXTH(cpu, dest, src):
@@ -770,9 +780,7 @@ class Armv7Cpu(Cpu):
         :param ARMv7Operand dest: the destination register; register
         :param ARMv7Operand dest: the source register; register
         """
-        val = GetNBits(src.read(), 16)
-        word = Operators.ZEXTEND(val, cpu.address_bit_size)
-        dest.write(word)
+        cpu._UXT(dest, src, 16)
 
     @instruction
     def PLD(cpu, addr, offset=None):

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -762,6 +762,19 @@ class Armv7Cpu(Cpu):
         dest.write(word)
 
     @instruction
+    def UXTH(cpu, dest, src):
+        """
+        UXTH extracts an 16-bit value from a register, zero-extends
+        it to the size of the register, and writes the result to the destination register.
+
+        :param ARMv7Operand dest: the destination register; register
+        :param ARMv7Operand dest: the source register; register
+        """
+        val = GetNBits(src.read(), 16)
+        word = Operators.ZEXTEND(val, cpu.address_bit_size)
+        dest.write(word)
+
+    @instruction
     def PLD(cpu, addr, offset=None):
         """PLD instructs the cpu that the address at addr might be loaded soon."""
 

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -1605,6 +1605,12 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.cpu.R2, 0x55555555)
         self.assertEqual(self.cpu.R1, 0x55)
 
+    @itest_setregs("R1=0x45", "R2=0x55555555")
+    @itest("uxth r1, r2")
+    def test_uxth(self):
+        self.assertEqual(self.cpu.R2, 0x55555555)
+        self.assertEqual(self.cpu.R1, 0x5555)
+
     @itest_setregs("R1=1","R2=0","R3=0","R4=0","R12=0x4141")
     @itest_thumb_multiple(["cmp r1, #1", "itt ne", "mov r2, r12", "mov r3, r12", "mov r4, r12"])
     def test_itt_ne_noexec(self):


### PR DESCRIPTION
Same as utxb but with halfword instead of byte

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/935)
<!-- Reviewable:end -->
