### PR TITLE
Report test coverage to CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,17 +34,16 @@ cache:
 jobs:
   include:
     - stage: prepare
+      env: TEST_TYPE=env
       script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
         - ./cc-test-reporter before-build
+      after_script:
     - stage: submit
+      env: TEST_TYPE=env
       script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - pip install awscli
-        - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/
         - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+      install:
+      after_script:
 
 install:
   - scripts/travis_install.sh $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ stages:
 env:
   global:
     - CC_TEST_REPORTER_ID=db72f1ed59628c16eb0c00cbcd629c4c71f68aa1892ef42d18c7c2b8326f460a
+    - JOB_COUNT=2 # Two jobs generate test coverage
   matrix:
     - TEST_TYPE=examples
     - TEST_TYPE=tests
@@ -40,9 +41,10 @@ jobs:
     - stage: submit
       script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
         - pip install awscli
         - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/
-        - ./cc-test-reporter sum-coverage -t coverage.py --output - --parts 2 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+        - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
 
 install:
   - scripts/travis_install.sh $TEST_TYPE
@@ -51,6 +53,6 @@ script:
   - scripts/travis_test.sh $TEST_TYPE
 
 after_script:
-  - ./cc-test-reporter format-coverage --output "coverage/codeclimate.$TEST_TYPE.json"
+  - ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$TEST_TYPE.json"
   - aws s3 sync coverage/ "s3://manticore-testdata/coverage/$TRAVIS_COMMIT"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
     - stage: submit
       env: TEST_TYPE=env
       script:
+        - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/ 
         - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
       after_script:
 
@@ -50,7 +51,7 @@ install:
 script:
   - scripts/travis_test.sh $TEST_TYPE
 
-after_script:
+after_success:
   - ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$TEST_TYPE.json"
   - aws s3 sync coverage/ "s3://manticore-testdata/coverage/$TRAVIS_COMMIT"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ jobs:
     - stage: submit
       script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - pip install --user awscli
+        - pip install awscli
         - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/
-        - ./cc-test-reporter sum-coverage --output - --parts 2 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+        - ./cc-test-reporter sum-coverage -t coverage.py --output - --parts 2 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
 
 install:
   - scripts/travis_install.sh $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ language: python
 python:
   - 3.6.5
 
+stages:
+  - prepare
+  - test
+  - submit
+
 env:
   global:
     - CC_TEST_REPORTER_ID=db72f1ed59628c16eb0c00cbcd629c4c71f68aa1892ef42d18c7c2b8326f460a
@@ -25,16 +30,27 @@ cache:
   - $HOME/virtualenv/python3.6.5/lib/python3.6/site-packages
   - $HOME/virtualenv/python3.6.5/bin/
 
+jobs:
+  include:
+    - stage: prepare
+      script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+    - stage: submit
+      script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - pip install --user awscli
+        - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/
+        - ./cc-test-reporter sum-coverage --output - --parts 2 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+
 install:
   - scripts/travis_install.sh $TEST_TYPE
-
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
 
 script:
   - scripts/travis_test.sh $TEST_TYPE
 
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter format-coverage --output "coverage/codeclimate.$TEST_TYPE.json"
+  - aws s3 sync coverage/ "s3://manticore-testdata/coverage/$TRAVIS_COMMIT"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ jobs:
       env: TEST_TYPE=env
       script:
         - ./cc-test-reporter before-build
-      after_script:
+      after_success:
     - stage: submit
       env: TEST_TYPE=env
       script:
         - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/ 
         - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
-      after_script:
+      after_success:
 
 install:
   - scripts/travis_install.sh $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
       env: TEST_TYPE=env
       script:
         - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
-      install:
       after_script:
 
 install:

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -10,6 +10,9 @@ install_solc
 pip install -U pip
 pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 
+curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+chmod +x ./cc-test-reporter
+
 # We only need to install keystone if we're just running regular tests
 EXTRAS="dev-noks"
 if [ "$1" = "tests" ]; then

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -17,4 +17,5 @@ if [ "$1" = "tests" ]; then
 fi
 
 pip install --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
+pip install awscli
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -5,20 +5,33 @@ function install_solc {
     sudo chmod +x /usr/bin/solc
 }
 
-install_solc
+function install_mcore {
+    pip install -U pip
+    pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 
-pip install -U pip
-pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 
-curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-chmod +x ./cc-test-reporter
+    # We only need to install keystone if we're just running regular tests
+    EXTRAS="dev-noks"
+    if [ "$1" = "tests" ]; then
+        EXTRAS="dev"
+    fi
 
-# We only need to install keystone if we're just running regular tests
-EXTRAS="dev-noks"
-if [ "$1" = "tests" ]; then
-    EXTRAS="dev"
+    pip install --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
+}
+
+function install_cc_env {
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+
+    pip install awscli
+}
+
+# install CodeClimate env in all conditions
+install_cc_env
+
+if [ "$1" != "env" ]; then
+    install_solc
+    install_mcore $1
 fi
 
-pip install --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
-pip install awscli
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -124,6 +124,8 @@ if [ "$should_run_eth_tests" = true ] ; then
     if [[ "${DID_OK}" != OK* ]]; then
         echo "Some functionality tests failed :("
         exit 2
+    else
+        coverage xml
     fi
 fi
 
@@ -134,6 +136,8 @@ if [ "$should_run_tests" = true ]; then
     if [[ "${DID_OK}" != OK* ]]; then
         echo "Some non-eth functionality tests failed :("
         exit 2
+    else
+        coverage xml
     fi
 
     echo "Measuring code coverage..."


### PR DESCRIPTION
This PR enables the reporting of test coverage of all the test jobs (`eth` and `tests`) to CodeClimate. This uses S3 to temporarily store results between jobs and later upload them to CC.

Fixes #1000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1004)
<!-- Reviewable:end -->
