### PR TITLE
Fixes missing is_return_symbolic value

### DIFF
--- a/manticore/ethereum.py
+++ b/manticore/ethereum.py
@@ -2619,7 +2619,8 @@ class ManticoreEVM(Manticore):
                             ret_types = metadata.get_func_return_types(function_id)
                             return_data = state.solve_one(tx.return_data)
                             return_values = ABI.deserialize(ret_types, return_data)  # function return
-                            is_return_symbolic = issymbolic(tx.return_data)
+
+                        is_return_symbolic = issymbolic(tx.return_data)
 
                         tx_summary.write('\n')
                         tx_summary.write("Function call:\n")


### PR DESCRIPTION
Fixes the issue presented below:
```
➜ cat manticore_ex.py
from manticore.ethereum import ManticoreEVM, evm, Operators

m = ManticoreEVM()

source_code = '''
pragma solidity ^0.4.24;

contract Foo {
    function foo() {}
}
'''

user_account = m.create_account(balance=1000, name='user_account')

contract_account = m.solidity_create_contract(source_code, owner=user_account, name='contract_account')
contract_account.foo(1)

print("[+] Now the symbolic values")
symbolic_data = m.make_symbolic_buffer(320)
symbolic_value = m.make_symbolic_value(name="VALUE")
symbolic_address = m.make_symbolic_value(name="ADDRESS")
symbolic_caller = m.make_symbolic_value(name="CALLER")
m.transaction(
    caller=symbolic_caller,
    address=symbolic_address,
    data=symbolic_data,
    value=symbolic_value
)

m.finalize()
print("[+] Look for results in %s " % m.workspace)

➜ python manticore_ex.py
[+] Now the symbolic values
Traceback (most recent call last):
  File "manticore_ex.py", line 30, in <module>
    m.finalize()
  File "/home/dc/projects/manticore/manticore/ethereum.py", line 2715, in finalize
    finalizer(-1)
  File "/home/dc/projects/manticore/manticore/ethereum.py", line 2702, in finalizer
    self._generate_testcase_callback(st, 'test', '')
  File "/home/dc/projects/manticore/manticore/ethereum.py", line 2635, in _generate_testcase_callback
    is_something_symbolic = is_calldata_symbolic or is_return_symbolic
UnboundLocalError: local variable 'is_return_symbolic' referenced before assignment
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1125)
<!-- Reviewable:end -->
