### PR TITLE
Fix terminate state

### DIFF
--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -628,6 +628,7 @@ class Manticore(Eventful):
         a :func:`~hook`.
         '''
         self._executor.shutdown()
+        raise TerminateState('Terminated')
 
     def shutdown(self):
         '''

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -606,20 +606,25 @@ class Manticore(Eventful):
         :param timeout: Analysis timeout, in seconds
         '''
         assert not self.running, "Manticore is already running."
-        self._start_run()
-
-        self._time_started = time.time()
-        if timeout > 0:
-            t = Timer(timeout, self.terminate)
-            t.start()
         try:
-            self._start_workers(procs, profiling=should_profile)
+            self._start_run()
 
-            self._join_workers()
-        finally:
+            self._time_started = time.time()
             if timeout > 0:
-                t.cancel()
-        self._finish_run(profiling=should_profile)
+                t = Timer(timeout, self.terminate)
+                t.start()
+            try:
+                self._start_workers(procs, profiling=should_profile)
+
+                self._join_workers()
+            finally:
+                if timeout > 0:
+                    t.cancel()
+            self._finish_run(profiling=should_profile)
+        except TerminateState:
+            #  Must have been raised outside of executor loop. likely by Manticore.terminate()
+            # or State.abandon() in the init hook.
+            pass
 
     #Fixme remove. terminate is used to TerminateState. May be confusing
     def terminate(self):


### PR DESCRIPTION
Fixes #1076 

- raises TerminateState in m.terminate()
- adds an except for Terminate state in Manticore.run(). this prevents TerminateStates (such as from m.terminate() and state.abandon() to 'break out' to the user) like if you do m.terminate() outside the executor loop (in the init hook, for example)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1150)
<!-- Reviewable:end -->
