### PR TITLE
eth: add ether leak detector

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -97,6 +97,9 @@ def parse_arguments():
     parser.add_argument('--detect-selfdestruct', action='store_true',
                         help='Enable detection of reachable selfdestruct instructions')
 
+    parser.add_argument('--detect-etherleak', action='store_true',
+                        help='Enable detection of reachable ether send/leak to sender or arbitrary address')
+
     parser.add_argument('--detect-all', action='store_true',
                         help='Enable all detector heuristics (Ethereum only)')
 
@@ -119,7 +122,7 @@ def parse_arguments():
 
 
 def ethereum_cli(args):
-    from .ethereum import ManticoreEVM, DetectInvalid, DetectIntegerOverflow, DetectUninitializedStorage, DetectUninitializedMemory, FilterFunctions, DetectReentrancy, DetectUnusedRetVal, DetectSelfdestruct, LoopDepthLimiter
+    from .ethereum import ManticoreEVM, DetectInvalid, DetectIntegerOverflow, DetectUninitializedStorage, DetectUninitializedMemory, FilterFunctions, DetectReentrancy, DetectUnusedRetVal, DetectSelfdestruct, LoopDepthLimiter, DetectEtherLeak
     log.init_logging()
 
     m = ManticoreEVM(procs=args.procs, workspace_url=args.workspace)
@@ -138,6 +141,8 @@ def ethereum_cli(args):
         m.register_detector(DetectUnusedRetVal())
     if args.detect_all or args.detect_selfdestruct:
         m.register_detector(DetectSelfdestruct())
+    if args.detect_all or args.detect_etherleak:
+        m.register_detector(DetectEtherLeak())
 
     if args.limit_loops:
         m.register_plugin(LoopDepthLimiter())

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -253,6 +253,8 @@ class DetectEtherLeak(Detector):
                 if state.can_be_true(msg_sender == dest_address):
                     self.add_finding_here(state, "Reachable ether leak to sender via argument")
                 else:
+                    # This might be a false positive if the dest_address can't actually be solved to anything
+                    # useful/exploitable
                     self.add_finding_here(state, "Reachable ether leak to user controlled address via argument")
             else:
                 if msg_sender == dest_address:

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -249,17 +249,14 @@ class DetectEtherLeak(Detector):
                 return
 
             if issymbolic(dest_address):
-                if state.can_be_true(msg_sender == dest_address)
-                    self.add_finding_here(state, "Reachable ether leak to sender")
+                # We assume dest_address is symbolic because it came from symbolic tx data (user input argument)
+                if state.can_be_true(msg_sender == dest_address):
+                    self.add_finding_here(state, "Reachable ether leak to sender via argument")
                 else:
-                    # If dest_address is symbolic, but can't be set to the msg sender, we assume it's
-                    # symbolic because it came from the tx data (user input)
-                    self.add_finding_here(state, "Reachable ether leak to user controlled address")
+                    self.add_finding_here(state, "Reachable ether leak to user controlled address via argument")
             else:
                 if msg_sender == dest_address:
                     self.add_finding_here(state, "Reachable ether leak to sender")
-
-            # print('address', dest_address, 'caller', msg_sender, msg_sender == dest_address, 'value', sent_value, 'v gt z', state.can_be_true(sent_value > 0))
 
 
 class DetectInvalid(Detector):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -248,9 +248,16 @@ class DetectEtherLeak(Detector):
             if not state.can_be_true(sent_value > 0):
                 return
 
