### PR TITLE
Add check and warning for mismatched args

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -11,6 +11,7 @@ from ..core.smtlib import ConstraintSet, Operators, solver, BitVec, Array, Array
 from ..platforms import evm
 from ..core.state import State, TerminateState
 from ..utils.helpers import issymbolic, PickleSerializer
+from ..utils.log import init_logging
 import tempfile
 from subprocess import Popen, PIPE, check_output
 from multiprocessing import Process, Queue
@@ -28,7 +29,10 @@ from .account import EVMAccount, EVMContract
 from .abi import ABI
 from .solidity import SolidityMetadata
 
+
 logger = logging.getLogger(__name__)
+
+init_logging()  # FIXME(mark): emitting a warning in abi.py does not work unless this is called a second time here
 
 
 def flagged(flag):

--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -43,7 +43,7 @@ class ABI(object):
         num_args = len(args)
         num_sig_args = len(type_spec.split(','))
         if num_args != num_sig_args:
-            logger.warning(f'Number of provided arguments does not match number of arguments in signature: {type_spec}')
+            logger.warning(f'Number of provided arguments ({num_args}) does not match number of arguments in signature: {type_spec}')
 
 
     @staticmethod

--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -1,10 +1,14 @@
 import re
 import uuid
 import sha3
+import logging
 
 from .. import abitypes, issymbolic
 from ..core.smtlib import Array, Operators, BitVec, ArrayVariable, ArrayProxy
 from ..exceptions import EthereumError
+
+
+logger = logging.getLogger(__name__)
 
 
 class ABI(object):
@@ -35,6 +39,14 @@ class ABI(object):
         raise ValueError
 
     @staticmethod
+    def _check_and_warn_num_args(type_spec, *args):
+        num_args = len(args)
+        num_sig_args = len(type_spec.split(','))
+        if num_args != num_sig_args:
+            logger.warning(f'Number of provided arguments does not match number of arguments in signature: {type_spec}')
+
+
+    @staticmethod
     def function_call(type_spec, *args):
         """
         Build transaction data from function signature and arguments
@@ -42,6 +54,8 @@ class ABI(object):
         m = re.match(r"(?P<name>[a-zA-Z_][a-zA-Z_0-9]*)(?P<type>\(.*\))", type_spec)
         if not m:
             raise EthereumError("Function signature expected")
+
+        ABI._check_and_warn_num_args(type_spec, *args)
 
         result = ABI.function_selector(type_spec)  # Funcid
         result += ABI.serialize(m.group('type'), *args)

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -70,7 +70,7 @@ class EVMContract(EVMAccount):
         if func_name in self._hashes:
             self._hashes[func_name].append(entry)
             return
-        if func_id in {h[1] for names in self._hashes.values() for h in names}:
+        if func_id in {entry.func_id for entries in self._hashes.values() for entry in entries}:
             raise EthereumError("A function with the same hash as {} is already defined".format(func_name))
         self._hashes[func_name] = [entry]
 

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -103,7 +103,6 @@ class EVMContract(EVMAccount):
             print(self._hashes)
             if self._hashes is not None and name in self._hashes.keys():
                 def f(*args, signature: Optional[str]=None, caller=None, value=0, **kwargs):
-                    num_args = len(args)
                     try:
                         if signature:
                             if f'{name}{signature}' not in {entry.signature for entries in self._hashes.values() for entry in entries}:
@@ -117,7 +116,6 @@ class EVMContract(EVMAccount):
                             entries = self._hashes[name]
                             if len(entries) > 1:
                                 sig = entries[0].signature[len(name):]
-                                # print(sig)
                                 raise EthereumError(
                                     f'Function: `{name}` has multiple signatures but `signature` is not '
                                     f'defined! Example: `account.{name}(..., signature="{sig}")`\n'

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -4,7 +4,9 @@ from typing import Optional
 from .abi import ABI
 from ..exceptions import EthereumError
 
+
 HashesEntry = namedtuple('HashesEntry', 'signature func_id')
+
 
 class EVMAccount(object):
     def __init__(self, address=None, manticore=None, name=None):

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -100,7 +100,6 @@ class EVMContract(EVMAccount):
         """
         if not name.startswith('_'):
             self.__init_hashes()
