### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ Manticore can analyze the following types of programs:
 - Linux ELF binaries (x86, x86_64 and ARMv7)
 - Ethereum smart contracts (EVM bytecode) ([release announcement](https://github.com/trailofbits/manticore/releases/tag/0.1.6))
 
-## Requirements
-
-Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended.
-Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
-
 ## Usage
 
 ### CLI
@@ -65,7 +60,9 @@ m.run()
 
 ### Ethereum
 
-Manticore ships with _detectors_ accessible from the command line. Solidity smart contracts must have a `.sol` extension to be consumed by Manticore.
+Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It also integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode. See a demo: https://asciinema.org/a/154012
+
+Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for consumption by Manticore.
 
 ```
 $ manticore ./path/to/contract.sol  # runs, and creates a mcore_* directory with analysis results
@@ -73,7 +70,7 @@ $ manticore --detect-reentrancy ./path/to/contract.sol  # Above, but with reentr
 $ manticore --detect-all ./path/to/contract.sol  # Above, but with all bug detectors enabled
 ```
 
-Use the Python API to verify arbitrary properties of smart contracts by inspecting the states that Manticore discovers.
+Manticore is capable of detailed verification of arbitrary properties of smart contracts via its Python API.
 
 ```python
 from manticore.ethereum import ManticoreEVM
@@ -115,9 +112,10 @@ Further documentation is available in several places:
   * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
     thorough and in-depth documentation on our API
 
-Manticore is beta software. It is actively developed and maintained, and users should expect improvements, interface changes, and of course, some bugs.
+## Requirements
 
-
+Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended.
+Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ cd ../script
 python3 count_instructions.py ../linux/helloworld
 ```
 
-## Installation Options
+## Installation
 
 Option 1: Perform a user install (requires `~/.local/bin` in your `PATH`).
 
@@ -203,8 +203,8 @@ Documentation is available in several places:
   * The [examples](examples) directory has some very minimal examples that
     showcase API features
 
-  * The [manticore-examples](https://github.com/trailofbits/manticore-examples)
-    repository has some more involved examples, for instance solving real CTF problems
-
   * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
     thorough and in-depth documentation on our API
+
+  * The [manticore-examples](https://github.com/trailofbits/manticore-examples)
+    repository has some more involved examples, for instance solving real CTF problems

--- a/README.md
+++ b/README.md
@@ -143,9 +143,19 @@ docker run -it -v $PWD/examples:/home/manticore/examples trailofbits/manticore
 
 # Change to examples directory
 manticore@80d441275ebf:~$ cd examples/linux
-```
 
-Then follow from the `make` command above.
+# Build the examples
+make
+
+# Use the Manticore CLI
+manticore basic
+cat mcore_*/*0.stdin | ./basic
+cat mcore_*/*1.stdin | ./basic
+
+# Use the Manticore API
+cd ../script
+python3 count_instructions.py ../linux/helloworld
+```
 
 ## Installation Options
 

--- a/README.md
+++ b/README.md
@@ -142,19 +142,19 @@ git clone https://github.com/trailofbits/manticore.git && cd manticore
 docker run -it -v $PWD/examples:/home/manticore/examples trailofbits/manticore
 
 # Change to examples directory
-manticore@80d441275ebf:~$ cd examples/linux
+manticore@80d441275ebf$ cd examples/linux
 
 # Build the examples
-make
+manticore@80d441275ebf$ make
 
 # Use the Manticore CLI
-manticore basic
-cat mcore_*/*0.stdin | ./basic
-cat mcore_*/*1.stdin | ./basic
+manticore@80d441275ebf$ manticore basic
+manticore@80d441275ebf$ cat mcore_*/*0.stdin | ./basic
+manticore@80d441275ebf$ cat mcore_*/*1.stdin | ./basic
 
 # Use the Manticore API
-cd ../script
-python3 count_instructions.py ../linux/helloworld
+manticore@80d441275ebf$ cd ../script
+manticore@80d441275ebf$ python3 count_instructions.py ../linux/helloworld
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ m.run()
 
 ### Ethereum
 
-Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It also integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode.
+Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode.
 
-Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for analysis by Manticore. See a demo: https://asciinema.org/a/154012
+Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Solidity smart contracts must have a `.sol` extension for analysis by Manticore. See a demo: https://asciinema.org/a/154012
 
 ```
 $ manticore ./path/to/contract.sol  # runs, and creates a mcore_* directory with analysis results
@@ -185,9 +185,9 @@ For installing a development version of Manticore, see our [wiki](https://github
 
 > Note: If you are experiencing unanticipated errors when running Manticore on native binaries, you can try using the `--process-dependency-links` pip flag. This will install the development branch of our disassembler dependency, which may contain useful bug fixes.
 
-## Further Documentation
+## Documentation
 
-Further documentation is available in several places:
+Documentation is available in several places:
 
   * The [wiki](https://github.com/trailofbits/manticore/wiki) contains some
     basic information about getting started with manticore and contributing

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ m.run()
 
 Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It also integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode. See a demo: https://asciinema.org/a/154012
 
-Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for consumption by Manticore.
+Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for analysis by Manticore.
 
 ```
 $ manticore ./path/to/contract.sol  # runs, and creates a mcore_* directory with analysis results

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Manticore can analyze the following types of programs:
 
 Manticore has a command line interface which can be used to easily symbolically execute a supported program. Analysis results will be placed into a new directory beginning with `mcore_`.
 
-
 ```
 $ manticore ./path/to/binary        # runs, and creates a mcore_* directory with analysis results
 $ manticore ./path/to/binary ab cd  # use concrete strings "ab", "cd" as program arguments
@@ -37,7 +36,6 @@ $ manticore ./path/to/binary ++ ++  # use two symbolic strings of length two as 
 ### API
 
 Manticore has a Python programming interface which can be used to implement custom analyses.
-
 
 ```python
 # example Manticore script
@@ -112,9 +110,11 @@ Further documentation is available in several places:
   * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
     thorough and in-depth documentation on our API
 
-## Installation
+## Requirements
 
 Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended. Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
+
+## Quickstart
 
 Install and try Manticore in a few shell commands (see an [asciinema](https://asciinema.org/a/567nko3eh2yzit099s0nq4e8z)):
 
@@ -141,9 +141,7 @@ cd ../script
 python3 count_instructions.py ../linux/helloworld
 ```
 
-### Docker
-
-Alternatively, you can use Docker to install Manticore:
+Alternatively, you can use Docker to quickly install and test out Manticore:
 
 ```
 # Download manticore image
@@ -161,7 +159,7 @@ manticore@80d441275ebf:~$ cd examples/linux
 
 Then follow from the `make` command above.
 
-### Expert Installation
+### Installation Options
 
 Option 1: Perform a user install (requires `~/.local/bin` in your `PATH`).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Manticore is a symbolic execution tool for analysis of binaries and smart contra
 Manticore can analyze the following types of programs:
 
 - Linux ELF binaries (x86, x86_64 and ARMv7)
-- Ethereum smart contracts (EVM bytecode) ([release announcement](https://github.com/trailofbits/manticore/releases/tag/0.1.6))
+- Ethereum smart contracts (EVM bytecode)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Use the CLI to explore possible states in Ethereum smart contracts. Manticore in
 ```
 $ manticore ./path/to/contract.sol  # runs, and creates a mcore_* directory with analysis results
 $ manticore --detect-reentrancy ./path/to/contract.sol  # Above, but with reentrancy detection enabled
-$ manticore --detect-all ./path/to/contract.sol  # Above, but with all bug detectors enabled
+$ manticore --detect-all ./path/to/contract.sol  # Above, but with all detectors enabled
 ```
 
-Manticore is capable of detailed verification of arbitrary properties of smart contracts via its Python API.
+Manticore is capable of detailed verification of arbitrary properties of smart contracts via its Python API. Set starting conditions, identify symbolic transactions, then review discovered states to ensure invariants for your contract hold.
 
 ```python
 from manticore.ethereum import ManticoreEVM
@@ -112,12 +112,9 @@ Further documentation is available in several places:
   * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
     thorough and in-depth documentation on our API
 
-## Requirements
-
-Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended.
-Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
-
 ## Installation
+
+Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended. Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
 
 Install and try Manticore in a few shell commands (see an [asciinema](https://asciinema.org/a/567nko3eh2yzit099s0nq4e8z)):
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ Once installed, the `manticore` CLI tool and Python API will be available.
 
 For installing a development version of Manticore, see our [wiki](https://github.com/trailofbits/manticore/wiki/Hacking-on-Manticore).
 
-> Note: If you are experiencing unanticipated errors when running Manticore on native binaries, you can try using the `--process-dependency-links` pip flag. This will install the development branch of our disassembler dependency, which may contain useful bug fixes.
-
 ## Documentation
 
 Documentation is available in several places:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ m.run()
 
 ### Ethereum
 
-Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It also integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode. See a demo: https://asciinema.org/a/154012
+Manticore includes a symbolic Ethereum Virtual Machine (EVM) and a convenient interface for automated compilation and analysis of Solidity. It also integrates with [Ethersplay](https://github.com/trailofbits/ethersplay), Trail of Bits’ visual disassembler for EVM bytecode, for analysis visualization. As with binaries, Manticore offers a simple command line interface and a Python API for analysis of EVM bytecode.
 
-Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for analysis by Manticore.
+Use the CLI to explore possible states in Ethereum smart contracts. Manticore includes _detectors_ which flag certain conditions, including known vulnerable code, as it explores possible states. Note: Solidity smart contracts must have a `.sol` extension for analysis by Manticore. See a demo: https://asciinema.org/a/154012
 
 ```
 $ manticore ./path/to/contract.sol  # runs, and creates a mcore_* directory with analysis results
@@ -96,23 +96,11 @@ for state in m.running_states:
 
 ```
 
-Further documentation is available in several places:
-
-  * The [wiki](https://github.com/trailofbits/manticore/wiki) contains some
-    basic information about getting started with manticore and contributing
-
-  * The [examples](examples) directory has some very minimal examples that
-    showcase API features
-
-  * The [manticore-examples](https://github.com/trailofbits/manticore-examples)
-    repository has some more involved examples, for instance solving real CTF problems
-
-  * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
-    thorough and in-depth documentation on our API
-
 ## Requirements
 
-Manticore is supported on Linux and requires Python >=3.6. Ubuntu 18.04 is strongly recommended. Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
+* Manticore is supported on Linux and requires Python >=3.6.
+* Ubuntu 18.04 is strongly recommended.
+* Ethereum smart contract analysis requires the [`solc`](https://github.com/ethereum/solidity) program in your `$PATH`.
 
 ## Quickstart
 
@@ -141,7 +129,7 @@ cd ../script
 python3 count_instructions.py ../linux/helloworld
 ```
 
-Alternatively, you can use Docker to quickly install and test out Manticore:
+You can also use Docker to quickly install and try Manticore:
 
 ```
 # Download manticore image
@@ -159,7 +147,7 @@ manticore@80d441275ebf:~$ cd examples/linux
 
 Then follow from the `make` command above.
 
-### Installation Options
+## Installation Options
 
 Option 1: Perform a user install (requires `~/.local/bin` in your `PATH`).
 
@@ -196,3 +184,19 @@ Once installed, the `manticore` CLI tool and Python API will be available.
 For installing a development version of Manticore, see our [wiki](https://github.com/trailofbits/manticore/wiki/Hacking-on-Manticore).
 
 > Note: If you are experiencing unanticipated errors when running Manticore on native binaries, you can try using the `--process-dependency-links` pip flag. This will install the development branch of our disassembler dependency, which may contain useful bug fixes.
+
+## Further Documentation
+
+Further documentation is available in several places:
+
+  * The [wiki](https://github.com/trailofbits/manticore/wiki) contains some
+    basic information about getting started with manticore and contributing
+
+  * The [examples](examples) directory has some very minimal examples that
+    showcase API features
+
+  * The [manticore-examples](https://github.com/trailofbits/manticore-examples)
+    repository has some more involved examples, for instance solving real CTF problems
+
+  * The [API reference](http://manticore.readthedocs.io/en/latest/) has more
+    thorough and in-depth documentation on our API


### PR DESCRIPTION
- Bump all the requirements and installation instructions to the bottom
- Eliminate the statement about Manticore being beta software
- Add more background material to the Ethereum section
- Rename Quickstart to Installation and Installation to Expert Installation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1037)
<!-- Reviewable:end -->
