### PR TITLE
Issue #1071  --> Global lock held for a long time

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -148,14 +148,14 @@ class BranchLimited(Policy):
         with self.locked_context() as policy_ctx:
             visited = policy_ctx.get('visited', dict())
             summaries = policy_ctx.get('summaries', dict())
-            lst = []
-            for id_, pc in summaries.items():
-                cnt = visited.get(pc, 0)
-                if id_ not in state_ids:
-                    continue
-                if cnt <= self._limit:
-                    lst.append((id_, visited.get(pc, 0)))
-            lst = sorted(lst, key=lambda x: x[1])
+        lst = []
+        for id_, pc in summaries.items():
+            cnt = visited.get(pc, 0)
+            if id_ not in state_ids:
+                continue
+            if cnt <= self._limit:
+                lst.append((id_, visited.get(pc, 0)))
+        lst = sorted(lst, key=lambda x: x[1])
 
         if lst:
             return lst[0][0]


### PR DESCRIPTION
**Fix for issue #1071**

**- Problem:**
  * Global lock need to be held until the required variables are fetched
  * Lock should be released while processing further

**- Fix:**
  * Scope the lock loop only until the variables are set

**- Uncertain:**
  * A similar scenario in `choice` function at Uncovered policy, should it be fixed as well?
  * Do we have to explicitly unlock?
  * Should there be any error handle for failures in lock loop?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1187)
<!-- Reviewable:end -->