-            if msg_sender == dest_address:
-                self.add_finding_here(state, "Reachable ether leak to sender")
-            # TODO if dest_address is from an argument
+            if issymbolic(dest_address):
+                if state.can_be_true(msg_sender == dest_address)
+                    self.add_finding_here(state, "Reachable ether leak to sender")
+                else:
+                    # If dest_address is symbolic, but can't be set to the msg sender, we assume it's
+                    # symbolic because it came from the tx data (user input)
+                    self.add_finding_here(state, "Reachable ether leak to user controlled address")
+            else:
+                if msg_sender == dest_address:
+                    self.add_finding_here(state, "Reachable ether leak to sender")
 
             # print('address', dest_address, 'caller', msg_sender, msg_sender == dest_address, 'value', sent_value, 'v gt z', state.can_be_true(sent_value > 0))
 

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -237,6 +237,23 @@ class DetectSelfdestruct(Detector):
         if instruction.semantics == 'SELFDESTRUCT':
             self.add_finding_here(state, 'Reachable SELFDESTRUCT')
 
+class DetectEtherLeak(Detector):
+    def will_evm_execute_instruction_callback(self, state, instruction, arguments):
+        if instruction.semantics == 'CALL':
+            dest_address = arguments[1]
+            sent_value = arguments[2]
+            msg_sender = state.platform.current_vm.caller
+
+            # If nothing can be transferred out, we don't care
+            if not state.can_be_true(sent_value > 0):
+                return
+
+            if msg_sender == dest_address:
+                self.add_finding_here(state, "Ether leak to sender")
+            # TODO if dest_address is from an argument
+
+            # print('address', dest_address, 'caller', msg_sender, msg_sender == dest_address, 'value', sent_value, 'v gt z', state.can_be_true(sent_value > 0))
+
 
 class DetectInvalid(Detector):
     def __init__(self, only_human=True, **kwargs):

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -249,7 +249,7 @@ class DetectEtherLeak(Detector):
                 return
 
             if msg_sender == dest_address:
-                self.add_finding_here(state, "Ether leak to sender")
+                self.add_finding_here(state, "Reachable ether leak to sender")
             # TODO if dest_address is from an argument
 
             # print('address', dest_address, 'caller', msg_sender, msg_sender == dest_address, 'value', sent_value, 'v gt z', state.can_be_true(sent_value > 0))

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -241,6 +241,7 @@ class DetectSelfdestruct(Detector):
         if instruction.semantics == 'SELFDESTRUCT':
             self.add_finding_here(state, 'Reachable SELFDESTRUCT')
 
+
 class DetectEtherLeak(Detector):
     def will_evm_execute_instruction_callback(self, state, instruction, arguments):
         if instruction.semantics == 'CALL':

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -132,6 +132,10 @@ class FilterFunctions(Plugin):
 class LoopDepthLimiter(Plugin):
     ''' This just abort explorations too deep '''
 
+    def __init__(self, loop_count_threshold=5, **kwargs):
+        super().__init__(**kwargs)
+        self.loop_count_threshold = loop_count_threshold
+
     def will_start_run_callback(self, *args):
         with self.manticore.locked_context('seen_rep', dict) as reps:
             reps.clear()
@@ -143,7 +147,7 @@ class LoopDepthLimiter(Plugin):
             if item not in reps:
                 reps[item] = 0
             reps[item] += 1
-            if reps[item] > 2:
+            if reps[item] > self.loop_count_threshold:
                 state.abandon()
 
 

