### PR TITLE
Change how we query for version

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -134,6 +134,8 @@ class Z3Solver(Solver):
         self._get_value_fmt = (re.compile('\(\((?P<expr>(.*))\ #x(?P<value>([0-9a-fA-F]*))\)\)'), 16)
 
         self.debug = False
+        # To cache what get-info returned; can be directly set when writing tests
+        self._received_version = None
         self.version = self._solver_version()
 
         self.support_maximize = False
@@ -165,9 +167,10 @@ class Z3Solver(Solver):
         '''
         their_version = Version(0, 0, 0)
         self._reset()
-        self._send('(get-info :version)')
-        version_output = self._recv()
-        key, version = shlex.split(version_output[1:-1])
+        if self._received_version is None:
+            self._send('(get-info :version)')
+            self._received_version = self._recv()
+        key, version = shlex.split(self._received_version[1:-1])
         return Version(*map(int, version.split('.')))
 
     def _start_proc(self):

--- a/tests/test_smtlibv2.py
+++ b/tests/test_smtlibv2.py
@@ -794,33 +794,23 @@ class ExpressionTest(unittest.TestCase):
         self.assertTrue(solver.check(cs))
         self.assertEqual(solver.get_value(cs, a), -7&0xFF)
 
-import importlib
-class Z3Test(unittest.TestCase):
-    def setUp(self):
-        #Manual mock for check_output
-        self.module = importlib.import_module('manticore.core.smtlib.solver')
-        self.module.check_output = lambda *args, **kwargs: self.version
-        self.z3 = self.module.Z3Solver
-
     def test_check_solver_min(self):
-        self.version = 'Z3 version 4.4.1'
-        self.assertTrue(self.z3._solver_version() == Version(major=4, minor=4, patch=1))
+        self.solver._received_version = '(:version "4.4.1")'
+        self.assertTrue(self.solver._solver_version() == Version(major=4, minor=4, patch=1))
 
     def test_check_solver_newer(self):
-        self.version = 'Z3 version 4.5.0'
-        self.assertTrue(self.z3._solver_version() > Version(major=4, minor=4, patch=1))
+        self.solver._received_version = '(:version "4.5.0")'
+        self.assertTrue(self.solver._solver_version() > Version(major=4, minor=4, patch=1))
 
     def test_check_solver_optimize(self):
-        self.version = 'Z3 version 4.5.0'
-        solver = self.z3()
-        self.assertTrue(solver.support_maximize)
-        self.assertTrue(solver.support_minimize)
+        self.solver._received_version = '(:version "4.5.0")'
+        self.assertTrue(self.solver.support_maximize)
+        self.assertTrue(self.solver.support_minimize)
 
     def test_check_solver_optimize(self):
-        self.version = 'Z3 version 4.4.0'
-        solver = self.z3()
-        self.assertFalse(solver.support_maximize)
-        self.assertFalse(solver.support_minimize)
+        self.solver._received_version = '(:version "4.4.0")'
+        self.assertFalse(self.solver.support_maximize)
+        self.assertFalse(self.solver.support_minimize)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1021

This also should decrease how many times we invoke z3. (The instance used to query version should stick around)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1023)
<!-- Reviewable:end -->
