### PR TITLE
Added --txnoether option to avoid sending ether to contracts

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -70,6 +70,9 @@ def parse_arguments():
     parser.add_argument('--txnocoverage', action='store_true',
                         help='Do not use coverage as stopping criteria (Ethereum only)')
 
+    parser.add_argument('--txnoether', action='store_true',
+                        help='Do not send ether to contract (Ethereum only)')
+
     parser.add_argument('--txaccount', type=str, default="attacker",
                         help='Account used as caller in the symbolic transactions, either "attacker" or "owner" (Ethereum only)')
 
@@ -148,7 +151,7 @@ def ethereum_cli(args):
 
     logger.info("Beginning analysis")
 
-    m.multi_tx_analysis(args.argv[0], contract_name=args.contract, tx_limit=args.txlimit, tx_use_coverage=not args.txnocoverage, tx_account=args.txaccount)
+    m.multi_tx_analysis(args.argv[0], contract_name=args.contract, tx_limit=args.txlimit, tx_use_coverage=not args.txnocoverage, tx_send_ether=not args.txnoether, tx_account=args.txaccount)
 
     #TODO unregister all plugins
     m.finalize()

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -71,7 +71,7 @@ def parse_arguments():
                         help='Do not use coverage as stopping criteria (Ethereum only)')
 
     parser.add_argument('--txnoether', action='store_true',
-                        help='Do not send ether to contract (Ethereum only)')
+                        help='Do not attempt to send ether to contract (Ethereum only)')
 
     parser.add_argument('--txaccount', type=str, default="attacker",
                         help='Account used as caller in the symbolic transactions, either "attacker" or "owner" (Ethereum only)')

--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -1961,7 +1961,7 @@ class ManticoreEVM(Manticore):
 
         return address
 
-    def multi_tx_analysis(self, solidity_filename, contract_name=None, tx_limit=None, tx_use_coverage=True, tx_account="attacker", args=None):
+    def multi_tx_analysis(self, solidity_filename, contract_name=None, tx_limit=None, tx_use_coverage=True, tx_send_ether=True, tx_account="attacker", args=None):
 
         owner_account = self.create_account(balance=1000, name='owner')
         attacker_account = self.create_account(balance=1000, name='attacker')
@@ -1995,11 +1995,14 @@ class ManticoreEVM(Manticore):
 
                 # run_symbolic_tx
                 symbolic_data = self.make_symbolic_buffer(320)
-                symbolic_value = self.make_symbolic_value()
+                if tx_send_ether:
+                    value = self.make_symbolic_value()
+                else:
+                    value = 0
                 self.transaction(caller=tx_account[min(tx_no, len(tx_account) - 1)],
                                  address=contract_account,
                                  data=symbolic_data,
-                                 value=symbolic_value)
+                                 value=value)
                 logger.info("%d alive states, %d terminated states", self.count_running_states(), self.count_terminated_states())
             except NoAliveStates:
                 break


### PR DESCRIPTION
The majority of the contracts we analyze everyday do not receive any ether (e.g. vanilla ERC20 ones). If Manticore tries to send ether to them, it will only generate useless test cases and slow down the analysis. That's why I believe it is useful to add an optional flag to avoid manticore to send ether when it is performing the symbolic execution of the transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1078)
<!-- Reviewable:end -->