--- a/tests/binaries/detectors/etherleak_true_neg.sol
+++ b/tests/binaries/detectors/etherleak_true_neg.sol
@@ -1,0 +1,31 @@
+/*
+   Example contract - True Negative
+   The ether leak is not reachable by non-creator and there is no way to set
+   yourself as the owner.
+
+   This should NOT report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  constructor () {
+    owner = msg.sender;
+  }
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds() onlyOwner {
+    msg.sender.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_neg1.sol
+++ b/tests/binaries/detectors/etherleak_true_neg1.sol
@@ -1,0 +1,31 @@
+/*
+   Example contract - True Negative, Potential false positive
+   The ether leak is not reachable by non-creator and there is no way to set
+   yourself as the owner.
+
+   This should NOT report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor () { // writes to owner storage, but not exploitably
+    owner = 2;
+  }
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds() onlyOwner {
+    msg.sender.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_neg2.sol
+++ b/tests/binaries/detectors/etherleak_true_neg2.sol
@@ -1,0 +1,31 @@
+/*
+   Example contract - True Negative
+   The ether leak is reachable by non-creator if you set yourself as the owner, BUT the balance
+   can never be > 0.
+
+   This should NOT report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor() {
+    owner = msg.sender;
+  }
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds() onlyOwner {
+    msg.sender.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_neg2.sol
+++ b/tests/binaries/detectors/etherleak_true_neg2.sol
@@ -21,9 +21,6 @@ contract DetectThis {
     owner = msg.sender;
   }
 
-  function () payable { // makes it possible for contract to have balance > 0
-  }
-
   function withdrawfunds() onlyOwner {
     msg.sender.transfer(this.balance);
   }

--- a/tests/binaries/detectors/etherleak_true_neg3.sol
+++ b/tests/binaries/detectors/etherleak_true_neg3.sol
@@ -1,0 +1,30 @@
+/*
+   Example contract - True Negative, Potential false positive
+   The ether leak is reachable by non-creator if you set yourself as the owner, and the
+   balance can be > 0, but only 0 can ever be sent.
+
+   This should NOT report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor() payable {
+    owner = msg.sender;
+  }
+
+  function withdrawfunds() onlyOwner {
+    if (this.balance == 0) {
+        msg.sender.transfer(this.balance);
+    }
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_pos_argument.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_argument.sol
@@ -1,0 +1,30 @@
+/*
+   Example contract - True Positive
+   The argument ether leak is reachable by non-creator if you set yourself as the owner.
+
+   This should report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor() {
+    owner = msg.sender;
+  }
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds(address attacker) onlyOwner {
+    attacker.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_pos_argument.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_argument.sol
@@ -16,11 +16,8 @@ contract DetectThis {
     _;
   }
 
-  function fakeconstructor() {
+  function fakeconstructor() payable { // makes it possible for contract to have balance > 0
     owner = msg.sender;
-  }
-
-  function () payable { // makes it possible for contract to have balance > 0
   }
 
   function withdrawfunds(address attacker) onlyOwner {

--- a/tests/binaries/detectors/etherleak_true_pos_argument1.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_argument1.sol
@@ -21,17 +21,13 @@ contract DetectThis {
     _;
   }
     
-  function set(uint256 key, uint256 value) public { // you can use this to overwrite owner
+  function set(uint256 key, uint256 value) public payable { // you can use this to overwrite owner // makes it possible for contract to have balance > 0
     // Expand dynamic array as needed
     if (map.length <= key) {
       map.length = key + 1;
     }
 
     map[key] = value;
-  }
-
-
-  function () payable { // makes it possible for contract to have balance > 0
   }
 
   function withdrawfunds(address attacker) onlyOwner {

--- a/tests/binaries/detectors/etherleak_true_pos_argument1.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_argument1.sol
@@ -1,0 +1,41 @@
+/*
+   Example contract - True Positive, Potential false negative
+   The ether leak is reachable by non-creator if you set yourself as the owner by exploiting
+   the set() function.
+
+   NOTE: this currently requires the LoopDepthLimiter plugin to find quickly. This is due to the
+   assignment to map.length.
+
+   This should report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+  uint256[] map;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+    
+  function set(uint256 key, uint256 value) public { // you can use this to overwrite owner
+    // Expand dynamic array as needed
+    if (map.length <= key) {
+      map.length = key + 1;
+    }
+
+    map[key] = value;
+  }
+
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds(address attacker) onlyOwner {
+    attacker.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_pos_argument2.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_argument2.sol
@@ -1,0 +1,29 @@
+/*
+   Example contract - True Positive
+   The argument ether leak is reachable by non-creator if you set yourself as the owner.
+
+   This should report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor() payable { // makes it possible for contract to have balance > 0
+    owner = msg.sender;
+  }
+
+  function withdrawfunds(address attacker) onlyOwner {
+    if (attacker != msg.sender) {
+        attacker.transfer(this.balance);
+    }
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_pos_msgsender.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_msgsender.sol
@@ -16,11 +16,8 @@ contract DetectThis {
     _;
   }
 
-  function fakeconstructor() {
+  function fakeconstructor() payable { // makes it possible for contract to have balance > 0
     owner = msg.sender;
-  }
-
-  function () payable { // makes it possible for contract to have balance > 0
   }
 
   function withdrawfunds() onlyOwner {

--- a/tests/binaries/detectors/etherleak_true_pos_msgsender.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_msgsender.sol
@@ -1,0 +1,30 @@
+/*
+   Example contract - True Positive
+   The ether leak is reachable by non-creator if you set yourself as the owner.
+
+   This should report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function fakeconstructor() {
+    owner = msg.sender;
+  }
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds() onlyOwner {
+    msg.sender.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/etherleak_true_pos_msgsender1.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_msgsender1.sol
@@ -21,17 +21,13 @@ contract DetectThis {
     _;
   }
 
-  function set(uint256 key, uint256 value) public { // you can use this to overwrite owner
+  function set(uint256 key, uint256 value) public payable { // you can use this to overwrite owner // makes it possible for contract to have balance > 0
     // Expand dynamic array as needed
     if (map.length <= key) {
       map.length = key + 1;
     }
 
     map[key] = value;
-  }
-
-
-  function () payable { // makes it possible for contract to have balance > 0
   }
 
   function withdrawfunds() onlyOwner {

--- a/tests/binaries/detectors/etherleak_true_pos_msgsender1.sol
+++ b/tests/binaries/detectors/etherleak_true_pos_msgsender1.sol
@@ -1,0 +1,41 @@
+/*
+   Example contract - True Positive, Potential false negative
+   The ether leak is reachable by non-creator if you set yourself as the owner by exploiting
+   the set() function.
+
+   NOTE: this currently requires the LoopDepthLimiter plugin to find quickly. This is due to the
+   assignment to map.length.
+
+   This should report a finding.
+*/
+
+pragma solidity ^0.4.24;
+
+contract DetectThis {
+
+  address private owner;
+  uint256[] map;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function set(uint256 key, uint256 value) public { // you can use this to overwrite owner
+    // Expand dynamic array as needed
+    if (map.length <= key) {
+      map.length = key + 1;
+    }
+
+    map[key] = value;
+  }
+
+
+  function () payable { // makes it possible for contract to have balance > 0
+  }
+
+  function withdrawfunds() onlyOwner {
+    msg.sender.transfer(this.balance);
+  }
+
+}

