### PR TITLE
Global exceptions file

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -4,7 +4,7 @@ import random
 import logging
 import signal
 
-from ..exceptions import ExecutorError, SolverError
+from ..exceptions import ExecutorError, SolverException
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils.event import Eventful
 from .smtlib import Z3Solver, Expression
@@ -483,7 +483,7 @@ class Executor(Eventful):
                             self.generate_testcase(current_state, str(e))
                         current_state = None
 
-                    except SolverError as e:
+                    except SolverException as e:
                         # raise
                         import traceback
                         trace = traceback.format_exc()

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -4,7 +4,7 @@ import random
 import logging
 import signal
 
-from ..manticore import ManticoreError
+from ..exceptions import ExecutorError
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils.event import Eventful
 from .smtlib import Z3Solver, Expression, SolverException
@@ -15,10 +15,6 @@ from multiprocessing.managers import SyncManager
 from contextlib import contextmanager
 
 # This is the single global manager that will handle all shared memory among workers
-
-
-class ExecutorError(ManticoreError):
-    pass
 
 
 def mgr_init():

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -4,10 +4,10 @@ import random
 import logging
 import signal
 
-from ..exceptions import ExecutorError
+from ..exceptions import ExecutorError, SolverError
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils.event import Eventful
-from .smtlib import Z3Solver, Expression, SolverError
+from .smtlib import Z3Solver, Expression
 from .state import Concretize, TerminateState
 
 from .workspace import Workspace

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -7,7 +7,7 @@ import signal
 from ..exceptions import ExecutorError
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils.event import Eventful
-from .smtlib import Z3Solver, Expression, SolverException
+from .smtlib import Z3Solver, Expression, SolverError
 from .state import Concretize, TerminateState
 
 from .workspace import Workspace
@@ -483,7 +483,7 @@ class Executor(Eventful):
                             self.generate_testcase(current_state, str(e))
                         current_state = None
 
-                    except SolverException as e:
+                    except SolverError as e:
                         # raise
                         import traceback
                         trace = traceback.format_exc()

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -16,6 +16,8 @@
 # You can add new constraints. A new constraint may change the state from {None, sat} to {sat, unsat, unknown}
 from abc import ABCMeta, abstractmethod
 from subprocess import PIPE, Popen, check_output
+
+from ...exceptions import Z3NotFoundError, SolverError, SolverUnknown, TooManySolutions
 from . import operators as Operators
 from .expression import *
 from .constraints import *
@@ -29,24 +31,6 @@ import io
 import collections
 
 logger = logging.getLogger(__name__)
-
-
-class Z3NotFoundError(EnvironmentError):
-    pass
-
-
-class SolverError(Exception):
-    pass
-
-
-class SolverUnknown(SolverError):
-    pass
-
-
-class TooManySolutions(SolverError):
-    def __init__(self, solutions):
-        super().__init__("Max number of different solutions hit")
-        self.solutions = solutions
 
 
 class Solver(object, metaclass=ABCMeta):

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -9,7 +9,7 @@ import re
 import os
 import pyevmasm as EVMAsm
 from .. import Manticore
-from ..manticore import ManticoreError
+from ..exceptions import EthereumError, DependencyError, NoAliveStates
 from ..core.smtlib import ConstraintSet, Operators, solver, BitVec, Array, ArrayVariable, ArrayProxy
 from ..platforms import evm
 from ..core.state import State
@@ -29,19 +29,6 @@ from .detectors import Detector, DetectEnvInstruction, DetectExternalCallAndLeak
 
 logger = logging.getLogger(__name__)
 
-
-class EthereumError(ManticoreError):
-    pass
-
-
-class DependencyError(EthereumError):
-    def __init__(self, lib_names):
-        super().__init__("You must pre-load and provide libraries addresses{ libname:address, ...} for %r" % lib_names)
-        self.lib_names = lib_names
-
-
-class NoAliveStates(EthereumError):
-    pass
 
 
 #

--- a/manticore/exceptions.py
+++ b/manticore/exceptions.py
@@ -24,7 +24,7 @@ class Z3NotFoundError(SmtlibError):
     pass
 
 
-class SolverError(Exception):
+class SolverError(SmtlibError):
     pass
 
 

--- a/manticore/exceptions.py
+++ b/manticore/exceptions.py
@@ -20,6 +20,24 @@ class SmtlibError(ManticoreError):
     pass
 
 
+class Z3NotFoundError(SmtlibError):
+    pass
+
+
+class SolverError(Exception):
+    pass
+
+
+class SolverUnknown(SolverError):
+    pass
+
+
+class TooManySolutions(SolverError):
+    def __init__(self, solutions):
+        super().__init__("Max number of different solutions hit")
+        self.solutions = solutions
+
+
 # Ethereum
 
 

