### PR TITLE
Fix bug with symbolic pointer constraining

### DIFF
--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -1181,7 +1181,7 @@ class LazySMemory(SMemory):
             # address >= map.start,
             # address + size < map.end)
             Operators.UGE(address, map.start),
-            Operators.ULT(address, map.end))
+            Operators.ULT(address+size-1, map.end))
 
     def _deref_can_succeed(self, map, address, size):
         deref_possible = self._map_deref_expr(map, address, size)
@@ -1232,10 +1232,15 @@ class LazySMemory(SMemory):
                     found = m
             return found
 
-    def valid_ptr(self, address):
+    def valid_ptr(self, address, size):
+        """
+
+        :param address:
+        :return:
+        """
         assert issymbolic(address)
 
-        expressions = [self._map_deref_expr(m, address, 1) for m in self._maps]
+        expressions = [self._map_deref_expr(m, address, size) for m in self._maps]
         valid = functools.reduce(Operators.OR, expressions)
 
         return valid

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -1234,9 +1234,8 @@ class LazySMemory(SMemory):
 
     def valid_ptr(self, address, size):
         """
-
-        :param address:
-        :return:
+        Generate a constraint expression to constrain the memory access described by `address` and `size` into valid
+        maps.
         """
         assert issymbolic(address)
 

--- a/tests/test_lazy_memory.py
+++ b/tests/test_lazy_memory.py
@@ -44,6 +44,7 @@ class LazyMemoryTest(unittest.TestCase):
         mem.mmap(0, 4096, 'rwx', name='map')
 
         addr = cs.new_bitvec(32)
+        size = 1
 
         # constrain on a boundary
         cs.add(addr >= 0xffc)
@@ -51,7 +52,7 @@ class LazyMemoryTest(unittest.TestCase):
 
         # Ensure that all valid derefs are within mapped memory
         with cs as new_cs:
-            new_cs.add(mem.valid_ptr(addr))
+            new_cs.add(mem.valid_ptr(addr, size))
             vals = solver.get_all_values(new_cs, addr)
             self.assertGreater(len(vals), 0)
             for v in vals:
@@ -60,7 +61,7 @@ class LazyMemoryTest(unittest.TestCase):
 
         # Ensure that all invalid derefs are outside of mapped memory
         with cs as new_cs:
-            new_cs.add(mem.invalid_ptr(addr))
+            new_cs.add(mem.invalid_ptr(addr, size))
             vals = solver.get_all_values(new_cs, addr)
             self.assertGreater(len(vals), 0)
             for v in vals:


### PR DESCRIPTION
When constraining a pointer into a valid map, we need to also take into account the size of the memory access. Previously this wasn't done, which can result in a solution for the symbolic address that still causes a segfault if the next bytes accessed go off the page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1062)
<!-- Reviewable:end -->