--- a/tests/binaries/detectors/selfdestruct_true_neg1.sol
+++ b/tests/binaries/detectors/selfdestruct_true_neg1.sol
@@ -16,7 +16,7 @@ contract DetectThis {
     assert(msg.sender == owner);
     _;
   }
-  function fakeSetOwner() { // writes to owner memory, but not exploitably
+  function fakeSetOwner() { // writes to owner storage, but not exploitably
     owner = 2;
   }
 

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -84,7 +84,7 @@ class EthSelfdestruct(EthDetectorTest):
         self._test(name, {(307, 'Reachable SELFDESTRUCT', False)})
 
     def test_selfdestruct_true_pos1(self):
-        self.mevm.register_plugin(LoopDepthLimiter())
+        self.mevm.register_plugin(LoopDepthLimiter(2))
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, {(307, 'Reachable SELFDESTRUCT', False)})
 
@@ -117,7 +117,7 @@ class EthEtherLeak(EthDetectorTest):
         self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
 
     def test_etherleak_true_pos_argument1(self):
-        self.mevm.register_plugin(LoopDepthLimiter())
+        self.mevm.register_plugin(LoopDepthLimiter(5))
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
 
@@ -130,7 +130,7 @@ class EthEtherLeak(EthDetectorTest):
         self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
 
     def test_etherleak_true_pos_msgsender1(self):
