### PR TITLE
Test manticore on MacOS

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -24,7 +24,8 @@ class ManticoreDriverTest(unittest.TestCase):
 
 
     def testCreating(self):
-        m = Manticore('/bin/ls')
+        dirname = os.path.dirname(__file__)
+        m = Manticore(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
         m.log_file = '/dev/null'
 
     def test_issymbolic(self):

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -14,11 +14,8 @@ from manticore.core.cpu.abstractcpu import ConcretizeRegister
 from binascii import hexlify
 
 class LinuxTest(unittest.TestCase):
-    '''
-    TODO(mark): these tests assumes /bin/ls is a dynamic x64 binary
-    '''
     _multiprocess_can_split_ = True
-    BIN_PATH = '/bin/ls'
+    BIN_PATH = os.path.join(os.path.dirname(__file__), 'binaries', 'basic_linux_amd64')
 
     def setUp(self):
         self.linux = linux.Linux(self.BIN_PATH)
@@ -64,10 +61,10 @@ class LinuxTest(unittest.TestCase):
 
         # binary should be first two
         first_map, second_map = mappings[:2]
-        first_map_name = first_map[4]
-        second_map_name = second_map[4]
-        self.assertEqual(first_map_name, '/bin/ls')
-        self.assertEqual(second_map_name, '/bin/ls')
+        first_map_name = os.path.basename(first_map[4])
+        second_map_name = os.path.basename(second_map[4])
+        self.assertEqual(first_map_name, 'basic_linux_amd64')
+        self.assertEqual(second_map_name, 'basic_linux_amd64')
 
     def test_syscall_fstat(self):
         nr_fstat64 = 197
@@ -246,7 +243,8 @@ class LinuxTest(unittest.TestCase):
 
     def test_symbolic_argv_envp(self):
 
-        self.m = Manticore.linux('tests/binaries/arguments_linux_amd64', argv=['+'],
+        dirname = os.path.dirname(__file__)
+        self.m = Manticore.linux(os.path.join(dirname, 'binaries', 'arguments_linux_amd64'), argv=['+'],
                                  envp={'TEST': '+'})
         state = self.m.initial_state
 

--- a/tests/test_manticore.py
+++ b/tests/test_manticore.py
@@ -1,11 +1,13 @@
 import unittest
+import os
 
 from manticore import Manticore
 
 class ManticoreTest(unittest.TestCase):
     _multiprocess_can_split_ = True
     def setUp(self):
-        self.m = Manticore('tests/binaries/arguments_linux_amd64')
+        dirname = os.path.dirname(__file__)
+        self.m = Manticore(os.path.join(dirname, 'binaries', 'arguments_linux_amd64'))
 
     def test_add_hook(self):
         def tmp(state):
@@ -51,8 +53,9 @@ class ManticoreTest(unittest.TestCase):
                 pass
 
     def test_integration_basic_stdin(self):
-        import os, struct
-        self.m = Manticore('tests/binaries/basic_linux_amd64')
+        import struct
+        dirname = os.path.dirname(__file__)
+        self.m = Manticore(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
         self.m.run()
         workspace = self.m._output.store.uri
         with open(os.path.join(workspace, 'test_00000000.stdin'), 'rb') as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from manticore.core.smtlib import ConstraintSet, solver
 from manticore.core.state import State
@@ -20,7 +21,8 @@ class ModelMiscTest(unittest.TestCase):
 
 
 class ModelTest(unittest.TestCase):
-    l = linux.SLinux('/bin/ls')
+    dirname = os.path.dirname(__file__)
+    l = linux.SLinux(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
     state = State(ConstraintSet(), l)
     stack_top = state.cpu.RSP
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+
 from manticore.utils.event import Eventful
 from manticore.platforms import linux
 from manticore.core.state import State
@@ -66,7 +68,8 @@ class FakePlatform(Eventful):
 class StateTest(unittest.TestCase):
     _multiprocess_can_split_ = True
     def setUp(self):
-        l = linux.Linux('/bin/ls')
+        dirname = os.path.dirname(__file__)
+        l = linux.Linux(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
         self.state = State(ConstraintSet(), l)
 
     def test_solve_one(self):

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -1,5 +1,6 @@
 import unittest
 import struct
+import os
 from functools import wraps
 
 from manticore.core.cpu.arm import Armv7Cpu as Cpu, Mask, Interruption
@@ -1318,7 +1319,8 @@ class UnicornConcretization(unittest.TestCase):
     def get_state(cls):
         if cls.cpu is None:
             constraints = ConstraintSet()
-            platform = linux.SLinux('/bin/ls')
+            dirname = os.path.dirname(__file__)
+            platform = linux.SLinux(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
             cls.state = State(constraints, platform)
             cls.cpu = platform._mk_proc('armv7')
         return (cls.cpu, cls.state)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,6 @@
 import signal
 import unittest
+import os
 
 from multiprocessing.managers import SyncManager
 
@@ -58,7 +59,8 @@ class StateTest(unittest.TestCase):
         if not hasattr(self, 'manager'):
             self.manager = SyncManager()
             self.manager.start(lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))
-        l = linux.Linux('/bin/ls')
+        dirname = os.path.dirname(__file__)
+        l = linux.Linux(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
         self.state = State(ConstraintSet(), l)
         self.lock = self.manager.Condition()
 


### PR DESCRIPTION
Make test_manticore.py like test_binaries.py for path to binary to test
Otherwise, we get 
`Exception: tests/binaries/basic_linux_amd64 is not an existing regular file`

Related to #110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1032)
<!-- Reviewable:end -->