-            print(self._hashes)
             if self._hashes is not None and name in self._hashes.keys():
                 def f(*args, signature: Optional[str]=None, caller=None, value=0, **kwargs):
                     try:
@@ -112,7 +111,6 @@ class EVMContract(EVMAccount):
 
                             tx_data = ABI.function_call(f'{name}{signature}', *args)
                         else:
-                            # print(12333)
                             entries = self._hashes[name]
                             if len(entries) > 1:
                                 sig = entries[0].signature[len(name):]

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -1,8 +1,10 @@
+from collections import namedtuple
 from typing import Optional
 
 from .abi import ABI
 from ..exceptions import EthereumError
 
+HashesEntry = namedtuple('HashesEntry', 'signature func_id')
 
 class EVMAccount(object):
     def __init__(self, address=None, manticore=None, name=None):
@@ -62,12 +64,13 @@ class EVMContract(EVMAccount):
         if func_name.startswith('__') or func_name in {'add_function', 'address', 'name'}:
             # TODO(mark): is this actually true? is there anything actually wrong with a solidity name beginning w/ an underscore?
             raise EthereumError("Function name ({}) is internally reserved".format(func_name))
+        entry = HashesEntry(signature, func_id)
         if func_name in self._hashes:
-            self._hashes[func_name].append((signature, func_id))
+            self._hashes[func_name].append(entry)
             return
         if func_id in {h[1] for names in self._hashes.values() for h in names}:
             raise EthereumError("A function with the same hash as {} is already defined".format(func_name))
-        self._hashes[func_name] = [(signature, func_id)]
+        self._hashes[func_name] = [entry]
 
     def __null_func(self):
         pass
@@ -95,25 +98,30 @@ class EVMContract(EVMAccount):
         """
         if not name.startswith('_'):
             self.__init_hashes()
+            print(self._hashes)
             if self._hashes is not None and name in self._hashes.keys():
                 def f(*args, signature: Optional[str]=None, caller=None, value=0, **kwargs):
+                    num_args = len(args)
                     try:
                         if signature:
-                            if f'{name}{signature}' not in {h[0] for names in self._hashes.values() for h in names}:
+                            if f'{name}{signature}' not in {entry.signature for entries in self._hashes.values() for entry in entries}:
                                 raise EthereumError(
                                     f'Function: `{name}` has no such signature`\n'
-                                    f'Known signatures: {[x[0][len(name):] for x in self._hashes[name]]}')
+                                    f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
 
                             tx_data = ABI.function_call(f'{name}{signature}', *args)
                         else:
-                            if len(self._hashes[name]) > 1:
-                                sig = self._hashes[name][0][0][len(name):]
+                            # print(12333)
+                            entries = self._hashes[name]
+                            if len(entries) > 1:
+                                sig = entries[0].signature[len(name):]
+                                # print(sig)
                                 raise EthereumError(
                                     f'Function: `{name}` has multiple signatures but `signature` is not '
                                     f'defined! Example: `account.{name}(..., signature="{sig}")`\n'
-                                    f'Known signatures: {[x[0][len(name):] for x in self._hashes[name]]}')
+                                    f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
 
-                            tx_data = ABI.function_call(str(self._hashes[name][0][0]), *args)
+                            tx_data = ABI.function_call(str(entries[0].signature), *args)
                     except KeyError as e:
                         raise e
 


### PR DESCRIPTION
This adds a check and warning if a contract function is called with a number of arguments that does not match the signature.

The reason a warning is logged rather than an error thrown, is because passing an incorrect number of arguments to a contract invocation will result in an incorrect length tx data being used in the tx. If it's too short, the missing arguments will be implicitly zero (see yellow paper, oob reads in txdata are 0). If it's too long, the extra arguments won't be accessed by the contract. So imo neither case is technically "wrong".

Also refactors `EVMContract.__getattribute__` to be more readable using a namedtuple.

Fixes #1178

Running the script in the issue now produces

```
[I] (py3) vagrant ubuntu-bionic /v/m/1178 ❯ py x.py                         ❮ 10/08 05:39
2018-10-08 17:39:38,724: [4249] m.e.abi:WARNING: Number of provided arguments (2) does not match number of arguments in signature: add(uint256)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1181)
<!-- Reviewable:end -->