-        self.mevm.register_plugin(LoopDepthLimiter())
+        self.mevm.register_plugin(LoopDepthLimiter(5))
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
 

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -87,7 +87,6 @@ class EthSelfdestruct(unittest.TestCase):
         self.mevm.register_detector(DetectSelfdestruct())
         mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=(mevm.make_symbolic_value(),))
 
-        print(mevm.global_findings)
         expected_findings = set((c, d) for b, c, d in should_find)
         actual_findings = set(((c, d) for a, b, c, d in mevm.global_findings))
         self.assertEqual(expected_findings, actual_findings)

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -12,7 +12,7 @@ import os
 from manticore.core.smtlib import operators
 from eth_general import make_mock_evm_state
 from manticore.ethereum import ManticoreEVM, DetectInvalid, DetectIntegerOverflow, Detector, NoAliveStates, ABI, \
-    EthereumError, DetectReentrancy, DetectUnusedRetVal, DetectSelfdestruct, LoopDepthLimiter
+    EthereumError, DetectReentrancy, DetectUnusedRetVal, DetectSelfdestruct, LoopDepthLimiter, DetectEtherLeak
 
 import shutil
 
@@ -25,8 +25,11 @@ init_logging()
 set_verbosity(0)
 
 
-class EthRetVal(unittest.TestCase):
-    """ https://consensys.net/diligence/evm-analyzer-benchmark-suite/ """
+class EthDetectorTest(unittest.TestCase):
+    """
+    Subclasses must assign this class variable to the class for the detector
+    """
+    DETECTOR_CLASS = None
 
     def setUp(self):
         self.mevm = ManticoreEVM()
@@ -45,12 +48,16 @@ class EthRetVal(unittest.TestCase):
 
         filename = os.path.join(THIS_DIR, 'binaries', 'detectors', '{}.sol'.format(name))
 
-        self.mevm.register_detector(DetectUnusedRetVal())
+        self.mevm.register_detector(self.DETECTOR_CLASS())
         mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=(mevm.make_symbolic_value(),))
 
         expected_findings = set(((c, d) for b, c, d in should_find))
         actual_findings = set(((c, d) for a, b, c, d in mevm.global_findings))
         self.assertEqual(expected_findings, actual_findings)
+
+class EthRetVal(EthDetectorTest):
+    """ https://consensys.net/diligence/evm-analyzer-benchmark-suite/ """
+    DETECTOR_CLASS = DetectUnusedRetVal
 
     def test_retval_ok(self):
         name = inspect.currentframe().f_code.co_name[5:]
@@ -58,7 +65,7 @@ class EthRetVal(unittest.TestCase):
 
     def test_retval_not_ok(self):
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, set([(337, 'Returned value at CALL instruction is not used', False)]))
+        self._test(name, {(337, 'Returned value at CALL instruction is not used', False)})
 
     def test_retval_crazy(self):
         name = inspect.currentframe().f_code.co_name[5:]
@@ -69,27 +76,8 @@ class EthRetVal(unittest.TestCase):
         self._test(name, set())
 
 
-class EthSelfdestruct(unittest.TestCase):
-    def setUp(self):
-        self.mevm = ManticoreEVM()
-        self.mevm.verbosity(0)
-        self.worksp = self.mevm.workspace
-
-    def tearDown(self):
-        self.mevm = None
-        shutil.rmtree(self.worksp)
-
-    def _test(self, name, should_find):
-        mevm = self.mevm
-
-        filename = os.path.join(THIS_DIR, 'binaries', 'detectors', '{}.sol'.format(name))
-
-        self.mevm.register_detector(DetectSelfdestruct())
-        mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=(mevm.make_symbolic_value(),))
-
-        expected_findings = set((c, d) for b, c, d in should_find)
-        actual_findings = set(((c, d) for a, b, c, d in mevm.global_findings))
-        self.assertEqual(expected_findings, actual_findings)
+class EthSelfdestruct(EthDetectorTest):
+    DETECTOR_CLASS = DetectSelfdestruct
 
     def test_selfdestruct_true_pos(self):
         name = inspect.currentframe().f_code.co_name[5:]
