### PR TITLE
Colored Output

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -42,6 +42,8 @@ def parse_arguments():
                         help='Specify symbolic input file, \'+\' marks symbolic bytes')
     parser.add_argument('--names', type=str, default=None,
                         help=argparse.SUPPRESS)
+    parser.add_argument('--no-colors', action='store_true',
+                        help='Disable ANSI color escape sequences in output')
     parser.add_argument('--offset', type=int, default=16,
                         help=argparse.SUPPRESS)
     # FIXME (theo) Add some documentation on the different search policy options
@@ -194,6 +196,8 @@ def main():
 
     log.init_logging()
     args = parse_arguments()
+    if args.no_colors:
+        log.disable_colors()
 
     Manticore.verbosity(args.v)
 

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -28,18 +28,17 @@ class ContextFilter(logging.Filter):
     for k, v in coloring.items():
         color_map[k] = colors[v]
 
-    color_set = u'\x1b[%sm'
-    color_reset = u'\x1b[0m'
+    colored_levelname_format = u'\x1b[{}m{}:\x1b[0m'
+    plain_levelname_format = u'{}:'
 
     def colored_level_name(self, levelname):
         '''
         Colors the logging level in the logging record
         '''
-        if ( self.colors_disabled ):
-            return levelname + u':'
+        if self.colors_disabled:
+            return self.plain_levelname_format.format(levelname)
         else:
-            retval = (self.color_set % self.color_map[levelname]) + levelname + u':' + self.color_reset
-            return retval
+            return self.colored_levelname_format.format(self.color_map[levelname], levelname)
 
     def filter(self, record):
         if hasattr(self, 'stateid') and isinstance(self.stateid, int):

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -8,7 +8,6 @@ class ContextFilter(logging.Filter):
     '''
     This is a filter which injects contextual information into the log.
     '''
-
     def summarized_name(self, name):
         '''
         Produce a summarized record name
@@ -18,6 +17,29 @@ class ContextFilter(logging.Filter):
         prefix = '.'.join(c[0] for c in components[:-1])
         return '{}.{}'.format(prefix, components[-1])
 
+    coloring = {u'DEBUG':u'magenta', u'WARNING':u'yellow',
+        u'ERROR':u'red', u'INFO':u'blue'}
+    colors =  dict(zip([u'black', u'red', u'green', u'yellow',
+        u'blue', u'magenta', u'cyan', u'white'], map(str, range(30, 30 + 8))))
+
+    color_map = {}
+    for k, v in coloring.items():
+        color_map[k] = colors[v]
+
+    color_set = u'\x1b[%sm'
+    color_reset = u'\x1b[0m'
+
+    def colored_level_name(self, levelname):
+        '''
+        Colors the logging level in the logging record
+        '''
+        if ( 1 == 0 ): # disable colored output if true
+            return levelname + u':'
+        else:
+            retval = (self.color_set % self.color_map[levelname]) +
+                levelname + u':' + self.color_reset
+            return retval
+
     def filter(self, record):
         if hasattr(self, 'stateid') and isinstance(self.stateid, int):
             record.stateid = '[%d]' % self.stateid
@@ -25,6 +47,7 @@ class ContextFilter(logging.Filter):
             record.stateid = ''
 
         record.name = self.summarized_name(record.name)
+        record.levelname = self.colored_level_name(record.levelname)
         return True
 
 
@@ -37,7 +60,7 @@ def init_logging(default_level=logging.WARNING):
     loggers = logging.getLogger().manager.loggerDict.keys()
 
     ctxfilter = ContextFilter()
-    logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s:"
+    logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s"
               " %(message)s")
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(logfmt)

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -17,6 +17,8 @@ class ContextFilter(logging.Filter):
         prefix = '.'.join(c[0] for c in components[:-1])
         return '{}.{}'.format(prefix, components[-1])
 
+    colors_disabled = False
+
     coloring = {u'DEBUG':u'magenta', u'WARNING':u'yellow',
         u'ERROR':u'red', u'INFO':u'blue'}
     colors =  dict(zip([u'black', u'red', u'green', u'yellow',
@@ -33,11 +35,10 @@ class ContextFilter(logging.Filter):
         '''
         Colors the logging level in the logging record
         '''
-        if ( 1 == 0 ): # disable colored output if true
+        if ( self.colors_disabled ):
             return levelname + u':'
         else:
-            retval = (self.color_set % self.color_map[levelname]) +
-                levelname + u':' + self.color_reset
+            retval = (self.color_set % self.color_map[levelname]) + levelname + u':' + self.color_reset
             return retval
 
     def filter(self, record):
@@ -54,6 +55,8 @@ class ContextFilter(logging.Filter):
 manticore_verbosity = 0
 all_loggers = []
 
+def disable_colors():
+    ContextFilter.colors_disabled = True
 
 def init_logging(default_level=logging.WARNING):
     global all_loggers


### PR DESCRIPTION
This pull request implements #1158 .  A "--no-colors" command line flag was added to disable the insertion of ANSI color escape sequences, which are now outputted by default.  Currently, "DEBUG:", "WARNING:", "ERROR:", and "INFO:" should output in magenta, yellow, red, and blue, respectively, but these colors can be changed by editing the `coloring` dict object.

Since Manticore starts logging before command line options are parsed, there is a brief window during which ANSI color escape sequences might be outputted before the toggle to disable them takes effect.  In addition, if there are any starting points of Manticore's execution /other/ than `manticore/__main__.py`, then I may have failed to insert a check for the aforementioned command line toggle in those areas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1177)
<!-- Reviewable:end -->
