### PR TITLE
Fix CC coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = manticore

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
-source = manticore
+source = .
+omit = tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,10 @@ jobs:
     - stage: submit
       env: TEST_TYPE=env
       script:
+        - true
+      after_script:
         - aws s3 sync "s3://manticore-testdata/coverage/$TRAVIS_COMMIT" coverage/ 
         - ./cc-test-reporter sum-coverage --output - --parts $JOB_COUNT coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
-      after_success:
 
 install:
   - scripts/travis_install.sh $TEST_TYPE


### PR DESCRIPTION
This fix does two things:

 1. Ignores non-manticore files from the coverage report to limit what can fail.
 2. Changes how travis runs s3 sync on completion. (Fixes #1006)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1007)
<!-- Reviewable:end -->
