### PR TITLE
fix building the examples in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ USER manticore
 WORKDIR /home/manticore
 ENV HOME /home/manticore
 ENV PATH $PATH:$HOME/.local/bin
+ENV LANG C.UTF-8
 
 RUN git clone https://github.com/trailofbits/manticore.git
 RUN cd manticore && pip3 install --user .


### PR DESCRIPTION
An unfortunate interaction between the locale, python3, and unicode characters present in crackme.py led to an obtuse failure. Setting the locale to UTF-8 fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1137)
<!-- Reviewable:end -->