@@ -107,6 +95,40 @@ class EthSelfdestruct(unittest.TestCase):
     def test_selfdestruct_true_neg1(self):
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, set())
+
+
+class EthEtherLeak(EthDetectorTest):
+    DETECTOR_CLASS = DetectEtherLeak
+
+    def test_etherleak_true_neg(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, set())
+
+    def test_etherleak_true_neg1(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, set())
+
+    def test_etherleak_true_neg2(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, set())
+
+    def test_etherleak_true_pos_argument(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, {(555555555555555555, "Reachable ether leak to user provided argument", False)})
+
+    def test_etherleak_true_pos_argument1(self):
+        self.mevm.register_plugin(LoopDepthLimiter())
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, {(555555555555555555, "Reachable ether leak to user provided argument", False)})
+
+    def test_etherleak_true_pos_msgsender(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
+
+    def test_etherleak_true_pos_msgsender1(self):
+        self.mevm.register_plugin(LoopDepthLimiter())
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
 
 
 class EthIntegerOverflow(unittest.TestCase):

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -114,25 +114,25 @@ class EthEtherLeak(EthDetectorTest):
 
     def test_etherleak_true_pos_argument(self):
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
+        self._test(name, {(0x1c5, "Reachable ether leak to sender via argument", False)})
 
     def test_etherleak_true_pos_argument1(self):
         self.mevm.register_plugin(LoopDepthLimiter(5))
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
+        self._test(name, {(0x1c5, "Reachable ether leak to sender via argument", False)})
 
     def test_etherleak_true_pos_argument2(self):
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to user controlled address via argument", False)})
+        self._test(name, {(0x1c5, "Reachable ether leak to user controlled address via argument", False)})
 
     def test_etherleak_true_pos_msgsender(self):
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
+        self._test(name, {(0x1c5, "Reachable ether leak to sender", False)})
 
     def test_etherleak_true_pos_msgsender1(self):
         self.mevm.register_plugin(LoopDepthLimiter(5))
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to sender", False)})
+        self._test(name, {(0x1c5, "Reachable ether leak to sender", False)})
 
 
 class EthIntegerOverflow(unittest.TestCase):

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -112,6 +112,10 @@ class EthEtherLeak(EthDetectorTest):
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, set())
 
+    def test_etherleak_true_neg3(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, set())
+
     def test_etherleak_true_pos_argument(self):
         name = inspect.currentframe().f_code.co_name[5:]
         self._test(name, {(0x1c5, "Reachable ether leak to sender via argument", False)})

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -114,12 +114,16 @@ class EthEtherLeak(EthDetectorTest):
 
     def test_etherleak_true_pos_argument(self):
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to user provided argument", False)})
+        self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
 
     def test_etherleak_true_pos_argument1(self):
         self.mevm.register_plugin(LoopDepthLimiter())
         name = inspect.currentframe().f_code.co_name[5:]
-        self._test(name, {(555555555555555555, "Reachable ether leak to user provided argument", False)})
+        self._test(name, {(555555555555555555, "Reachable ether leak to sender via argument", False)})
+
+    def test_etherleak_true_pos_argument2(self):
+        name = inspect.currentframe().f_code.co_name[5:]
+        self._test(name, {(555555555555555555, "Reachable ether leak to user controlled address via argument", False)})
 
     def test_etherleak_true_pos_msgsender(self):
         name = inspect.currentframe().f_code.co_name[5:]


### PR DESCRIPTION
this adds a detector ether leaks, and slightly refactors the detector tests

- make the LoopDepthLimiter plugin configurable (change the default to 5! the some for reason etherleak_pos_argument1.sol test needs 5, not 2 to work...)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1077)
<!-- Reviewable:end -->
