### PR TITLE
Simplify taint_with

### DIFF
--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import collections
 import logging
@@ -64,7 +65,7 @@ def get_taints(arg, taint=None):
 
 def taint_with(arg, taint, value_bits=256, index_bits=256):
     '''
-    Helper to taint a value, TODO / FIXME: this should not taint in place.
+    Helper to taint a value.
     :param arg: a value or Expression
     :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None this functions check for any taint value.
     '''
@@ -78,6 +79,7 @@ def taint_with(arg, taint, value_bits=256, index_bits=256):
             raise ValueError("type not supported")
 
     else:
+        arg = copy.copy(arg)
         arg._taint |= tainted_fset
 
     return arg

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -64,17 +64,22 @@ def get_taints(arg, taint=None):
 
 def taint_with(arg, taint, value_bits=256, index_bits=256):
     '''
-    Helper to taint a value, Fixme this should not taint in place.
+    Helper to taint a value, TODO / FIXME: this should not taint in place.
     :param arg: a value or Expression
     :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None this functions check for any taint value.
     '''
+    tainted_fset = frozenset((taint,))
+
     if not issymbolic(arg):
         if isinstance(arg, int):
             arg = BitVecConstant(value_bits, arg)
-    if not issymbolic(arg):
-        raise ValueError("type not supported")
-    #fixme we should make a copy and taint the copy
-    arg._taint = arg.taint | frozenset((taint,))
+            arg._taint = tainted_fset
+        else:
+            raise ValueError("type not supported")
+
+    else:
+        arg._taint |= tainted_fset
+
     return arg
 
 


### PR DESCRIPTION
1. Does not check for `issymbolic `twice
2. Does not retrieve object taints when `int` was passed (and so is not tainted)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1133)
<!-- Reviewable:end -->