--- a/manticore/exceptions.py
+++ b/manticore/exceptions.py
@@ -14,6 +14,12 @@ class ExecutorError(ManticoreError):
     pass
 
 
+# Smtlib
+
+class SmtlibError(ManticoreError):
+    pass
+
+
 # Ethereum
 
 

--- a/manticore/exceptions.py
+++ b/manticore/exceptions.py
@@ -1,0 +1,33 @@
+"""
+Public subclasses of Exception
+"""
+
+
+class ManticoreError(Exception):
+    """
+    Top level Exception object for custom exception hierarchy
+    """
+    pass
+
+
+class ExecutorError(ManticoreError):
+    pass
+
+
+# Ethereum
+
+
+class EthereumError(ManticoreError):
+    pass
+
+
+class DependencyError(EthereumError):
+    def __init__(self, lib_names):
+        super().__init__("You must pre-load and provide libraries addresses{ libname:address, ...} for %r" % lib_names)
+        self.lib_names = lib_names
+
+
+class NoAliveStates(EthereumError):
+    pass
+
+

--- a/manticore/exceptions.py
+++ b/manticore/exceptions.py
@@ -24,15 +24,16 @@ class Z3NotFoundError(SmtlibError):
     pass
 
 
-class SolverError(SmtlibError):
+# TODO: rename to SolverError
+class SolverException(SmtlibError):
     pass
 
 
-class SolverUnknown(SolverError):
+class SolverUnknown(SolverException):
     pass
 
 
-class TooManySolutions(SolverError):
+class TooManySolutions(SolverException):
     def __init__(self, solutions):
         super().__init__("Max number of different solutions hit")
         self.solutions = solutions

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -18,14 +18,6 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
 
-# this is here because of circular import issues, various modules imported below need it
-class ManticoreError(Exception):
-    """
-    Top level Exception object for custom exception hierarchy
-    """
-    pass
-
-
 from .core.executor import Executor
 from .core.state import State, TerminateState
 from .core.smtlib import solver, ConstraintSet

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -19,7 +19,7 @@ from manticore.core.smtlib import Expression
 from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeArgument
 from ..core.cpu.cpufactory import CpuFactory
 from ..core.memory import SMemory32, SMemory64, Memory32, Memory64
-from ..core.smtlib import Operators, ConstraintSet, SolverException, solver
+from ..core.smtlib import Operators, ConstraintSet, SolverError, solver
 from ..core.cpu.arm import *
 from ..core.executor import TerminateState
 from ..platforms.platform import Platform, SyscallNotImplemented
@@ -2690,7 +2690,7 @@ class SLinux(Linux):
                     if issymbolic(c):
                         c = solver.get_value(self.constraints, c)
                     fd.write(make_chr(c))
-            except SolverException:
+            except SolverError:
                 fd.write('{SolverException}')
 
         out = io.BytesIO()

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -19,7 +19,8 @@ from manticore.core.smtlib import Expression
 from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeArgument
 from ..core.cpu.cpufactory import CpuFactory
 from ..core.memory import SMemory32, SMemory64, Memory32, Memory64
-from ..core.smtlib import Operators, ConstraintSet, SolverError, solver
+from ..core.smtlib import Operators, ConstraintSet, solver
+from ..exceptions import SolverError
 from ..core.cpu.arm import *
 from ..core.executor import TerminateState
 from ..platforms.platform import Platform, SyscallNotImplemented

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -15,7 +15,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from elftools.elf.descriptions import describe_symbol_type
 
-from manticore.core.smtlib import Expression
+from ..core.smtlib import Expression
 from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeArgument
 from ..core.cpu.cpufactory import CpuFactory
 from ..core.memory import SMemory32, SMemory64, Memory32, Memory64

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -20,7 +20,7 @@ from ..core.cpu.abstractcpu import Interruption, Syscall, ConcretizeArgument
 from ..core.cpu.cpufactory import CpuFactory
 from ..core.memory import SMemory32, SMemory64, Memory32, Memory64
 from ..core.smtlib import Operators, ConstraintSet, solver
-from ..exceptions import SolverError
+from ..exceptions import SolverException
 from ..core.cpu.arm import *
 from ..core.executor import TerminateState
 from ..platforms.platform import Platform, SyscallNotImplemented
@@ -2691,7 +2691,7 @@ class SLinux(Linux):
                     if issymbolic(c):
                         c = solver.get_value(self.constraints, c)
                     fd.write(make_chr(c))
-            except SolverError:
+            except SolverException:
                 fd.write('{SolverException}')
 
         out = io.BytesIO()


### PR DESCRIPTION
this is partial, only the errors that were easy/straightforward.

i omitted evm and core/cpu because those seemed a little more involved, and also those might be subject to near term refactorings to try to reconcile evm and cpu (e.g. should an EVM actually be a CPU rather than its own class?)

todo:

- should it be named errors.py instead of exceptions.py

re #818 