### PR TITLE
A massive amount of spellchecking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,7 @@ Thanks to our external contributors to this release!
 ### Added
 
 - Support for Redis as a storage backend, plus an API for user-defined serializers and storage backends
-- "Events" which work as global signals for communication across manticore
+- "Events" which work as global signals for communication across Manticore
 - Support for using Binary Ninja for visualization
 - Executor now provides a global shared context
 - State now provides a local context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ response if you ask in our [chat room](https://empireslacking.herokuapp.com/)
 ## Code
 
 Manticore uses the pull request contribution model. Please make an account on
-github, fork this repo, and submit code contributions via pull request. For
+Github, fork this repo, and submit code contributions via pull request. For
 more documentation, look [here](https://guides.github.com/activities/forking/).
 
 Some pull request guidelines:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Install and try Manticore in a few shell commands (see an [asciinema](https://as
 # Install system dependencies
 sudo apt-get update && sudo apt-get install python3 python3-pip -y
 
-# Install manticore and its dependencies
+# Install Manticore and its dependencies
 sudo pip3 install manticore
 
 # Download the examples
@@ -141,7 +141,7 @@ python3 count_instructions.py ../linux/helloworld
 You can also use Docker to quickly install and try Manticore:
 
 ```
-# Download manticore image
+# Download the Manticore image
 docker pull trailofbits/manticore
 
 # Download the examples
@@ -210,7 +210,7 @@ Feel free to stop by our [Slack channel](https://empirehacking.slack.com/message
 Documentation is available in several places:
 
   * The [wiki](https://github.com/trailofbits/manticore/wiki) contains some
-    basic information about getting started with manticore and contributing
+    basic information about getting started with Manticore and contributing
 
   * The [examples](examples) directory has some very minimal examples that
     showcase API features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,12 +156,12 @@ texinfo_documents = [
 # -- Custom
 
 # our setup.py does not install z3-solver when on rtd because
-# for some reason z3 it built during the dep install process,
-# and rtd ooms. something related to `python setup.py --force`
+# for some reason z3 is built during the dep install process,
+# and rtd ooms (something related to `python setup.py --force`)
 
 # so because z3-solver is not installed as a dep, but
 # rtd still does `import manticore`, we need to mock the environment
-# enough to make manticore importable. specifically, we need to mock
+# enough to make Manticore importable. specifically, we need to mock
 # things so a Z3Solver can be constructed.
 
 

--- a/docs/gotchas.rst
+++ b/docs/gotchas.rst
@@ -34,4 +34,4 @@ Client code should use the :meth:`~manticore.Manticore.locked_context` API::
 "Random" Policy
 ---------------
 
-The `random` policy, which is the manticore default, is not actually random and is instead deterministically seeded. This means that running the same analysis twice should return the same results (and get stuck in the same places).
+The `random` policy, which is the Manticore default, is not actually random and is instead deterministically seeded. This means that running the same analysis twice should return the same results (and get stuck in the same places).

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -18,7 +18,7 @@ if errorlevel 9009 (
 	echo.
 	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
 	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.to the full path of the 'sphinx-build' executable. Alternatively, you
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from

--- a/examples/evm/coverage.sol
+++ b/examples/evm/coverage.sol
@@ -1,6 +1,6 @@
-/* There is two main functions `explore` and  `explore2`
-`explore` is the first level of exploration, you have to call it multiple times to explore the path
-`explore2` is a bit more complex, the owner has to call first the `enable_exploration` function
+/* There are two main functions: `explore` and  `explore2`
+`explore` is the first level of exploration; you have to call it multiple times to explore the path
+`explore2` is a bit more complex; the owner has to call first the `enable_exploration` function
 */
 pragma solidity ^0.4.15;
 
@@ -47,7 +47,7 @@ contract Coverage{
     function add(address user, uint val)
         private
     {
-        // comment the require to trigger overflow
+        // comment out the require to trigger an overflow
         require(balances[user] + val >= val);
         balances[user] += val;
     }
@@ -55,14 +55,14 @@ contract Coverage{
     function remove(address user, uint val)
         private
     {
-        // comment the require to trigger underflow
+        // comment out the require to trigger an underflow
         require(balances[user] >= val);
         balances[user] -= val;
     }
 
     // Entry point for simple exploration
-    // Anyone can give or take to anyone
-    // But if you cant take to someone poorer than you
+    // Anyone can give to or take from anyone
+    // But you can't take from someone poorer than you
     function explore(uint value, address user, bool give)
         public
     {
@@ -88,7 +88,7 @@ contract Coverage{
             }
             else{
                 // If you try to take to someone poorer than you
-                // you will give it the value
+                // you will instead give the specified value
                 remove(msg.sender, value);
                 add(user, value);
                 Give(msg.sender, user, value);
@@ -96,7 +96,7 @@ contract Coverage{
         }
     }
 
-    // Same as explore, but you can really take to anyone
+    // Same as explore, but you can really take from anyone
     function explore2(uint value, address user, bool give)
         onlyExplorationOn
         public

--- a/examples/evm/mappingchallenge.py
+++ b/examples/evm/mappingchallenge.py
@@ -27,7 +27,7 @@ print("Source code:\n", source_code)
 
 
 class StopAtDepth(Detector):
-    ''' This just abort explorations too deep '''
+    ''' This just aborts explorations that are too deep '''
 
     def will_start_run_callback(self, *args):
         with self.manticore.locked_context('seen_rep', dict) as reps:

--- a/examples/evm/minimal_bytecode_only.py
+++ b/examples/evm/minimal_bytecode_only.py
@@ -1,7 +1,7 @@
 from manticore.ethereum import ManticoreEVM, evm
 from binascii import unhexlify, hexlify
 ################ Script #######################
-# Bytecode only based analisys
+# Bytecode only based analysis
 # No solidity, no compiler, no metadata
 
 m = ManticoreEVM()

--- a/examples/evm/reentrancy_concrete.py
+++ b/examples/evm/reentrancy_concrete.py
@@ -88,7 +88,7 @@ m.world.set_balance(contract_account, 1000000000000000000)  #give it some ether
 
 exploit_account = m.solidity_create_contract(exploit_source_code, owner=attacker_account)
 
-print("[+] Setup the exploit")
+print("[+] Set up the exploit")
 exploit_account.set_vulnerable_contract(contract_account)
 exploit_account.set_reentry_reps(2)
 
@@ -115,7 +115,7 @@ exploit_account.proxycall(ABI.function_selector('addToBalance()'), value=1000000
 print("[+] Let attacker extract all using exploit") 
 exploit_account.proxycall(ABI.function_selector('withdrawBalance()'))
 
-print("[+] Let attacker destroy the exploit andprofit") 
+print("[+] Let attacker destroy the exploit contract and profit") 
 exploit_account.get_money() 
 
 print(" attacker_account %x balance: %d"% (attacker_account.address, m.get_balance(attacker_account.address)))

--- a/examples/evm/reentrancy_symbolic.py
+++ b/examples/evm/reentrancy_symbolic.py
@@ -93,7 +93,7 @@ print("     user_account %x balance: %d"%  (user_account.address, m.get_balance(
 print("     contract_account %x balance: %d"%  (contract_account.address, m.get_balance(contract_account.address)))
 
 
-print("[+] Setup the exploit")
+print("[+] Set up the exploit")
 exploit_account.set_vulnerable_contract(contract_account)
 
 print("\t Setting 30 reply reps")

--- a/examples/linux/arguments.c
+++ b/examples/linux/arguments.c
@@ -1,4 +1,4 @@
-/* This program parses a commandline argument.
+/* This program parses a command line argument.
  *
  * Compile with :
  *   $ gcc -static -Os arguments.c -o arguments

--- a/examples/linux/basic.c
+++ b/examples/linux/basic.c
@@ -8,7 +8,7 @@
  * Analyze it with:
  *   $ manticore basic
  *
- *   - By default manticore will consider all input of stdin symbolic
+ *   - By default, Manticore will consider all input of stdin to be symbolic
  *
  * Expected output:
  *  $ manticore basic

--- a/examples/linux/crackme.py
+++ b/examples/linux/crackme.py
@@ -9,7 +9,7 @@ password = 'SCRT'
 
 PROGRAM = ''
 PROGRAM += '''
-/* This program parses a commandline argument.
+/* This program parses a command line argument.
  *
  * Compile with :
  *   $ gcc -static -Os crackme.c -o crackme
@@ -17,7 +17,7 @@ PROGRAM += '''
  * Analyze it with:
  *   $ manticore crackme 
  *
- *   - By default manticore will consider all input of stdin symbolic
+ *   - By default, Manticore will consider all input of stdin to be symbolic
  *     It will explore all possible paths, eventually finding the SCRT key
  * 
  * Expected output:

--- a/examples/linux/indexhell.c
+++ b/examples/linux/indexhell.c
@@ -8,7 +8,7 @@
  * Analyze it with:
  *   $ manticore indexhell
  *
- *   - By default manticore will consider all input of stdin symbolic
+ *   - By default, Manticore will consider all input of stdin to be symbolic
  *
  * 2017-04-24 12:46:46,227: [15880] MAIN:INFO: Loading program: ['indexhell']
  * 2017-04-24 12:46:46,228: [15880] MAIN:INFO: Workspace: ./mcore_72BTxZ

--- a/examples/linux/nostdlib.c
+++ b/examples/linux/nostdlib.c
@@ -1,5 +1,5 @@
 /* Minimal toy example with some input output no stdlib
- * Symbolic values are read from stdin using int80 or syscall. The program has 2 posible paths
+ * Symbolic values are read from stdin using int80 or syscall. The program has 2 possible paths
  * 
  * Compile with :
  *   $ gcc -fno-builtin -static -nostdlib -m32  -fomit-frame-pointer  toy001.c  -o toy001

--- a/examples/linux/sindex.c
+++ b/examples/linux/sindex.c
@@ -10,7 +10,7 @@
  * Analyze it with:
  *   $ manticore sindex
  *
- *   - By default manticore will consider` all input of stdin symbolic
+ *   - By default, Manticore will consider` all input of stdin to be symbolic
  *
  * Expected output:
  *  $ manticore sindex

--- a/examples/linux/strncmp.c
+++ b/examples/linux/strncmp.c
@@ -7,7 +7,7 @@
  *
  * Analyze it with:
  *  $ manticore strncmp
- *   - By default manticore will consider` all input of stdin symbolic
+ *   - By default, Manticore will consider` all input of stdin to be symbolic
  *
  * Expected output:
  * 2017-04-24 16:04:22,261: [30182] MAIN:INFO: Loading program: ['strncmp']

--- a/examples/script/concolic.py
+++ b/examples/script/concolic.py
@@ -214,7 +214,7 @@ def get_new_constrs_for_queue(oldcons, newcons):
         # candidate new constraint sets might not be sat because we blindly
         # permute the new constraints that the path uncovered and append them
         # back onto the original set. we do this without regard for how the
-        # permutation of the new constraints combines with the old constratins
+        # permutation of the new constraints combines with the old constraints
         # to affect the satisfiability of the whole
         if constraints_are_sat(candidate):
             ret.append(candidate)
@@ -243,7 +243,7 @@ def concrete_input_to_constraints(ci, prev=None):
     
     log("getting constraints from symbolic run")
     cons, datas = symbolic_run_get_cons(trc)
-    # hmmm ideally do some smart stuff so we don't have to check if the
+    # hmmm: ideally, do some smart stuff so we don't have to check if the
     # constraints are unsat. something like the compare the constraints set
     # which you used to generate the input, and the constraint set you got
     # from the symex. sounds pretty hard
@@ -268,8 +268,8 @@ def main():
     for each in to_queue:
         q.put(each)
 
-    # hmmm probably issues with the datas stuff here? probably need to store
-    # the datas in the q or something. what if there was a new read(2) deep in the program, changing the datas
+    # hmmm: probably issues with the datas stuff here? probably need to store
+    # the datas in the queue or something. what if there was a new read(2) deep in the program, changing the datas?
     while not q.empty():
         log('get constraint set from queue, queue size: {}'.format(q.qsize()))
         cons = q.get()

--- a/examples/script/lads-baby-re.py
+++ b/examples/script/lads-baby-re.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         base = arraytop - 0x18
         for i in range(4):
             symbolic_input = cpu.read_int(base + i*4)
-            # TODO apis to contrain input to ascii
+            # TODO apis to constrain input to ascii
             concrete_input = state.solve_one(symbolic_input)
             flag += chr(concrete_input & 0xff)
         print('flag is:', flag)

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -77,7 +77,7 @@ def parse_arguments():
                         help='Account used as caller in the symbolic transactions, either "attacker" or "owner" (Ethereum only)')
 
     parser.add_argument('--contract', type=str,
-                        help='Contract name to analyze in case of multiple ones (Ethereum only)')
+                        help='Contract name to analyze in case of multiple contracts (Ethereum only)')
 
     parser.add_argument('--detect-overflow', action='store_true',
                         help='Enable integer overflow detection (Ethereum only)')
@@ -95,7 +95,7 @@ def parse_arguments():
                         help='Enable detection of reentrancy bug (Ethereum only)')
 
     parser.add_argument('--detect-unused-retval', action='store_true',
-                        help='Enable detection of not used internal transaction return value (Ethereum only)')
+                        help='Enable detection of unused internal transaction return value (Ethereum only)')
 
     parser.add_argument('--detect-delegatecall', action='store_true',
                         help='Enable detection of problematic uses of DELEGATECALL instruction (Ethereum only)')

--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -117,7 +117,7 @@ class Operand(object):
     def __init__(self, cpu, op):
         '''
         This encapsulates the arch-independent way to access instruction
-        operands and immediates based on the dissasembler operand descriptor in
+        operands and immediates based on the disassembler operand descriptor in
         use. This class knows how to browse an operand and get its details.
 
         It also knows how to access the specific Cpu to get the actual values

--- a/manticore/core/cpu/x86.py
+++ b/manticore/core/cpu/x86.py
@@ -51,7 +51,7 @@ OP_NAME_MAP = {
 
 
 ###############################################################################
-# Auxiliar decorators...
+# Auxiliary decorators...
 def rep(old_method):
     # This decorates REP instructions (STOS, LODS, MOVS, INS, OUTS)
     @wraps(old_method)
@@ -94,7 +94,7 @@ def repe(old_method):
 
             FLAG = count != 0
 
-            # Repeate!
+            # Repeat!
             if FLAG:
                 old_method(cpu, *args, **kw_args)
                 count = cpu.write_register(counter_name, count - 1)
@@ -723,7 +723,7 @@ class X86Cpu(Cpu):
     def _wrap_operands(self, operands):
         return [AMD64Operand(self, op) for op in operands]
 
-    # Auxiliar stack acess
+    # Auxiliary stack access
     def push(cpu, value, size):
         '''
         Writes a value in the stack.
@@ -1738,7 +1738,7 @@ class X86Cpu(Cpu):
         the length of the destination operand format. The CF and OF flags are
         set when significant bits are carried into the upper half of the
         result. The CF and OF flags are cleared when the result fits exactly in
-        the lower half of the result.The three forms of the IMUL instruction
+        the lower half of the result. The three forms of the IMUL instruction
         are similar in that the length of the product is calculated to twice
         the length of the operands. With the one-operand form, the product is
         stored exactly in the destination. With the two- and three- operand
@@ -1991,7 +1991,7 @@ class X86Cpu(Cpu):
         an immediate value is used as an operand, it is sign-extended to the
         length of the destination operand format.
         The SUB instruction does not distinguish between signed or unsigned
-        operands. Instedef SUBad, the processor evaluates the result for both
+        operands. Instead, the processor evaluates the result for both
         data types and sets the OF and CF flags to indicate a borrow in the
         signed or unsigned result, respectively. The SF flag indicates the sign
         of the signed result::
@@ -3688,7 +3688,7 @@ class X86Cpu(Cpu):
     @instruction
     def ROR(cpu, dest, src):
         '''
-        Rotates rigth (ROR).
+        Rotates right (ROR).
 
         Shifts (rotates) the bits of the first operand (destination operand) the number of bit positions specified in the
         second operand (count operand) and stores the result in the destination operand. The destination operand can be
@@ -3856,7 +3856,7 @@ class X86Cpu(Cpu):
 
         cpu.ZF = Operators.ITE(count != 0, res == 0, cpu.ZF)
         cpu.SF = Operators.ITE(count != 0, (res & SIGN_MASK) != 0, cpu.SF)
-        # OF is only defined for count == 1, but in practice (unit tests from real cpu) its calculated for count != 0
+        # OF is only defined for count == 1, but in practice (unit tests from real cpu) it's calculated for count != 0
         cpu.OF = Operators.ITE(count != 0, ((value >> (OperandSize - 1)) & 0x1) == 1, cpu.OF)
         cpu.PF = Operators.ITE(count != 0, cpu._calculate_parity_flag(res), cpu.PF)
 
@@ -5318,7 +5318,7 @@ class X86Cpu(Cpu):
         Calls to interrupt procedure.
 
         The INT n instruction generates a call to the interrupt or exception handler specified
-        with the destination operand. The INT n instruction is the  general mnemonic for executing
+        with the destination operand. The INT n instruction is the general mnemonic for executing
         a software-generated call to an interrupt handler. The INTO instruction is a special
         mnemonic for calling overflow exception (#OF), interrupt vector number 4. The overflow
         interrupt checks the OF flag in the EFLAGS register and calls the overflow interrupt handler

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -86,7 +86,7 @@ class Random(Policy):
 class Uncovered(Policy):
     def __init__(self, executor, *args, **kwargs):
         super().__init__(executor, *args, **kwargs)
-        # hook on the necesary executor signals
+        # hook on the necessary executor signals
         # on callbacks save data in executor.context['policy']
         with self._executor.locked_context() as ctx:
             ctx['policy'] = {}
@@ -222,7 +222,7 @@ class Executor(Eventful):
             It needs a lock. Its used like this:
 
             with executor.context() as context:
-                vsited = context['visited']
+                visited = context['visited']
                 visited.append(state.cpu.PC)
                 context['visited'] = visited
         '''
@@ -316,15 +316,15 @@ class Executor(Eventful):
         if self.is_shutdown():
             return None
 
-        # if not more states in the queue lets wait for some forks
+        # if not more states in the queue, let's wait for some forks
         while len(self._states) == 0:
-            # if no worker is running bail out
+            # if no worker is running, bail out
             if self.running == 0:
                 return None
-            # if a shutdown has been requested bail out
+            # if a shutdown has been requested, bail out
             if self.is_shutdown():
                 return None
-            # if there is actually some workers running wait for state forks
+            # if there ares actually some workers running, wait for state forks
             logger.debug("Waiting for available states")
             self._lock.wait()
 
@@ -405,7 +405,7 @@ class Executor(Eventful):
 
                 # enqueue new_state
                 state_id = self.enqueue(new_state)
-                # maintain a list of childres for logging purpose
+                # maintain a list of children for logging purpose
                 children.append(state_id)
 
         logger.info("Forking current state into states %r", children)

--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -293,7 +293,7 @@ class ExamplePlugin(Plugin):
         logger.info('did_execute_instruction %r %r %r %r', state, pc, target_pc, instruction)
 
     def will_start_run_callback(self, state):
-        ''' Called once at the begining of the run.
+        ''' Called once at the beginning of the run.
             state is the initial root state
         '''
         logger.info('will_start_run')

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -64,7 +64,7 @@ class ConstraintSet(object):
 
         if isinstance(constraint, BoolConstant):
             if not constraint.value:
-                logger.info("Adding an imposible constant constraint")
+                logger.info("Adding an impossible constant constraint")
                 self._constraints = [constraint]
             else:
                 return
@@ -77,7 +77,7 @@ class ConstraintSet(object):
                 raise ValueError("Added an impossible constraint")
 
     def _get_sid(self):
-        ''' Returns an unique id. '''
+        ''' Returns a unique id. '''
         assert self._child is None
         self._sid += 1
         return self._sid
@@ -218,7 +218,7 @@ class ConstraintSet(object):
         return self.to_string()
 
     def _make_unique_name(self, name='VAR'):
-        ''' Makes an uniq variable name'''
+        ''' Makes a unique variable name'''
         # the while loop is necessary because appending the result of _get_sid()
         # is not guaranteed to make a unique name on the first try; a colliding
         # name could have been added previously
@@ -244,7 +244,7 @@ class ConstraintSet(object):
 
             :param expression: the potentially foreign expression
             :param name_migration_map: mapping of already migrated variables. maps from string name of foreign variable to its currently existing migrated string name. this is updated during this migration.
-            :return: a migrated expresion where all the variables are local. name_migration_map is updated
+            :return: a migrated expression where all the variables are local. name_migration_map is updated
 
         '''
         if name_migration_map is None:
@@ -269,7 +269,7 @@ class ConstraintSet(object):
             else:
                 # foreign_var was not found in the local declared variables nor
                 # any variable with the same name was previously migrated
-                # lets make a new uniq internal name for it
+                # let's make a new unique internal name for it
                 migrated_name = foreign_var.name
                 if migrated_name in self._declarations:
                     migrated_name = self._make_unique_name(foreign_var.name + '_migrated')
@@ -288,15 +288,15 @@ class ConstraintSet(object):
                 # Update the name to name mapping
                 name_migration_map[foreign_var.name] = new_var.name
 
-        #  Actually replace each appearence of migrated variables by the new ones
+        #  Actually replace each appearance of migrated variables by the new ones
         migrated_expression = replace(expression, object_migration_map)
         return migrated_expression
 
     def new_bool(self, name=None, taint=frozenset(), avoid_collisions=False):
         ''' Declares a free symbolic boolean in the constraint store
             :param name: try to assign name to internal variable representation,
-                         if not uniq a numeric nonce will be appended
-            :param avoid_collisions: potentially avoid_collisions the variable to avoid name colisions if True
+                         if not unique, a numeric nonce will be appended
+            :param avoid_collisions: potentially avoid_collisions the variable to avoid name collisions if True
             :return: a fresh BoolVariable
         '''
         if name is None:
@@ -313,8 +313,8 @@ class ConstraintSet(object):
         ''' Declares a free symbolic bitvector in the constraint store
             :param size: size in bits for the bitvector
             :param name: try to assign name to internal variable representation,
-                         if not uniq a numeric nonce will be appended
-            :param avoid_collisions: potentially avoid_collisions the variable to avoid name colisions if True
+                         if not unique, a numeric nonce will be appended
+            :param avoid_collisions: potentially avoid_collisions the variable to avoid name collisions if True
             :return: a fresh BitVecVariable
         '''
         if not (size == 1 or size % 8 == 0):
@@ -334,9 +334,9 @@ class ConstraintSet(object):
             :param index_bits: size in bits for the array indexes one of [32, 64]
             :param value_bits: size in bits for the array values
             :param name: try to assign name to internal variable representation,
-                         if not uniq a numeric nonce will be appended
-            :param index_max: upper limit for indexes on ths array (#FIXME)
-            :param avoid_collisions: potentially avoid_collisions the variable to avoid name colisions if True
+                         if not unique, a numeric nonce will be appended
+            :param index_max: upper limit for indexes on this array (#FIXME)
+            :param avoid_collisions: potentially avoid_collisions the variable to avoid name collisions if True
             :return: a fresh ArrayProxy
         '''
         if name is None:

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -71,7 +71,7 @@ class Operation(Expression):
         assert all(isinstance(x, Expression) for x in operands)
         self._operands = operands
 
-        # If taint was not forced by a keyword argument calculate default
+        # If taint was not forced by a keyword argument, calculate default
         if 'taint' not in kwargs:
             kwargs['taint'] = reduce(lambda x, y: x.union(y.taint), operands, frozenset())
 
@@ -595,7 +595,7 @@ class Array(Expression):
 
     def cast(self, possible_array):
         if isinstance(possible_array, bytearray):
-            # FIXME Ths should be related to a constrainSet
+            # FIXME This should be related to a constrainSet
             arr = ArrayVariable(self.index_bits, len(possible_array), 8)
             for pos, byte in enumerate(possible_array):
                 arr = arr.store(pos, byte)
@@ -852,7 +852,7 @@ class ArrayProxy(Array):
             self._array = array
             self._name = array.name
         else:
-            #arrayproxy for an prepopulated array
+            #arrayproxy for a prepopulated array
             super().__init__(array.index_bits, array.index_max, array.value_bits)
             self._name = array.underlying_variable.name
             self._array = array
@@ -910,8 +910,8 @@ class ArrayProxy(Array):
         if isinstance(index, Constant):
             self._concrete_cache[index.value] = value
         self.written.add(index)
-        auxiliar = self._array.store(index, value)
-        self._array = auxiliar
+        auxiliary = self._array.store(index, value)
+        self._array = auxiliary
         return self
 
     def __getitem__(self, index):

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -4,8 +4,9 @@
 # A solver maintains a companion smtlib capable process connected via stdio.
 # It can be in 4 main states: None, unknown, sat, unsat
 # None      nothing was yet sent to the smtlib process. Al the state is only at the python side
-# unknown   is an error state. Some query sent early was unsuccessful or timed out. Further
-#           interaction with the smtlib process will probably kept beign unknown. An exception is raised.
+# unknown   is an error state. Some query sent earlier was unsuccessful or timed out.
+#           Further interaction with the smtlib process will probably keep returning
+#           unknown. An exception is raised.
 # sat       the current set of constraints is satisfiable and has at least one solution
 # unsat     the current set of constraints is impossible
 #
@@ -54,7 +55,7 @@ class Solver(object, metaclass=ABCMeta):
         pass
 
     def optimize(self, constraints, X, operation, M=10000):
-        ''' Iterativelly finds the maximum or minimal value for the operation
+        ''' Iteratively finds the maximum or minimal value for the operation
             (Normally Operators.UGT or Operators.ULT)
             :param constraints: the constraints set
             :param X: a symbol or expression
@@ -89,7 +90,7 @@ class Solver(object, metaclass=ABCMeta):
         raise Exception("Abstract method not implemented")
 
     def max(self, constraints, X, M=10000):
-        ''' Iterativelly finds the maximum value for a symbol.
+        ''' Iteratively finds the maximum value for a symbol.
             :param X: a symbol or expression
             :param M: maximum number of iterations allowed
         '''
@@ -97,7 +98,7 @@ class Solver(object, metaclass=ABCMeta):
         return self.optimize(constraints, X, 'maximize')
 
     def min(self, constraints, X, M=10000):
-        ''' Iterativelly finds the minimum value for a symbol.
+        ''' Iteratively finds the minimum value for a symbol.
             :param X: a symbol or expression
             :param M: maximum number of iterations allowed
         '''
@@ -179,7 +180,7 @@ class Z3Solver(Solver):
         try:
             self._proc = Popen(self._command.split(' '), stdin=PIPE, stdout=PIPE, bufsize=0, universal_newlines=True)
         except OSError as e:
-            print(e, "Probably too  much cached expressions? visitors._cache...")
+            print(e, "Probably too many cached expressions? visitors._cache...")
             # Z3 was removed from the system in the middle of operation
             raise Z3NotFoundError  # TODO(mark) don't catch this exception in two places
 
@@ -337,7 +338,7 @@ class Z3Solver(Solver):
         self._send('(push 1)')
 
     def _pop(self):
-        ''' Recall the last pushed constraint store  and state. '''
+        ''' Recall the last pushed constraint store and state. '''
         self._send('(pop 1)')
 
     #@memoized
@@ -400,7 +401,7 @@ class Z3Solver(Solver):
 
     #@memoized
     def optimize(self, constraints, x, goal, M=10000):
-        ''' Iterativelly finds the maximum or minimal value for the operation
+        ''' Iteratively finds the maximum or minimal value for the operation
             (Normally Operators.UGT or Operators.ULT)
             :param X: a symbol or expression
             :param M: maximum number of iterations allowed

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -195,7 +195,7 @@ class PrettyPrinter(Visitor):
         '''
         Overload Visitor.visit because:
         - We need a pre-order traversal
-        - We use a recursion as it makes eaiser to keep track of the indentation
+        - We use a recursion as it makes it easier to keep track of the indentation
 
         '''
         self._method(expression)
@@ -203,7 +203,7 @@ class PrettyPrinter(Visitor):
     def _method(self, expression, *args):
         '''
         Overload Visitor._method because we want to stop to iterate over the
-        visit_ functions as soon as a valide visit_ function is found
+        visit_ functions as soon as a valid visit_ function is found
         '''
         assert expression.__class__.__mro__[-1] is object
         for cls in expression.__class__.__mro__:
@@ -473,7 +473,7 @@ class ArithmeticSimplifier(Visitor):
         ''' ct & x => x & ct                move constants to the right
             a & 0 => 0                      remove zero
             a & 0xffffffff => a             remove full mask
-            (b & ct2) & ct => b & (ct&ct2)  ?
+            (b & ct2) & ct => b & (ct&ct2)  associative property
             (a & (b | c) => a&b | a&c       distribute over |
         '''
         left = expression.operands[0]
@@ -519,7 +519,7 @@ class ArithmeticSimplifier(Visitor):
         if isinstance(index, BitVecConstant):
             ival = index.value
 
-            # props are slow and using them tight loops should be avoided, esp when they offer no additional validation
+            # props are slow and using them in tight loops should be avoided, esp when they offer no additional validation
             # arr._operands[1] = arr.index, arr._operands[0] = arr.array
             while isinstance(arr, ArrayStore) and isinstance(arr._operands[1], BitVecConstant) and arr._operands[1]._value != ival:
                 arr = arr._operands[0]  # arr.array
@@ -694,7 +694,7 @@ def translate_to_smtlib(expression, **kwargs):
 
 
 class Replace(Visitor):
-    ''' Simple visitor to replaces expresions '''
+    ''' Simple visitor to replaces expressions '''
 
     def __init__(self, bindings=None, **kwargs):
         super().__init__(**kwargs)

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -340,7 +340,7 @@ class State(Eventful):
     def solve_max(self, expr):
         '''
         Solves a symbolic :class:`~manticore.core.smtlib.expression.Expression` into
-        its maximun solution
+        its maximum solution
 
         :param manticore.core.smtlib.Expression expr: Symbolic value to solve
         :return: Concrete value
@@ -354,7 +354,7 @@ class State(Eventful):
     def solve_min(self, expr):
         '''
         Solves a symbolic :class:`~manticore.core.smtlib.expression.Expression` into
-        its minimun solution
+        its minimum solution
 
         :param manticore.core.smtlib.Expression expr: Symbolic value to solve
         :return: Concrete value

--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -224,7 +224,7 @@ class MemoryStore(Store):
     """
     An in-memory (dict) Manticore workspace.
 
-    NOTE: This is mostly used for experimentation and testing funcionality.
+    NOTE: This is mostly used for experimentation and testing functionality.
     Can not be used with multiple workers!
     """
     store_type = 'mem'
@@ -364,7 +364,7 @@ class Workspace(object):
         Save a state to storage, return identifier.
 
         :param state: The state to save
-        :param int state_id: If not None force the state id potentially overwritting old states
+        :param int state_id: If not None force the state id potentially overwriting old states
         :return: New state id
         :rtype: int
         """

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -168,14 +168,15 @@ class Manticore(Eventful):
             raise TypeError('path_or_state must be either a str or State, not {}'.format(type(path_or_state).__name__))
 
         if not isinstance(self._initial_state, State):
-            raise TypeError("Manticore must be intialized with either a State or a path to a binary")
+            raise TypeError("Manticore must be initialized with either a State or a path to a binary")
 
-        # Move the folowing into a linux plugin
+        # Move the following into a linux plugin
+
         self._assertions = {}
         self._coverage_file = None
         self.trace = None
 
-        # FIXME move the folowing to a plugin
+        # FIXME move the following to a plugin
         self.subscribe('will_generate_testcase', self._generate_testcase_callback)
         self.subscribe('did_finish_run', self._did_finish_run_callback)
 
@@ -246,7 +247,7 @@ class Manticore(Eventful):
         :type envp: str
         :param symbolic_files: Filenames to mark as having symbolic input
         :type symbolic_files: list[str]
-        :param str concrete_start: Concrete stdin to use before symbolic inputt
+        :param str concrete_start: Concrete stdin to use before symbolic input
         :param kwargs: Forwarded to the Manticore constructor
         :return: Manticore instance, initialized with a Linux State
         :rtype: Manticore
@@ -262,7 +263,7 @@ class Manticore(Eventful):
         Constructor for Decree binary analysis.
 
         :param str path: Path to binary to analyze
-        :param str concrete_start: Concrete stdin to use before symbolic inputt
+        :param str concrete_start: Concrete stdin to use before symbolic input
         :param kwargs: Forwarded to the Manticore constructor
         :return: Manticore instance, initialized with a Decree State
         :rtype: Manticore
@@ -361,7 +362,7 @@ class Manticore(Eventful):
 
     def enqueue(self, state):
         ''' Dynamically enqueue states. Users should typically not need to do this '''
-        assert not self.running, "Can't add state where running. Can we?"
+        assert not self.running, "Can't add state when running, can we?"
         self._executor.enqueue(state)
 
     ###########################################################################
@@ -583,7 +584,7 @@ class Manticore(Eventful):
             self.enqueue(self._initial_state)
             self._initial_state = None
 
-        # Copy the local main context to the shared conext
+        # Copy the local main context to the shared context
         self._executor._shared_context.update(self._context)
         self._context = None
 

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -444,7 +444,7 @@ class Decree(Platform):
         ''' random - fill a buffer with random data
 
            The  random  system call populates the buffer referenced by buf with up to
-           count bytes of random data. If count is zero, random returns 0 and optionallyi
+           count bytes of random data. If count is zero, random returns 0 and optionally
            sets *rx_bytes to zero. If count is greater than SSIZE_MAX, the result is unspecified.
 
            :param cpu: current CPU
@@ -486,10 +486,10 @@ class Decree(Platform):
 
             The receive system call reads up to count bytes from file descriptor fd to the
             buffer pointed to by buf. If count is zero, receive returns 0 and optionally
-            dets *rx_bytes to zero.
+            sets *rx_bytes to zero.
 
             :param cpu: current CPU.
-            :param fd: a valid file descripor
+            :param fd: a valid file descriptor
             :param buf: a memory buffer
             :param count: max number of bytes to receive
             :param rx_bytes: if valid, points to the actual number of bytes received
@@ -519,7 +519,7 @@ class Decree(Platform):
             # if random.randint(5) == 0 and count > 1:
             #    count = count/2
 
-            # Read the data and put in tin memory
+            # Read the data and put it in memory
             data = self.files[fd].receive(count)
             self.syscall_trace.append(("_receive", fd, data))
             cpu.write_bytes(buf, data)
@@ -543,7 +543,7 @@ class Decree(Platform):
           and optionally sets *tx_bytes to zero.
 
           :param cpu           current CPU
-          :param fd            a valid file descripor
+          :param fd            a valid file descriptor
           :param buf           a memory buffer
           :param count         number of bytes to send
           :param tx_bytes      if valid, points to the actual number of bytes transmitted
@@ -658,7 +658,7 @@ class Decree(Platform):
 
         if timeout:
             if timeout not in cpu.memory:  # todo: size
-                logger.info("FDWAIT: timeput is pointing to invalid memory. Returning EFAULT")
+                logger.info("FDWAIT: timeout is pointing to invalid memory. Returning EFAULT")
                 return Decree.CGC_EFAULT
 
         if readyfds:
@@ -698,7 +698,7 @@ class Decree(Platform):
                         readfds_ready.add(fd)
         n = len(readfds_ready) + len(writefds_ready)
         if n == 0:
-            # TODO FIX timout symbolic
+            # TODO FIX timeout symbolic
             if timeout != 0:
                 seconds = cpu.read_int(timeout, 32)
                 microseconds = cpu.read_int(timeout + 4, 32)
@@ -713,8 +713,8 @@ class Decree(Platform):
 
             cpu.PC -= cpu.instruction.size
             self.wait(readfds_wait, writefds_wait, to)
-            raise RestartSyscall()  # When comming back from a timeout remember
-            # not to backtrack instruction and set EAX to 0! :( uglyness alert!
+            raise RestartSyscall()  # When coming back from a timeout remember
+            # not to backtrack instruction and set EAX to 0! :( ugliness alert!
 
         if readfds:
             bits = 0
@@ -762,7 +762,7 @@ class Decree(Platform):
         ''' Yield CPU.
             This will choose another process from the RUNNNIG list and change
             current running process. May give the same cpu if only one running
-            proccess.
+            process.
         '''
         if len(self.procs) > 1:
             logger.info("SCHED:")
@@ -790,9 +790,9 @@ class Decree(Platform):
         self._current = next
 
     def wait(self, readfds, writefds, timeout):
-        ''' Wait for filedescriptors or timout.
-            Adds the current proceess in the correspondant wainting list and
-            yield the cpu to another running process.
+        ''' Wait for filedescriptors or timeout.
+            Adds the current process to the corresponding waiting list and
+            yields the cpu to another running process.
         '''
         logger.info("WAIT:")
         logger.info("\tProcess %d is going to wait for [ %r %r %r ]", self._current, readfds, writefds, timeout)
@@ -825,8 +825,8 @@ class Decree(Platform):
             self.check_timers()
 
     def awake(self, procid):
-        ''' Remove procid from waitlists and restablish it in the running list '''
-        logger.info("Remove procid:%d from waitlists and restablish it in the running list", procid)
+        ''' Remove procid from waitlists and reestablish it in the running list '''
+        logger.info("Remove procid:%d from waitlists and reestablish it in the running list", procid)
         for wait_list in self.rwait:
             if procid in wait_list:
                 wait_list.remove(procid)
@@ -861,7 +861,7 @@ class Decree(Platform):
             self.awake(procid)
 
     def check_timers(self):
-        ''' Awake proccess if timer has expired '''
+        ''' Awake process if timer has expired '''
         if self._current is None:
             # Advance the clocks. Go to future!!
             advance = min([x for x in self.timers if x is not None]) + 1
@@ -875,7 +875,7 @@ class Decree(Platform):
 
     def execute(self):
         """
-        Execute one cpu instruction in the current thread (only one suported).
+        Execute one cpu instruction in the current thread (only one supported).
         :rtype: bool
         :return: C{True}
 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -17,12 +17,12 @@ import sha3
 
 logger = logging.getLogger(__name__)
 
-#fixme make it gobal using this https://docs.python.org/3/library/configparser.html
+#fixme make it global using this https://docs.python.org/3/library/configparser.html
 #and save it at the workspace so results are reproducible
 config = namedtuple("config", "out_of_gas")
 config.out_of_gas = None  # 0: default not enough gas, 1 default to always enough gas, 2: for on both
 
-# Auxiliar constants and functions
+# Auxiliary constants and functions
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
 MASK160 = 2 ** 160 - 1
@@ -167,14 +167,14 @@ class InvalidOpcode(EndTx):
 
 
 class StackOverflow(EndTx):
-    ''' Attemped to push more than 1024 items '''
+    ''' Attempted to push more than 1024 items '''
 
     def __init__(self):
         super().__init__('THROW')
 
 
 class StackUnderflow(EndTx):
-    ''' Attemped to pop from an empty stack '''
+    ''' Attempted to pop from an empty stack '''
 
     def __init__(self):
         super().__init__('THROW')
@@ -522,7 +522,7 @@ class EVM(Eventful):
         _decoding_cache[pc] = instruction
         return instruction
 
-    # auxiliar funcs
+    # auxiliary funcs
     # Stack related
     def _push(self, value):
         '''
@@ -566,7 +566,7 @@ class EVM(Eventful):
         #FIXME add configurable checks here
         config.out_of_gas = 3
 
-        # Iff both are concrete values...
+        # If both are concrete values...
         if not issymbolic(self._gas) and not issymbolic(fee):
             if self._gas < fee:
                 logger.debug("Not enough gas for instruction")
@@ -622,7 +622,7 @@ class EVM(Eventful):
         return arguments
 
     def _top_arguments(self):
-        #Get arguments (imm, top). Stack is not chanaged
+        #Get arguments (imm, top). Stack is not changed
         current = self.instruction
         arguments = []
         if current.has_operand:
@@ -914,27 +914,27 @@ class EVM(Eventful):
     ############################################################################
     # Comparison & Bitwise Logic Operations
     def LT(self, a, b):
-        '''Less-than comparision'''
+        '''Less-than comparison'''
         return Operators.ITEBV(256, Operators.ULT(a, b), 1, 0)
 
     def GT(self, a, b):
-        '''Greater-than comparision'''
+        '''Greater-than comparison'''
         return Operators.ITEBV(256, Operators.UGT(a, b), 1, 0)
 
     def SLT(self, a, b):
-        '''Signed less-than comparision'''
+        '''Signed less-than comparison'''
         # http://gavwood.com/paper.pdf
         s0, s1 = to_signed(a), to_signed(b)
         return Operators.ITEBV(256, s0 < s1, 1, 0)
 
     def SGT(self, a, b):
-        '''Signed greater-than comparision'''
+        '''Signed greater-than comparison'''
         # http://gavwood.com/paper.pdf
         s0, s1 = to_signed(a), to_signed(b)
         return Operators.ITEBV(256, s0 > s1, 1, 0)
 
     def EQ(self, a, b):
-        '''Equality comparision'''
+        '''Equality comparison'''
         return Operators.ITEBV(256, a == b, 1, 0)
 
     def ISZERO(self, a):
@@ -1825,7 +1825,7 @@ class EVMWorld(Platform):
         return self._world_state[address]['storage']
 
     def _set_storage(self, address, storage):
-        """ Private auxiliar function to replace the storage """
+        """ Private auxiliary function to replace the storage """
         self._world_state[address]['storage'] = storage
 
     def set_balance(self, address, value):
@@ -1945,9 +1945,9 @@ class EVMWorld(Platform):
         if address is None:
             address = self.new_address()
         if address in self.accounts:
-            # FIXME account may have been created via selfdestruct destinatary
-            # or CALL and may contain some ether already. Though if it was a
-            # selfdestroyed address it can not be reused
+            # FIXME account may have been created via selfdestruct destination
+            # or CALL and may contain some ether already, though if it was a
+            # selfdestructed address, it can not be reused
             raise EthereumError('The account already exists')
         if storage is None:
             storage = self.constraints.new_array(index_bits=256, value_bits=256, name='STORAGE_{:x}'.format(address), avoid_collisions=True)
@@ -2045,7 +2045,7 @@ class EVMWorld(Platform):
             def set_caller(state, solution):
                 world = state.platform
                 world._pending_transaction = sort, address, price, data, solution, value, gas
-            #Constraint it so it can range over all normal accounts
+            #Constrain it so it can range over all normal accounts
             cond = self._constraint_to_accounts(caller, ty='normal')
             self.constraints.add(cond)
             raise Concretize('Concretizing caller on transaction',
@@ -2073,7 +2073,7 @@ class EVMWorld(Platform):
             raise EVMException('Caller account does not exist')
 
         if address not in self.accounts:
-            # Creating a unaccessible account
+            # Creating an unaccessible account
             self.create_account(address=address)
 
         # Check depth

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -64,8 +64,8 @@ def mode_from_flags(file_flags):
 
 class File(object):
     def __init__(self, path, flags):
-        # TODO: assert file is seekable otherwise we should save what was
-        # read/write to the state
+        # TODO: assert file is seekable; otherwise we should save what was
+        # read from/written to the state
         mode = mode_from_flags(flags)
         self.file = open(path, mode)
 
@@ -92,7 +92,7 @@ class File(object):
             if closed:
                 self.file.close()
         except IOError:
-            # If the file can't be opened anymore, should not typically happen
+            # If the file can't be opened anymore (should not typically happen)
             self.file = None
         if pos is not None:
             self.seek(pos)
@@ -113,7 +113,7 @@ class File(object):
         return os.fstat(self.fileno())
 
     def ioctl(self, request, argp):
-        # argp ignored..
+        # argp ignored...
         return fcntl.fcntl(self, request)
 
     def tell(self, *args):
@@ -227,7 +227,7 @@ class SymbolicFile(File):
                 symbols_cnt += 1
 
         if symbols_cnt > max_size:
-            logger.warning(("Found more wilcards in the file than free ",
+            logger.warning(("Found more wildcards in the file than free ",
                             "symbolic values allowed (%d > %d)"),
                            symbols_cnt,
                            max_size)
@@ -1265,7 +1265,7 @@ class Linux(Platform):
                 return -errno.EFAULT
 
             try:
-                # Read the data and put in tin memory
+                # Read the data and put it in memory
                 data = self._get_fd(fd).read(count)
             except FdError as e:
                 logger.info(("READ: Not valid file descriptor on read."
@@ -2041,7 +2041,7 @@ class Linux(Platform):
         The source of random (/dev/random or /dev/urandom) is decided based on
         the flags value.
 
-        Manticore's implementation simply fills a buffer with zeroes -- chosing
+        Manticore's implementation simply fills a buffer with zeroes -- choosing
         determinism over true randomness.
 
         :param buf: address of buffer to be filled with random bytes
@@ -2067,7 +2067,7 @@ class Linux(Platform):
 
         return size
 
-    # Distpatchers...
+    # Dispatchers...
     def syscall(self):
         '''
         Syscall dispatcher.
@@ -2181,9 +2181,9 @@ class Linux(Platform):
             self._current = procid
 
     def connections(self, fd):
-        """ File descriptors are connected to each other like pipes. Except
-        for 0,1,2. If you write to FD(N)  then that comes out from FD(N+1)
-        and vice-versa
+        """ File descriptors are connected to each other like pipes, except
+        for 0, 1, and 2. If you write to FD(N) for N >=3, then that comes
+		out from FD(N+1) and vice-versa
         """
         if fd in [0, 1, 2]:
             return None
@@ -2476,7 +2476,7 @@ class SLinux(Linux):
     def add_symbolic_file(self, symbolic_file):
         '''
         Add a symbolic file. Each '+' in the file will be considered
-        as symbolic, other char are concretized.
+        as symbolic; other chars are concretized.
         Symbolic files must have been defined before the call to `run()`.
 
         :param str symbolic_file: the name of the symbolic file
@@ -2631,7 +2631,7 @@ class SLinux(Linux):
 
     def sys_openat(self, dirfd, buf, flags, mode):
         '''
-        A version of openat that includes a symbolic path and symnbolic directory file descriptor
+        A version of openat that includes a symbolic path and symbolic directory file descriptor
 
         :param dirfd: directory file descriptor
         :param buf: address of zero-terminated pathname

--- a/manticore/platforms/platform.py
+++ b/manticore/platforms/platform.py
@@ -6,7 +6,7 @@ class OSException(Exception):
 
 
 class SyscallNotImplemented(OSException):
-    ''' Exception raised when you try to call a not implemented
+    ''' Exception raised when you try to call an unimplemented
         system call. Go to linux.py and add it!
     '''
 

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -271,7 +271,7 @@ class UnicornEmulator(object):
             val = self._emu.reg_read(self._to_unicorn_id(reg))
             self._cpu.write_register(reg, val)
 
-        # Unicorn hack. On single step unicorn wont advance the PC register
+        # Unicorn hack. On single step, unicorn wont advance the PC register
         mu_pc = self.get_unicorn_pc()
         if saved_PC == mu_pc:
             self._cpu.PC = saved_PC + instruction.size

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -29,7 +29,7 @@ def istainted(arg, taint=None):
     '''
     Helper to determine whether an object if tainted.
     :param arg: a value or Expression
-    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None this functions check for any taint value.
+    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None, this function checks for any taint value.
     '''
 
     if not issymbolic(arg):
@@ -47,7 +47,7 @@ def get_taints(arg, taint=None):
     '''
     Helper to list an object taints.
     :param arg: a value or Expression
-    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None this functions check for any taint value.
+    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None, this function checks for any taint value.
     '''
 
     if not issymbolic(arg):
@@ -66,7 +66,7 @@ def taint_with(arg, taint, value_bits=256, index_bits=256):
     '''
     Helper to taint a value, Fixme this should not taint in place.
     :param arg: a value or Expression
-    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None this functions check for any taint value.
+    :param taint: a regular expression matching a taint value (eg. 'IMPORTANT.*'). If None, this function checks for any taint value.
     '''
     if not issymbolic(arg):
         if isinstance(arg, int):

--- a/scripts/binaryninja/README.md
+++ b/scripts/binaryninja/README.md
@@ -6,7 +6,7 @@ Example:
 
 ```
 ## Installation:
-Copy and paste the `manticore_viz` directoru to the binary ninja [plugin folder](https://github.com/Vector35/binaryninja-api/tree/dev/python/examples#loading-plugins).
+Copy and paste the `manticore_viz` directory to the binary ninja [plugin folder](https://github.com/Vector35/binaryninja-api/tree/dev/python/examples#loading-plugins).
 
 
 Alternatively, you can create a symbolic link to the respective directories.
@@ -18,6 +18,6 @@ ln -s <manticore_root>/scripts/binaryninja/manticore_viz .
 
 ## Usage
 
-- Run manticore on a binary
+- Run Manticore on a binary
 - Open the same binary in Binary Ninja
 - Select "Highlight Trace"

--- a/scripts/binaryninja/manticore_viz/__init__.py
+++ b/scripts/binaryninja/manticore_viz/__init__.py
@@ -101,7 +101,7 @@ class TraceVisualizer(object):
             op = xref.function.get_lifted_il_at(xref.address).operation
         except IndexError:
             w = "ManticoreTrace: Could not lookup " + hex(xref.address)
-            w += " address for funciton " + str(xref.function)
+            w += " address for function " + str(xref.function)
             log.log_warn(w)
             return
         if not (op == enums.LowLevelILOperation.LLIL_CALL or

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -9,7 +9,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description='Extract different statistic and information from a manticore workspace')
     parser.add_argument('--workspace', type=str, default=None,
-                        help='A folder name fpor temporaries and results. (default mcore_?????)')
+                        help='A folder name for temporaries and results. (default mcore_?????)')
     parser.add_argument('--pcfreq', action='store_true', help='Print out visited pc and frequency')
     parser.add_argument('--visited', action='store_true', help='Print out visited pc set')
     parser.add_argument('--bbs', action='store_true', help='Print out visited basic blocks ')
@@ -20,7 +20,7 @@ def parse_arguments():
     parsed.workspace = parsed.workspace[0]
 
     assert int(parsed.pcfreq) + int(parsed.visited) + int(
-        parsed.bbs) == 1, "Choose one option one option from: --pcfreq --visited"
+        parsed.bbs) == 1, "Choose one option from: --pcfreq --visited"
     return parsed
 
 
@@ -29,7 +29,7 @@ workspace = args.workspace
 
 # search previously generated states
 saved_states = [os.path.join(workspace, filename) for filename in os.listdir(workspace) if filename.endswith('.pkl')]
-# prepare a dictionary to hold stats
+# prepare a dictionary to hold states
 db = {}
 edges = {}
 for filename in saved_states:
@@ -55,7 +55,7 @@ elif args.visited:
     for pc in list(db.keys()):
         print('%x' % pc)
 elif args.bbs:
-    assert len(set(edges['ROOT'])) == 1, "Something is wrong it should be only one root"
+    assert len(set(edges['ROOT'])) == 1, "Something is wrong; there should be only one root"
     bbs = set()
     for targets in list(edges.values()):
         if len(set(targets)) > 1:

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -72,7 +72,7 @@ def post_mcore(state, last_instruction):
 
     # Synchronize qemu state to manticore's after a system call
     if last_instruction.mnemonic.lower() == 'svc':
-        # Syncronize all writes that have happened
+        # Synchronize all writes that have happened
         writes = state.cpu.memory.pop_record_writes()
         if writes:
             logger.debug("Got %d writes", len(writes))

--- a/tests/EVM/eth_EVMADD.py
+++ b/tests/EVM/eth_EVMADD.py
@@ -21,7 +21,7 @@ class EVMTest_ADD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMADDMOD.py
+++ b/tests/EVM/eth_EVMADDMOD.py
@@ -21,7 +21,7 @@ class EVMTest_ADDMOD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMADDRESS.py
+++ b/tests/EVM/eth_EVMADDRESS.py
@@ -21,7 +21,7 @@ class EVMTest_ADDRESS(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMAND.py
+++ b/tests/EVM/eth_EVMAND.py
@@ -21,7 +21,7 @@ class EVMTest_AND(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMBALANCE.py
+++ b/tests/EVM/eth_EVMBALANCE.py
@@ -21,7 +21,7 @@ class EVMTest_BALANCE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMBYTE.py
+++ b/tests/EVM/eth_EVMBYTE.py
@@ -21,7 +21,7 @@ class EVMTest_BYTE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCALLCODE.py
+++ b/tests/EVM/eth_EVMCALLCODE.py
@@ -27,7 +27,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:
@@ -67,7 +67,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_2(self):
@@ -97,7 +97,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(0)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_3(self):
@@ -127,7 +127,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(1)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_4(self):
@@ -157,7 +157,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_5(self):
@@ -187,7 +187,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_6(self):
@@ -217,7 +217,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(16)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_7(self):
@@ -247,7 +247,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(32)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_8(self):
@@ -277,7 +277,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(48)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_9(self):
@@ -307,7 +307,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             new_vm._push(6089590155545428825848686802984512581899718912)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_10(self):
@@ -337,7 +337,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(0)
             new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_11(self):
@@ -367,7 +367,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(0)
             new_vm._push(0)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
     def test_CALLCODE_12(self):
@@ -397,7 +397,7 @@ class EVMTest_CALLCODE(unittest.TestCase):
             new_vm._push(0)
             new_vm._push(1)
             last_exception, last_returned = self._execute(new_vm)
-            self.assertEqual(last_exception, 'INSUFICIENT STACK')
+            self.assertEqual(last_exception, 'INSUFFICIENT STACK')
             self.assertEqual(new_vm.gas, 999960)
 
 

--- a/tests/EVM/eth_EVMCALLDATALOAD.py
+++ b/tests/EVM/eth_EVMCALLDATALOAD.py
@@ -21,7 +21,7 @@ class EVMTest_CALLDATALOAD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCALLDATASIZE.py
+++ b/tests/EVM/eth_EVMCALLDATASIZE.py
@@ -21,7 +21,7 @@ class EVMTest_CALLDATASIZE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCALLER.py
+++ b/tests/EVM/eth_EVMCALLER.py
@@ -21,7 +21,7 @@ class EVMTest_CALLER(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCALLVALUE.py
+++ b/tests/EVM/eth_EVMCALLVALUE.py
@@ -21,7 +21,7 @@ class EVMTest_CALLVALUE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCODESIZE.py
+++ b/tests/EVM/eth_EVMCODESIZE.py
@@ -21,7 +21,7 @@ class EVMTest_CODESIZE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMCOINBASE.py
+++ b/tests/EVM/eth_EVMCOINBASE.py
@@ -21,7 +21,7 @@ class EVMTest_COINBASE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMDIFFICULTY.py
+++ b/tests/EVM/eth_EVMDIFFICULTY.py
@@ -21,7 +21,7 @@ class EVMTest_DIFFICULTY(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMDIV.py
+++ b/tests/EVM/eth_EVMDIV.py
@@ -21,7 +21,7 @@ class EVMTest_DIV(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMDUP.py
+++ b/tests/EVM/eth_EVMDUP.py
@@ -21,7 +21,7 @@ class EVMTest_DUP(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMEQ.py
+++ b/tests/EVM/eth_EVMEQ.py
@@ -21,7 +21,7 @@ class EVMTest_EQ(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMEXP.py
+++ b/tests/EVM/eth_EVMEXP.py
@@ -21,7 +21,7 @@ class EVMTest_EXP(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMEXTCODESIZE.py
+++ b/tests/EVM/eth_EVMEXTCODESIZE.py
@@ -21,7 +21,7 @@ class EVMTest_EXTCODESIZE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMGAS.py
+++ b/tests/EVM/eth_EVMGAS.py
@@ -21,7 +21,7 @@ class EVMTest_GAS(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMGASLIMIT.py
+++ b/tests/EVM/eth_EVMGASLIMIT.py
@@ -21,7 +21,7 @@ class EVMTest_GASLIMIT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMGASPRICE.py
+++ b/tests/EVM/eth_EVMGASPRICE.py
@@ -21,7 +21,7 @@ class EVMTest_GASPRICE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMGETPC.py
+++ b/tests/EVM/eth_EVMGETPC.py
@@ -21,7 +21,7 @@ class EVMTest_GETPC(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMGT.py
+++ b/tests/EVM/eth_EVMGT.py
@@ -21,7 +21,7 @@ class EVMTest_GT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMINVALID.py
+++ b/tests/EVM/eth_EVMINVALID.py
@@ -21,7 +21,7 @@ class EVMTest_INVALID(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMISZERO.py
+++ b/tests/EVM/eth_EVMISZERO.py
@@ -21,7 +21,7 @@ class EVMTest_ISZERO(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMJUMP.py
+++ b/tests/EVM/eth_EVMJUMP.py
@@ -21,7 +21,7 @@ class EVMTest_JUMP(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMJUMPDEST.py
+++ b/tests/EVM/eth_EVMJUMPDEST.py
@@ -21,7 +21,7 @@ class EVMTest_JUMPDEST(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMLT.py
+++ b/tests/EVM/eth_EVMLT.py
@@ -21,7 +21,7 @@ class EVMTest_LT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMMOD.py
+++ b/tests/EVM/eth_EVMMOD.py
@@ -21,7 +21,7 @@ class EVMTest_MOD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMMSIZE.py
+++ b/tests/EVM/eth_EVMMSIZE.py
@@ -21,7 +21,7 @@ class EVMTest_MSIZE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMMSTORE8.py
+++ b/tests/EVM/eth_EVMMSTORE8.py
@@ -28,7 +28,7 @@ class EVMTest_MSTORE8(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMMUL.py
+++ b/tests/EVM/eth_EVMMUL.py
@@ -21,7 +21,7 @@ class EVMTest_MUL(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMMULMOD.py
+++ b/tests/EVM/eth_EVMMULMOD.py
@@ -21,7 +21,7 @@ class EVMTest_MULMOD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMNOT.py
+++ b/tests/EVM/eth_EVMNOT.py
@@ -21,7 +21,7 @@ class EVMTest_NOT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMOR.py
+++ b/tests/EVM/eth_EVMOR.py
@@ -21,7 +21,7 @@ class EVMTest_OR(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMORIGIN.py
+++ b/tests/EVM/eth_EVMORIGIN.py
@@ -21,7 +21,7 @@ class EVMTest_ORIGIN(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMPOP.py
+++ b/tests/EVM/eth_EVMPOP.py
@@ -21,7 +21,7 @@ class EVMTest_POP(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMPUSH.py
+++ b/tests/EVM/eth_EVMPUSH.py
@@ -21,7 +21,7 @@ class EVMTest_PUSH(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMREVERT.py
+++ b/tests/EVM/eth_EVMREVERT.py
@@ -28,7 +28,7 @@ class EVMTest_REVERT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSDIV.py
+++ b/tests/EVM/eth_EVMSDIV.py
@@ -21,7 +21,7 @@ class EVMTest_SDIV(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSELFDESTRUCT.py
+++ b/tests/EVM/eth_EVMSELFDESTRUCT.py
@@ -21,7 +21,7 @@ class EVMTest_SELFDESTRUCT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSGT.py
+++ b/tests/EVM/eth_EVMSGT.py
@@ -21,7 +21,7 @@ class EVMTest_SGT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSHA3.py
+++ b/tests/EVM/eth_EVMSHA3.py
@@ -28,7 +28,7 @@ class EVMTest_SHA3(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSIGNEXTEND.py
+++ b/tests/EVM/eth_EVMSIGNEXTEND.py
@@ -21,7 +21,7 @@ class EVMTest_SIGNEXTEND(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSLOAD.py
+++ b/tests/EVM/eth_EVMSLOAD.py
@@ -21,7 +21,7 @@ class EVMTest_SLOAD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSLT.py
+++ b/tests/EVM/eth_EVMSLT.py
@@ -21,7 +21,7 @@ class EVMTest_SLT(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSMOD.py
+++ b/tests/EVM/eth_EVMSMOD.py
@@ -21,7 +21,7 @@ class EVMTest_SMOD(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSSTORE.py
+++ b/tests/EVM/eth_EVMSSTORE.py
@@ -21,7 +21,7 @@ class EVMTest_SSTORE(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMSUB.py
+++ b/tests/EVM/eth_EVMSUB.py
@@ -21,7 +21,7 @@ class EVMTest_SUB(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/EVM/eth_EVMXOR.py
+++ b/tests/EVM/eth_EVMXOR.py
@@ -21,7 +21,7 @@ class EVMTest_XOR(unittest.TestCase):
         except evm.NotEnoughGas:
             last_exception = "OOG"
         except evm.StackUnderflow:
-            last_exception = "INSUFICIENT STACK"
+            last_exception = "INSUFFICIENT STACK"
         except evm.InvalidOpcode:
             last_exception = "INVALID"
         except evm.SelfDestruct:

--- a/tests/auto/Readme.md
+++ b/tests/auto/Readme.md
@@ -1,7 +1,7 @@
 Auto unittest generation
 ------------------------
 
-1) You need a Linux program that exercises a set of interestings intructions.
+1) You need a Linux program that exercises a set of interesting instructions.
 For instance try `make` in examples/linux.
 
 2) Run the tracer on your program. It is a gdb wrapper that will execute the program step by step
@@ -10,7 +10,7 @@ printing pre/pos information on each instruction:
 ```
 python make_dump.py ../../examples/linux/nostdlib32 > mytest.dump
 ```
-(Several dumps can be concatenated togheter)
+(Several dumps can be concatenated together)
 
 3) Generate the actual python unittest based on the dump.
 ```

--- a/tests/auto/make_dump.py
+++ b/tests/auto/make_dump.py
@@ -117,7 +117,7 @@ gdb.correspond("run arg1 arg2 < /dev/urandom > /dev/null\n")
 gdb.correspond("d 1\n")
 #print gdb.get_maps()
 '''
-# Simulate no vdso (As when analized with symbemu)
+# Simulate no vdso (As when analyzed with symbemu)
 found = 0
 for i in range(75,120):
     if gdb.getM('$sp+sizeof(void*)*%d'%i) ==0x19 and gdb.getM('$sp+%d'%(i+2))==0x1f:
@@ -299,7 +299,7 @@ while True:
                     X86_REG_ESI: X86_REG_RSI,
                     X86_REG_RSI: X86_REG_INVALID, 
         }
-        #There is a capstone branch that should fix all this annoyances .. soon
+        #There is a capstone branch that should fix all these annoyances... soon
         #https://github.com/aquynh/capstone/tree/next
         used = set()
         for ri in reg_sizes.keys():

--- a/tests/auto/trace.py
+++ b/tests/auto/trace.py
@@ -93,13 +93,13 @@ arch = gdb.correspond('')
 #guess arch
 arch = gdb.get_arch()
 
-#gues architecture from file
+#guess architecture from file
 entry = gdb.get_entry()
 gdb.correspond("b *0\n")
 gdb.correspond("run arg1 arg2 arg3 < /dev/urandom > /dev/null\n")
 gdb.correspond("d 1\n")
 
-# Simulate no vdso (As when analized with symbemu)
+# Simulate no vdso (As when analyzed with symbemu)
 found = 0
 for i in range(75,120):
     if gdb.getM('$sp+sizeof(void*)*%d'%i) ==0x19 and gdb.getM('$sp+%d'%(i+2))==0x1f:

--- a/tests/binaries/benchmark/integer_overflow_benign_2.sol
+++ b/tests/binaries/benchmark/integer_overflow_benign_2.sol
@@ -1,5 +1,5 @@
 //Single transaction overflow
-//Post-transaction effect: overflow nevers escapes to publicly-readable storage
+//Post-transaction effect: overflow never escapes to publicly-readable storage
 
 pragma solidity ^0.4.19;
 

--- a/tests/binaries/benchmark/integer_overflow_path_1.sol
+++ b/tests/binaries/benchmark/integer_overflow_path_1.sol
@@ -1,5 +1,5 @@
 //Single transaction overflow
-//Post-transaction effect: overflow nevers escapes to publicly-readable storage
+//Post-transaction effect: overflow never escapes to publicly-readable storage
 
 pragma solidity ^0.4.19;
 

--- a/tests/binaries/detectors/delegatecall_ok1.sol
+++ b/tests/binaries/detectors/delegatecall_ok1.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 /*
 There is a fair use of lowlevel instruction delegatecall in the fallback function.
-It is effectivelly a CALL to `default_call` with the full calldata that was givento the fallback function
+It is effectively a CALL to `default_call` with the full calldata that was given to the fallback function
 */
 contract DetectThis {
 

--- a/tests/binaries/detectors/delegatecall_ok2.sol
+++ b/tests/binaries/detectors/delegatecall_ok2.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 /*
 There is a fair use of lowlevel instruction delegatecall in the fallback function.
-It is effectivelly a CALL to `this.default_call` with a concrete data.
+It is effectively a CALL to `this.default_call` with a concrete data.
 The storage variable `addr` is initialized to `this` and can not be modified.
 */
 

--- a/tests/binaries/reached.sol
+++ b/tests/binaries/reached.sol
@@ -22,7 +22,7 @@ library Manticore{
 
     function assume(bool constraint){
         /*
-            Add constraint to the path contraint set
+            Add constraint to the path constraint set
         */
         assembly {
             jump(0x4141414141414141414141414141414141414141)
@@ -86,14 +86,14 @@ library Manticore{
     }
 
     function can_be_true(bool condition) returns (bool){
-        /* Retuen True if condiction can be true */
+        /* Return True if condition can be true */
         assembly {
             jump(0x4141414141414141414141414141414141414141)
         }
     }
 
     function assert(bool condition, string message){
-        /* Retuen True if condiction can be true */
+        /* Return True if condition can be true */
         assembly {
             jump(0x4141414141414141414141414141414141414141)
         }
@@ -108,7 +108,7 @@ contract Reachable {
         storage_variable = 0x585858;
         Manticore.print("Initializing!");
         if (Manticore.is_symbolic(storage_variable))
-            Manticore.print("Noo! storage_variable should not be symbolic");
+            Manticore.print("No! storage_variable should not be symbolic");
 
         //this.write_then_throw();
         this.call.gas(10001).value(msg.value)(bytes4(sha3("function write_then_throw()")));

--- a/tests/eth_benchmark.py
+++ b/tests/eth_benchmark.py
@@ -43,7 +43,7 @@ class EthBenchmark(unittest.TestCase):
 
     def _test(self, name, should_find):
         """
-        Tests DetectInvalid over the consensys benchmark suit
+        Tests DetectInvalid over the consensys benchmark suite
         """
         mevm = self.mevm
         mevm.register_detector(DetectInvalid())

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -181,7 +181,7 @@ class DetectEnvInstruction(EthDetectorTest):
 
 
 class EthDelegatecall(EthDetectorTest):
-    """ Test the detecion of funny delegatecalls """
+    """ Test the detection of funny delegatecalls """
     DETECTOR_CLASS = DetectDelegatecall
 
     def test_delegatecall_ok(self):

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -479,7 +479,7 @@ class EthTests(unittest.TestCase):
 
         #Some global expression `sym_add1` 
         sym_add1 = m.make_symbolic_value(name='sym_add1')
-        #Let's constraint it on the global fake constraintset
+        #Let's constrain it on the global fake constraintset
         m.constrain(sym_add1>0)
         m.constrain(sym_add1<10)
         #Symb tx 1
@@ -495,7 +495,7 @@ class EthTests(unittest.TestCase):
         #random concrete tx
         contract_account.sellerBalance(caller=attacker_account)
 
-        #anooother constraining on the global constraintset. Yet more running states could get unfeasible by this.
+        #another constraining on the global constraintset. Yet more running states could get unfeasible by this.
         m.constrain(sym_add1 > 8)
 
 

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -66,7 +66,7 @@ class SymCPUTest(unittest.TestCase):
     def setUp(self):
         mem = mockmem.Memory()
         self.cpu = I386Cpu(mem) #TODO reset cpu in between tests...
-                    #TODO mock getchar/putchar in case the instructon access memory directly
+                    #TODO mock getchar/putchar in case the instruction accesses memory directly
 
     def tearDown(self):
         self.cpu = None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -392,7 +392,7 @@ class MemoryTest(unittest.TestCase):
         #start with no maps
         self.assertEqual(len(mem.mappings()), 0)
 
-        #alloc/map a litlle mem
+        #alloc/map a little mem
         addr = mem.mmap(None, 0x10, 'r')
         for c in range(0, 0x10):
             self.assertRaises(MemoryException, mem.__setitem__, addr+c, 'a')
@@ -429,7 +429,7 @@ class MemoryTest(unittest.TestCase):
         #Check the search gives basically any value as the mem is free
         self.assertEqual(mem._search(0x1000, 0x20000000), 0x20000000)
 
-        #alloc/map a litlle mem
+        #alloc/map a little mem
         size = 0x1000
         addr = mem.mmap(None, size, 'rwx')
 
@@ -462,10 +462,10 @@ class MemoryTest(unittest.TestCase):
         #start with no maps
         self.assertEqual(len(mem.mappings()), 0)
 
-        #Chack the search gives basically any value as the mem is free
+        #Check the search gives basically any value as the mem is free
         self.assertEqual(mem._search(0x1000, 0x20000000), 0x20000000)
 
-        #alloc/map a litlle mem
+        #alloc/map a little mem
         size = 0x1000
         addr = mem.mmap(None, 0x1000, 'r')
 
@@ -1198,13 +1198,13 @@ class MemoryTest(unittest.TestCase):
         cs.add(x>=addr)
         cs.add(x<addr+10)
 
-        #Well.. x is symbolic
+        #Well... x is symbolic
         self.assertTrue(issymbolic(x))
         #It shall be a solution
         self.assertTrue(solver.check(cs))
-        #if we ask for a possible solution (an x that comply with the constraints)
+        #if we ask for a possible solution (an x that complies with the constraints)
         sol = solver.get_value(cs, x)
-        #it should comply..
+        #it should comply...
         self.assertTrue(sol >= addr and sol<addr+10)
 
         #min and max value should be addr and addr+9
@@ -1214,15 +1214,15 @@ class MemoryTest(unittest.TestCase):
 
         #If we ask for all possible solutions...
         for val in solver.get_all_values(cs, x):
-            #any solution must comply..
+            #any solution must comply...
             self.assertTrue(sol >= addr and sol<addr+10)
 
-        #so now lets ask the memory for values pointed by addr
+        #so now let's ask the memory for values pointed by addr
         c = mem[x]
         for val in solver.get_all_values(cs, c):
             self.assertTrue(val>=100 and val<110)
 
-        #constraint the address a litle more
+        #constraint the address a little more
         cs.add(x<=addr)
         #It shall be a solution
         self.assertTrue(solver.check(cs))
@@ -1231,7 +1231,7 @@ class MemoryTest(unittest.TestCase):
         #it must be addr
         self.assertTrue(sol == addr)
 
-        #lets ask the memory for the value under that address
+        #let's ask the memory for the value under that address
         c = mem[x]
         sol = solver.get_value(cs, c)
         self.assertTrue(Operators.ORD(sol)==100)
@@ -1263,13 +1263,13 @@ class MemoryTest(unittest.TestCase):
         mem[addr+5] = Operators.CHR(v)
 
 
-        #mak a free symbol of 32 bits
+        #make a free symbol of 32 bits
         x = cs.new_bitvec(32)
         #constraint it to range into [addr, addr+10)
         cs.add(x>=addr)
         cs.add(x<addr+10)
 
-        #so now lets ask the memory for values pointed by addr
+        #so now let's ask the memory for values pointed by addr
         c = mem[x]
         for val in solver.get_all_values(cs, c,1000):
             self.assertTrue(val>=100 and val<110 or val >= Operators.ORD('A') and val <= Operators.ORD('Z'))
@@ -1297,7 +1297,7 @@ class MemoryTest(unittest.TestCase):
     def testmprotectFailSymbReading(self):
         cs = ConstraintSet()
 
-        #In the beggining the solver was 'sat' ...
+        #In the beginning the solver was 'sat' ...
         self.assertTrue(solver.check(cs))
 
 
@@ -1319,7 +1319,7 @@ class MemoryTest(unittest.TestCase):
         #And now just 2
         self.assertEqual(len(mem.mappings()), 2)
 
-        #lets write some chars at the beginning of each page
+        #let's write some chars at the beginning of each page
         mem[addr] = 'a'
         mem[addr+0x2000] = 'b'
 
@@ -1333,13 +1333,13 @@ class MemoryTest(unittest.TestCase):
         cs.add(x>=addr)
         cs.add(x<=addr+0x2000)
 
-        #Well.. x is symbolic
+        #Well... x is symbolic
         self.assertTrue(issymbolic(x))
         #It shall be a solution
         self.assertTrue(solver.check(cs))
-        #if we ask for a possible solution (an x that comply with the constraints)
+        #if we ask for a possible solution (an x that complies with the constraints)
         sol = solver.get_value(cs, x)
-        #it should comply..
+        #it should comply...
         self.assertTrue(sol >= addr and sol<=addr+0x2000)
         #print map(hex,sorted(solver.get_all_values(cs, x, 0x100000))),  map(hex,solver.minmax(cs, x)), mem[x]
 

--- a/tests/test_smtlibv2.py
+++ b/tests/test_smtlibv2.py
@@ -100,7 +100,7 @@ class ExpressionTest(unittest.TestCase):
 
         #assert that the array is 'A' at key position
         cs.add(array[key] == ord('A'))
-        #lets restrict key to be greater than 1000
+        #let's restrict key to be greater than 1000
         cs.add(key.ugt(1000))
 
         with cs as temp_cs:
@@ -136,33 +136,33 @@ class ExpressionTest(unittest.TestCase):
         #make free 32bit bitvector
         key = cs.new_bitvec(32)
 
-        #assert that the array is 1234567890.. at key position
+        #assert that the array is 111...111 at key position
         cs.add(array[key] == 11111111111111111111111111111111111111111111)
-        #lets restrict key to be greater than 1000
+        #let's restrict key to be greater than 1000
         cs.add(key.ugt(1000))
 
         with cs as temp_cs:
-            #1001 position of array can be 'A'
+            #1001 position of array can be 111...111
             temp_cs.add(array[1001] == 11111111111111111111111111111111111111111111)
             self.assertTrue(self.solver.check(temp_cs))
 
         with cs as temp_cs:
-            #1001 position of array can also be 'B'
+            #1001 position of array can also be 222...222
             temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
             self.assertTrue(self.solver.check(temp_cs))
 
 
         with cs as temp_cs:
-            #but if it is 'B' ...
+            #but if it is 222...222 ...
             temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
             #then key can not be 1001
             temp_cs.add(key == 1001)
             self.assertFalse(self.solver.check(temp_cs))
 
         with cs as temp_cs:
-            #If 1001 position is 'B' ...
+            #If 1001 position is 222...222 ...
             temp_cs.add(array[1001] == 22222222222222222222222222222222222222222222)
-            #then key can be 1000 for ex..
+            #then key can be 1002 for ex..
             temp_cs.add(key == 1002)
             self.assertTrue(self.solver.check(temp_cs))
 
@@ -177,7 +177,7 @@ class ExpressionTest(unittest.TestCase):
 
         #assert that the array is 'A' at key position
         array = array.store(key, ord('A'))
-        #lets restrict key to be greater than 1000
+        #let's restrict key to be greater than 1000
         cs.add(key.ugt(1000))
 
         #1001 position of array can be 'A'
@@ -199,7 +199,7 @@ class ExpressionTest(unittest.TestCase):
         with cs as temp_cs:
             #If 1001 position is 'B' ...
             temp_cs.add(array.select(1001) == ord('B'))
-            #then key can be 1000 for ex..
+            #then key can be 1002 for ex..
             temp_cs.add(key != 1002)
             self.assertTrue(self.solver.check(temp_cs))
 
@@ -241,7 +241,6 @@ class ExpressionTest(unittest.TestCase):
         #make array of 32->8 bits
         array = cs.new_array(32, index_max=12)
 
-        #assert that the array is 'A' at key position
         array = array.write(0, hw)
 
         self.assertTrue(self.solver.must_be_true(cs, array == hw))
@@ -276,7 +275,7 @@ class ExpressionTest(unittest.TestCase):
 
         #assert that the array is 'A' at key position
         array = array.store(key, ord('A'))
-        #lets restrict key to be greater than 1000
+        #let's restrict key to be greater than 1000
         cs.add(key.ugt(1000))
         cs = pickle.loads(pickle.dumps(cs))
         self.assertTrue(self.solver.check(cs))


### PR DESCRIPTION
This was my pass at addressing issue #1104 .

Note that files manticore/core/smtlib/expression.py , manticore/core/smtlib/visitors.py , and tests/test_cpu_manual.py use "begining" instead of "beginning" as a variable name.  Since I have no way of actually testing the resulting code, I decided against correcting this particular misspelling in this commit.

Also, examples/evm/minimal.py , examples/evm/minimal_bytecode_only.py , and manticore/platforms/linux_syscalls.py include "Let seth know we are not sending more transactions" in a comment text.  The use of "seth" here may be a typo, but I'm not able to guess at what the correct text might be.