### PR TITLE
String representation for Manticore EVM

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -1548,10 +1548,7 @@ class ManticoreEVM(Manticore):
         pass
 
     def __repr__(self):
-        return "<ManticoreEVM | Alive States: {}; Terminated States: {}>".format(
-            self.count_running_states(),
-            self.count_terminated_states()
-        )
+        return self.__str__()
 
     def __str__(self):
         return "<ManticoreEVM | Alive States: {}; Terminated States: {}>".format(


### PR DESCRIPTION
Resolves #981 

* Implemented the __str__ method to print no. of alive and terminated states using `count_running_states` and `count_terminated_states` methods. 
* Also implemented __repr__ which is used as a "formal" string representation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1188)
<!-- Reviewable:end -->
