### PR TITLE
Allow function identifiers on smart contract to have numbers on them

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -613,7 +613,7 @@ class ABI(object):
         '''
         Build transaction data from function signature and arguments
         '''
-        m = re.match(r"(?P<name>[a-zA-Z_][0-9]+)(?P<type>\(.*\))", type_spec)
+        m = re.match(r"(?P<name>[a-zA-Z_][a-zA-Z_0-9]*)(?P<type>\(.*\))", type_spec)
         if not m:
             raise EthereumError("Function signature expected")
 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -613,7 +613,7 @@ class ABI(object):
         '''
         Build transaction data from function signature and arguments
         '''
-        m = re.match(r"(?P<name>[a-zA-Z_]+)(?P<type>\(.*\))", type_spec)
+        m = re.match(r"(?P<name>[a-zA-Z_][0-9]+)(?P<type>\(.*\))", type_spec)
         if not m:
             raise EthereumError("Function signature expected")
 


### PR DESCRIPTION
A quick fix of the regular expression on the function signature to allow numbers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/953)
<!-- Reviewable:end -->
