### PR TITLE
Allow users to specify path to solc and solc import remappings

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1411,7 +1411,7 @@ class ManticoreEVM(Manticore):
         # FIXME this is more naive than reasonable.
         return ABI.deserialize(types, self.make_symbolic_buffer(32, name="INITARGS"))
 
-    def solidity_create_contract(self, source_code, owner, contract_name=None, libraries=None, balance=0, address=None, args=(), solc_bin=None, solc_remaps=[]):
+    def solidity_create_contract(self, source_code, owner, name=None, contract_name=None, libraries=None, balance=0, address=None, args=(), solc_bin=None, solc_remaps=[]):
         ''' Creates a solidity contract and library dependencies
 
             :param str source_code: solidity source code

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -53,7 +53,7 @@ class EthDetectorsTest(unittest.TestCase):
         """
         arguments = [1 << 248, self.state.new_symbolic_value(256)]
         self.state.constrain(operators.ULT(arguments[1], 256))
-        
+
         cond = self.io._unsigned_mul_overflow(self.state, *arguments)
         check = self.state.can_be_true(cond)
         self.assertFalse(check)
@@ -518,5 +518,37 @@ class EthSolidityCompilerTest(unittest.TestCase):
                 source_list = output.get('sourceList', [])
                 self.assertIn(os.path.split(a.name)[-1], source_list)
                 self.assertIn(os.path.split(b.name)[-1], source_list)
+        finally:
+            shutil.rmtree(d)
+
+
+    def test_run_solc_with_remappings(self):
+        source_a = '''
+        import "test/B.sol";
+        contract A {
+            function callB(B _b) public { _b.fromA(); }
+            function fromB() public { revert(); }
+        }
+        '''
+        source_b = '''
+        import "../A.sol";
+        contract B {
+            function callA(A _a) public { _a.fromB(); }
+            function fromA() public { revert(); }
+        }
+        '''
+        d = tempfile.mkdtemp()
+        lib_dir = os.path.join(d, 'lib')
+        os.makedirs(lib_dir)
+        try:
+            with open(os.path.join(d, 'A.sol'), 'w') as a, open(os.path.join(lib_dir, 'B.sol'), 'w') as b:
+                a.write(source_a)
+                a.flush()
+                b.write(source_b)
+                b.flush()
+                output, warnings = ManticoreEVM._run_solc(a, solc_remaps=['test=lib'])
+                source_list = output.get('sourceList', [])
+                self.assertIn("A.sol", source_list)
+                self.assertIn("lib/B.sol", source_list)
         finally:
             shutil.rmtree(d)


### PR DESCRIPTION
This makes it possible for manticore to compile contracts that use build systems such as truffle to import external libraries such as openzeppelin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/945)
<!-- Reviewable:end -->
