### PR TITLE
Ethereum ABI support for bytesM and symbolic bytes

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -670,11 +670,20 @@ class ABI(object):
                 raise EthereumError('bytesM: unrecognized type <{}> for value'.format(type(value).__name__))
 
         elif ty[0] in ('bytes', 'string'):
+
             result += ABI._serialize_uint(dyn_offset)
             dyn_result += ABI._serialize_uint(len(value))
-            for byte in value:
-                dyn_result.append(byte)
-            dyn_result.extend('\0'*(32 - len(value)))
+
+            if isinstance(value, (str, bytearray)):
+                dyn_result.extend(value.ljust(32, '\0'))
+            elif isinstance(value, ArrayProxy):
+
+                dyn_result += value + bytearray('\0'*(32 - len(value)))
+
+            else:
+                raise EthereumError('bytes: unrecognized type <{}> for value'.format(type(value).__name__))
+
+
         elif ty[0] == 'function':
             result = ABI._serialize_uint(value[0], 20)
             result += value[1] + bytearray('\0' * 8)

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -682,7 +682,6 @@ class ABI(object):
             for byte in value:
                 dyn_result.append(byte)
             dyn_result.extend('\0'*(32 - len(value)))
-            # FIXME: need padding here!
         elif ty[0] == 'function':
             result = ABI._serialize_uint(value[0], 20)
             result += value[1] + bytearray('\0' * 8)

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -688,7 +688,7 @@ class ABI(object):
         :param value:
         :type value: bytearray or Array
         """
-        return value + bytearray('\0'*(32 - len(value)))
+        return value + bytearray('\0'*(32-len(value)))
 
     @staticmethod
     def _serialize_tuple(types, value, dyn_offset=None):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -670,7 +670,7 @@ class ABI(object):
                 # for sym_byte in value:
                 #     # result += sym_byte
                 #     result.append(sym_byte)
-                result += '\0'*(32 - len(value))
+                result += bytearray('\0'*(32 - len(value)))
                 # result.extend('\0'*(32 - len(value)))
 
             else:

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -652,7 +652,7 @@ class ABI(object):
 
         if ty[0] == 'int':
             result += ABI._serialize_int(value, size=ty[1] / 8, padding=32 - ty[1] / 8)
-        elif ty[0] in 'uint':
+        elif ty[0] == 'uint':
             result += ABI._serialize_uint(value, size=ty[1] / 8, padding=32 - ty[1] / 8)
         elif ty[0] in ('bytes', 'string'):
             result += ABI._serialize_uint(dyn_offset)

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -9,9 +9,7 @@ import re
 import os
 from . import Manticore
 from .manticore import ManticoreError
-from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, istainted, taint_with, get_taints, BitVec, Constant, operators, Array, ArrayVariable, \
-    ArrayProxy
-from .core.smtlib.visitors import simplify
+from .core.smtlib import ConstraintSet, Operators, solver, issymbolic, istainted, taint_with, get_taints, BitVec, Constant, operators, Array, ArrayVariable
 from .platforms import evm
 from .core.state import State
 from .utils.helpers import istainted, issymbolic

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -688,7 +688,7 @@ class ABI(object):
         :param value:
         :type value: bytearray or Array
         """
-        return value + bytearray('\0'*(32-len(value)))
+        return value + bytearray('\0' * (32 - len(value)))
 
     @staticmethod
     def _serialize_tuple(types, value, dyn_offset=None):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -654,6 +654,16 @@ class ABI(object):
             result += ABI._serialize_int(value, size=ty[1] / 8, padding=32 - ty[1] / 8)
         elif ty[0] == 'uint':
             result += ABI._serialize_uint(value, size=ty[1] / 8, padding=32 - ty[1] / 8)
+        elif ty[0] in ('bytesM',):
+            nbytes = ty[1]
+
+            if not isinstance(value, str):
+                raise EthereumError('unrecognized type for value')
+
+            if len(value) > nbytes:
+                raise EthereumError('value length exceeds size of bytes{} type'.format(nbytes))
+
+            result += value.ljust(32, '\0')
         elif ty[0] in ('bytes', 'string'):
             result += ABI._serialize_uint(dyn_offset)
             dyn_result += ABI._serialize_uint(len(value))

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -661,18 +661,11 @@ class ABI(object):
             if isinstance(value, (str, bytearray)):
                 if len(value) > nbytes:
                     raise EthereumError('bytesM: value length exceeds size of bytes{} type'.format(nbytes))
-                # result += bytearray(value.ljust(32, '\0'))
                 result.extend(value.ljust(32, '\0'))
             elif isinstance(value, ArrayProxy):
                 if len(value) > nbytes:
                     raise EthereumError('bytesM: value length exceeds size of bytes{} type'.format(nbytes))
-                result = value
-                # for sym_byte in value:
-                #     # result += sym_byte
-                #     result.append(sym_byte)
-                result += bytearray('\0'*(32 - len(value)))
-                # result.extend('\0'*(32 - len(value)))
-
+                result = value + bytearray('\0'*(32 - len(value)))
             else:
                 raise EthereumError('bytesM: unrecognized type <{}> for value'.format(type(value).__name__))
 

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -309,16 +309,13 @@ class EthAbiTests(unittest.TestCase):
         ret = ABI.serialize('bytes', buf)
 
         # does the offset field look right?
