### PR TITLE
Explicit smtlib imports in memory

### DIFF
--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -1,6 +1,6 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from weakref import WeakValueDictionary
-from .smtlib import *
+from .smtlib import Operators, ConstraintSet, arithmetic_simplify, solver, TooManySolutions
 import logging
 from ..utils.mappings import mmap, munmap
 from ..utils.helpers import issymbolic

--- a/manticore/core/memory.py
+++ b/manticore/core/memory.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from weakref import WeakValueDictionary
-from .smtlib import Operators, ConstraintSet, arithmetic_simplify, solver, TooManySolutions
+from .smtlib import Operators, ConstraintSet, arithmetic_simplify, solver, TooManySolutions, BitVec, BitVecConstant
 import logging
 from ..utils.mappings import mmap, munmap
 from ..utils.helpers import issymbolic

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -4,6 +4,7 @@ import unittest
 from manticore.core.cpu.x86 import *
 from manticore.core.smtlib import Operators
 from manticore.core.memory import *
+from manticore.core.smtlib import BitVecOr
 from tests import mockmem
 from functools import reduce
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -7,6 +7,7 @@ import fcntl
 import resource
 import sys
 from manticore.core.memory import *
+from manticore.core.smtlib import Expression
 from manticore.utils.helpers import issymbolic
 
 def isconcrete(value):

--- a/tests/test_x86_pcmpxstrx.py
+++ b/tests/test_x86_pcmpxstrx.py
@@ -2,7 +2,7 @@
 import unittest
 import functools
 from manticore.core.cpu.x86 import *
-from manticore.core.smtlib import Operators
+from manticore.core.smtlib import Operators, Expression
 from manticore.core.memory import *
 
 


### PR DESCRIPTION
Previously pycharm would mark the `from abc` line as redundant.
but this is brittle because ABCMeta etc only happened to be imported
as a result of modules inside .smtlib importing ABCMeta. if we
followed pycharm's advice, and remove this abc import, and if solver.py
decided not to import ABCMeta anymore, this could would break.
so this makes it less brittle.