### PR TITLE
Fix logic in warning check

### DIFF
--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -42,7 +42,9 @@ class ABI(object):
     def _check_and_warn_num_args(type_spec, *args):
         num_args = len(args)
         num_sig_args = len(type_spec.split(','))
-        if num_args != num_sig_args:
+        no_declared_args = '()' in type_spec
+
+        if no_declared_args and num_args or num_args != num_sig_args:
             logger.warning(f'Number of provided arguments ({num_args}) does not match number of arguments in signature: {type_spec}')
 
 


### PR DESCRIPTION
It used to falsely warn if there were 0 declared arguments, and 0 were given.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1191)
<!-- Reviewable:end -->