-        self.assertEqual(solver.minmax(cs, ret[0]), (0, 0))
-        self.assertEqual(solver.minmax(cs, ret[31]), (32, 32))
+        self.assertTrue(solver.must_be_true(cs, ret[0:32] == bytearray('\0'*31 + '\x20')))
 
         # does the size field look right?
-        self.assertEqual(solver.minmax(cs, ret[32]), (0, 0))
-        self.assertEqual(solver.minmax(cs, ret[63]), (17, 17))
+        self.assertTrue(solver.must_be_true(cs, ret[32:64] == bytearray('\0'*31 + '\x11')))
 
         # does the data field look right?
-        self.assertEqual(solver.minmax(cs, ret[64]), (0, 255))
-        self.assertEqual(solver.minmax(cs, ret[64+17]), (0, 0))
+        self.assertTrue(solver.must_be_true(cs, ret[64:64+32] == buf + bytearray('\0'*15)))
 
         assert 0
 

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -309,17 +309,16 @@ class EthAbiTests(unittest.TestCase):
         ret = ABI.serialize('bytes', buf)
 
         # does the offset field look right?
-        self.assertEqual(solver.minmax(cs, ret[0]), (0, 255))
+        self.assertEqual(solver.minmax(cs, ret[0]), (0, 0))
         self.assertEqual(solver.minmax(cs, ret[31]), (32, 32))
 
         # does the size field look right?
-        self.assertEqual(solver.minmax(cs, ret[32]), (0, 255))
-        self.assertEqual(solver.minmax(cs, ret[63]), (2, 2))
+        self.assertEqual(solver.minmax(cs, ret[32]), (0, 0))
+        self.assertEqual(solver.minmax(cs, ret[63]), (17, 17))
 
         # does the data field look right?
-        self.assertEqual(solver.minmax(cs, ret[64]), (104, 104))
-        self.assertEqual(solver.minmax(cs, ret[65]), (105, 105))
-        self.assertEqual(solver.minmax(cs, ret[66]), (0, 0))
+        self.assertEqual(solver.minmax(cs, ret[64]), (0, 255))
+        self.assertEqual(solver.minmax(cs, ret[64+17]), (0, 0))
 
         assert 0
 

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -317,8 +317,6 @@ class EthAbiTests(unittest.TestCase):
         # does the data field look right?
         self.assertTrue(solver.must_be_true(cs, ret[64:64+32] == buf + bytearray('\0'*15)))
 
-        assert 0
-
 class EthTests(unittest.TestCase):
     def setUp(self):
         self.mevm = ManticoreEVM()

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -294,6 +294,35 @@ class EthAbiTests(unittest.TestCase):
         with self.assertRaises(EthereumError):
             ABI.serialize('bytes2', 'hii')
 
+    # test serializing symbolic buffer with bytesM
+    def test_serialize_bytesM_symbolic(self):
+        cs = ConstraintSet()
+        buf = cs.new_array(index_max=17)
+        ret = ABI.serialize('bytes32', buf)
+        self.assertEqual(solver.minmax(cs, ret[0]), (0, 255))
+        self.assertEqual(solver.minmax(cs, ret[17]), (0, 0))
+
+    # test serializing symbolic buffer with bytes
+    def test_serialize_bytes_symbolic(self):
+        cs = ConstraintSet()
+        buf = cs.new_array(index_max=17)
+        ret = ABI.serialize('bytes', buf)
+
+        # does the offset field look right?
+        self.assertEqual(solver.minmax(cs, ret[0]), (0, 255))
+        self.assertEqual(solver.minmax(cs, ret[31]), (32, 32))
+
+        # does the size field look right?
+        self.assertEqual(solver.minmax(cs, ret[32]), (0, 255))
+        self.assertEqual(solver.minmax(cs, ret[63]), (2, 2))
+
+        # does the data field look right?
+        self.assertEqual(solver.minmax(cs, ret[64]), (104, 104))
+        self.assertEqual(solver.minmax(cs, ret[65]), (105, 105))
+        self.assertEqual(solver.minmax(cs, ret[66]), (0, 0))
+
+        assert 0
+
 class EthTests(unittest.TestCase):
     def setUp(self):
         self.mevm = ManticoreEVM()

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -278,6 +278,21 @@ class EthAbiTests(unittest.TestCase):
         self.assertEqual(parsed_func_id, func_id)
         self.assertEqual(((0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359, selector),), args)
 
+    def test_serialize_fixed_bytes32(self):
+        ret = ABI.serialize('bytes32', 'hi')
+        self.assertEqual(ret, 'hi'.ljust(32, '\0'))
+
+    def test_serialize_fixed_bytes2(self):
+        ret = ABI.serialize('bytes2', 'aa')
+        self.assertEqual(ret, 'aa'.ljust(32, '\0'))
+
+    def test_serialize_fixed_bytes_less_data(self):
+        ret = ABI.serialize('bytes4', 'aa')
+        self.assertEqual(ret, 'aa'.ljust(32, '\0'))
+
+    def test_serialize_fixed_bytes_too_big(self):
+        with self.assertRaises(EthereumError):
+            ABI.serialize('bytes2', 'hii')
 
 class EthTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- Add support for bytesM types (symbolic and concrete)
- Add symbolic support for bytes types

fixes #952 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/962)
<!-- Reviewable:end -->
