### PR TITLE
Fix Consensus-errors.1 & 2

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -946,7 +946,6 @@ class ManticoreEVM(Manticore):
 
         if contract_account is None:
             logger.info("Failed to create contract: exception in constructor")
-            self.finalize()
             return
 
         prev_coverage = 0
@@ -1258,18 +1257,18 @@ class ManticoreEVM(Manticore):
 
         if last_tx:
             at_runtime = last_tx.sort != 'CREATE'
-            address, offset, at_init = state.context['evm.trace'][-1]
-            assert at_runtime != at_init
 
             #Last instruction if last tx was valid
             if str(state.context['last_exception']) != 'TXERROR':
-                metadata = self.get_metadata(blockchain.last_transaction.address)
-                if metadata is not None:
-                    stream.write('Last instruction at contract %x offset %x\n' % (address, offset))
-                    source_code_snippet = metadata.get_source_for(offset, at_runtime)
-                    if source_code_snippet:
-                        stream.write('    '.join(source_code_snippet.splitlines(True)))
-                    stream.write('\n')
+                if 'evm.trace' in state.context:
+                    address, offset, at_init = state.context['evm.trace'][-1]
+                    metadata = self.get_metadata(blockchain.last_transaction.address)
+                    if metadata is not None:
+                        stream.write('Last instruction at contract %x offset %x\n' % (address, offset))
+                        source_code_snippet = metadata.get_source_for(offset, at_runtime)
+                        if source_code_snippet:
+                            stream.write('    '.join(source_code_snippet.splitlines(True)))
+                        stream.write('\n')
 
         # Accounts summary
         is_something_symbolic = False

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -478,9 +478,18 @@ class EVM(Eventful):
 
         #Compile the list of valid jumpdests via linear dissassembly
         def extend_with_zeroes(b):
+            #Fixme(felipe) This does not deal with the corner case  in which the
+            # arguments are actually dynamic code 
+            #This simplifies the bytecode that ends early or has symbolic arguments
+            #appeded at the end
             try:
                 for x in b:
-                    yield(to_constant(x))
+                    x = to_constant(x)
+                    if isinstance(x, int):
+                        yield(x)
+                    else:
+                        yield(0)
+                        
                 for x in (0,)*32:
                     yield(x)
             except Exception as e:

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -470,16 +470,15 @@ class EVM(Eventful):
             bytecode_symbolic[0:bytecode_size] = bytecode
             bytecode = bytecode_symbolic
 
-        #TODO: Handle the case in which bytecode is  symbolic (This happens at 
+        #TODO: Handle the case in which bytecode is  symbolic (This happens at
         # CREATE instructions that has the arguments appended to the bytecode)
         self._check_jumpdest = False
         self._valid_jumpdests = set()
 
-
         #Compile the list of valid jumpdests via linear dissassembly
         def extend_with_zeroes(b):
             #Fixme(felipe) This does not deal with the corner case  in which the
-            # arguments are actually dynamic code 
+            # arguments are actually dynamic code
             #This simplifies the bytecode that ends early or has symbolic arguments
             #appeded at the end
             try:
@@ -489,11 +488,10 @@ class EVM(Eventful):
                         yield(x)
                     else:
                         yield(0)
-                        
-                for x in (0,)*32:
-                    yield(x)
+                for _ in range(32):
+                    yield(0)
             except Exception as e:
-                raise StopIteration
+                return
 
         for i in EVMAsm.disassemble_all(extend_with_zeroes(bytecode)):
             if i.mnemonic == 'JUMPDEST':

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -838,14 +838,14 @@ class EVM(Eventful):
         self._check_jumpdest = flag
 
     def _check_jmpdest(self):
-        if issymbolic(self._check_jumpdest):
-            should_check_jumpdest = solver.get_all_values(self.constraints, self._check_jumpdest)
-            if len(should_check_jumpdest) != 1:
+        should_check_jumpdest = self._check_jumpdest
+        if issymbolic(should_check_jumpdest):
+            should_check_jumpdest_solutions = solver.get_all_values(self.constraints, self._check_jumpdest)
+            if len(should_check_jumpdest_solutions) != 1:
                 raise EthereumError("Conditional not concretized at JMPDEST check")
-        else:
-            should_check_jumpdest = [self._check_jumpdest]
+            should_check_jumpdest = should_check_jumpdest_solutions[0]
 
-        if should_check_jumpdest == [True]:
+        if should_check_jumpdest:
             self._check_jumpdest = False
             if self.pc not in self._valid_jumpdests:
                 raise InvalidOpcode()

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -470,17 +470,16 @@ class EVM(Eventful):
             bytecode_symbolic[0:bytecode_size] = bytecode
             bytecode = bytecode_symbolic
 
-        #TODO: Handle the case in which bytecode is  symbolic (This happens at
+        #TODO: Handle the case in which bytecode is symbolic (This happens at
         # CREATE instructions that has the arguments appended to the bytecode)
+        # This is a very cornered corner case in which code is actually symbolic
+        # We should simply not allow to jump to unconstrained(*) symbolic code.
+        # (*) bytecode that could take more than a single value
         self._check_jumpdest = False
         self._valid_jumpdests = set()
 
         #Compile the list of valid jumpdests via linear dissassembly
         def extend_with_zeroes(b):
-            # Fixme(felipe) This does not deal with the corner case in which the
-            # arguments are actually dynamic code 
-            # This simplifies the bytecode that ends early or has symbolic arguments
-            # appended at the end
             try:
                 for x in b:
                     x = to_constant(x)

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -893,11 +893,9 @@ class EthSolidityCompilerTest(unittest.TestCase):
             result = e.result
             if e.result in ('RETURN', 'REVERT'):
                 returndata = e.data
-        # test spent gas
+
         self.assertEqual(result, 'THROW')
         self.assertEqual(new_vm.gas, 99992)
-        #check refund
-        #check logs
         
 
 

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -865,7 +865,10 @@ class EthSolidityCompilerTest(unittest.TestCase):
 
     def test_jmpdest_check(self):
         '''
-        '''    
+            This test that jumping to a JUMPDEST in the operand of a PUSH should 
+            be treated as an INVALID instruction.
+            https://github.com/trailofbits/manticore/issues/1169
+        '''
     
         constraints = ConstraintSet()
         world = evm.EVMWorld(constraints)


### PR DESCRIPTION
Fix sub issues 1 & 2 from here:  https://github.com/trailofbits/manticore/issues/1169
```
Missing analysis of valid JUMPDESTs. The EVM does not allow jumping into a data-section, for example into the 32 bytes following a PUSH32. So if the code is
PUSH01 5b
PUSH1 01
JUMP
Then it appears that manticore evm would jump into the 'artificial' jumpdest 5b at byte 1 and continue execution.

Missing JUMPDEST check. Apparently known already
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1172)
<!-- Reviewable:end -->
