### PR TITLE
python3 update to linux example makefile

### DIFF
--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS=-O3 -static
 NOSTDLIBFLAGS=-fno-builtin -static -nostdlib -fomit-frame-pointer
-PYTHON=python
+PYTHON=python3
 
 EXAMPLES=basic sindex  strncmp  arguments ibranch sendmail crackme indexhell  helloworld simple_copy simpleassert
 OTHER_EXAMPLES=nostdlib


### PR DESCRIPTION
Ubuntu 18.04 doesn't alias python to python3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1122)
<!-- Reviewable:end -->
