### PR TITLE
Fix not being able to handle solidity imports

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -338,16 +338,17 @@ class ManticoreEVM(Manticore):
         #solc path search is a mess #fixme
         #https://solidity.readthedocs.io/en/latest/layout-of-source-files.html
         current_folder = os.getcwd()
-        abs_filename = os.path.abspath(source_file.name)
-        working_folder, filename = os.path.split(abs_filename)
+        filepath = os.path.abspath(source_file.name)
+
+        filename = filepath[filepath.rindex(os.path.sep)+1:]
 
         solc_invocation = [solc] + list(solc_remaps) + [
             '--combined-json', 'abi,srcmap,srcmap-runtime,bin,hashes,bin-runtime',
             '--allow-paths', '.',
-            filename
+            filepath
         ]
 
-        p = Popen(solc_invocation, stdout=PIPE, stderr=PIPE, cwd=working_folder)
+        p = Popen(solc_invocation, stdout=PIPE, stderr=PIPE, cwd=current_folder)
         stdout, stderr = p.communicate()
 
         stdout, stderr = stdout.decode(), stderr.decode()


### PR DESCRIPTION
This commit fixes a Manticore bug related to Solidity code, described
below. The fix makes so that Manticore runs `solc` in proper working
directory and provides relative path to the compiled contract.

---

When Manticore is run on a Solidity file that contains imports, e.g. as:
```
manticore ./contracts/SomeContract.sol
```

It executes `solc` as:
```
['solc', '--combined-json', 'abi,srcmap,srcmap-runtime,bin,hashes,bin-runtime', '--allow-paths', '.', 'MultiSig.sol']
```

and sets current working directory to `$(pwd)/contracts`. This leads to the failure shown below.

```
manticore --detect-all ./SomeContract.sol --contract SomeContract
2018-10-02 20:30:33,525: [32752] m.main:INFO: Beginning analysis
2018-10-02 20:30:33,526: [32752] m.ethereum:INFO: Starting symbolic create contract
Traceback (most recent call last):
  File "/manticore/manticore/ethereum/__init__.py", line 991, in _run_solc
    return json.loads(stdout), stderr
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/.venv/manticore/bin/manticore", line 11, in <module>
    load_entry_point('manticore', 'console_scripts', 'manticore')()
  File "/manticore/manticore/__main__.py", line 196, in main
    ethereum_cli(args)
  File "/manticore/manticore/__main__.py", line 178, in ethereum_cli
    m.multi_tx_analysis(args.argv[0], contract_name=args.contract, tx_limit=args.txlimit, tx_use_coverage=not args.txnocoverage, tx_send_ether=not args.txnoether, tx_account=args.txaccount)
  File "/manticore/manticore/ethereum/__init__.py", line 1574, in multi_tx_analysis
    contract_account = self.solidity_create_contract(f, contract_name=contract_name, owner=owner_account, args=args)
  File "/manticore/manticore/ethereum/__init__.py", line 1284, in solidity_create_contract
    compile_results = self._compile(source_code, contract_name_i, libraries=deps, solc_bin=solc_bin, solc_remaps=solc_remaps)
  File "/manticore/manticore/ethereum/__init__.py", line 1014, in _compile
    output, warnings = ManticoreEVM._run_solc(source_code, solc_bin, solc_remaps)
  File "/manticore/manticore/ethereum/__init__.py", line 993, in _run_solc
    raise EthereumError('Solidity compilation error:\n\n{}'.format(stderr))
manticore.ethereum.EthereumError: Solidity compilation error:

SomeContract.sol:3:1: Error: Source "math/SafeMath.sol" not found: File not found.
import "../math/SafeMath.sol";
^----------------------------^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1171)
<!-- Reviewable:end -->
