### PR TITLE
Moved block hash calculation to EVMWorld and genericized it

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2462,7 +2462,7 @@ class EVMWorld(Platform):
     def block_gaslimit(self):
         return 0
 
-    def block_hash(self, block_number = None, force_recent = True):
+    def block_hash(self, block_number=None, force_recent=True):
         ''' Calculates a block's hash
             :param block_number: the block number for which to calculate the hash, defaulting to the most recent block
             :param force_recent: if True (the default) return zero for any block that is in the future or older than 256 blocks
@@ -2470,7 +2470,7 @@ class EVMWorld(Platform):
         '''
         if block_number is None:
             block_number = self.block_number() - 1
-        
+
         # We are not maintaining an actual -block-chain- so we just generate
         # some hashes for each virtual block
         value = sha3.keccak_256(repr(block_number) + 'NONCE').hexdigest()


### PR DESCRIPTION
The block hash calculation used to live within the implementation of the `BLOCKHASH` EVM opcode in the `EVM` class. This change moves that code to a new `block_hash` function in `EVMWorld` that can calculate arbitrary block hashes (not just limited to those mined within the past 256 blocks).

Fixes #957 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/958)
<!-- Reviewable:end -->
