### PR TITLE
Fix err message if file doesn't exist

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -151,6 +151,8 @@ class Manticore(Eventful):
         self._executor = Executor(store=self._output.store, policy=policy)
         self._workers = []
 
+        self.plugins = set()
+
         # Link Executor events to default callbacks in manticore object
         self.forward_events_from(self._executor)
 
@@ -167,8 +169,6 @@ class Manticore(Eventful):
 
         if not isinstance(self._initial_state, State):
             raise TypeError("Manticore must be intialized with either a State or a path to a binary")
-
-        self.plugins = set()
 
         # Move the folowing into a linux plugin
         self._assertions = {}


### PR DESCRIPTION
we used to get this line:

```
[I] vagrant ubuntu-bionic /v/manticore (dev-concrete-replay) ❯ manticore asd
Traceback (most recent call last):
  File "/home/vagrant/.local/bin/manticore", line 11, in <module>
    load_entry_point('manticore', 'console_scripts', 'manticore')()
  File "/vagrant/manticore/manticore/__main__.py", line 207, in main
    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, concrete_start=args.data)
  File "/vagrant/manticore/manticore/manticore.py", line 159, in __init__
    raise Exception('{} is not an existing regular file'.format(path_or_state))
Exception: asd is not an existing regular file
Exception ignored in: <bound method Manticore.__del__ of <manticore.manticore.Manticore object at 0x7fd1df295940>>
Traceback (most recent call last):
  File "/vagrant/manticore/manticore/manticore.py", line 231, in __del__
    plugins = list(self.plugins)
AttributeError: 'Manticore' object has no attribute 'plugins'
```
the exception was being thrown in the ctor before self.plugins was created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1134)
<!-- Reviewable:end -->
