### PR TITLE
Fixes issue #170: Cannot control input size from cli

### DIFF
--- a/docs/syminput.rst
+++ b/docs/syminput.rst
@@ -29,7 +29,8 @@ For API use, use the ``argv`` and ``envp`` arguments to the :meth:`manticore.Man
 Symbolic stdin
 --------------
 
-Manticore by default is configured with 256 bytes of symbolic stdin data, after an optional
+Manticore by default is configured with 256 bytes of symbolic stdin data which is configurable
+with the ``stdin_size`` kwarg of :meth:`manticore.Manticore.linux` , after an optional
 concrete data prefix, which can be provided with the ``concrete_start`` kwarg of
 :meth:`manticore.Manticore.linux`.
 

--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,3 +1,3 @@
-from .manticore import Manticore  # noqa
+from .manticore import Manticore, STDIN_INPUT_DEFAULT_SIZE  # noqa
 from .models import variadic  # noqa
 from .utils.helpers import issymbolic  # noqa

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -56,7 +56,7 @@ def parse_arguments():
                         help='Show program version information')
     parser.add_argument('--config', type=str,
                         help='Manticore config file (.yml) to use. (default config file pattern is: ./[.]m[anti]core.yml)')
-    parser.add_argument('--stdin_size', type=int, default=256,
+    parser.add_argument('--stdin_size', type=int, default=STDIN_INPUT_DEFAULT_SIZE,
                         help='Control the maximum symbolic stdin size')
 
     bin_flags = parser.add_argument_group('Binary flags')

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import argparse
 
-from . import Manticore
+from . import Manticore, STDIN_INPUT_DEFAULT_SIZE
 from .utils import log, config
 
 # XXX(yan): This would normally be __name__, but then logger output will be pre-

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -56,8 +56,8 @@ def parse_arguments():
                         help='Show program version information')
     parser.add_argument('--config', type=str,
                         help='Manticore config file (.yml) to use. (default config file pattern is: ./[.]m[anti]core.yml)')
-    parser.add_argument('--input_size', type=int, default=256,
-                        help='Control the maximum input size')
+    parser.add_argument('--stdin_size', type=int, default=256,
+                        help='Control the maximum symbolic stdin size')
 
     bin_flags = parser.add_argument_group('Binary flags')
     bin_flags.add_argument('--entrysymbol', type=str, default=None,
@@ -226,7 +226,7 @@ def main():
 
     env = {key: val for key, val in [env[0].split('=') for env in args.env]}
 
-    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, concrete_start=args.data, input_size=args.input_size)
+    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, concrete_start=args.data, stdin_size=args.stdin_size)
 
     # Default plugins for now.. FIXME REMOVE!
     m.register_plugin(InstructionCounter())

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -56,6 +56,8 @@ def parse_arguments():
                         help='Show program version information')
     parser.add_argument('--config', type=str,
                         help='Manticore config file (.yml) to use. (default config file pattern is: ./[.]m[anti]core.yml)')
+    parser.add_argument('--input_size', type=int, default=256,
+                        help='Control the maximum input size')
 
     bin_flags = parser.add_argument_group('Binary flags')
     bin_flags.add_argument('--entrysymbol', type=str, default=None,
@@ -224,7 +226,7 @@ def main():
 
     env = {key: val for key, val in [env[0].split('=') for env in args.env]}
 
-    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, concrete_start=args.data)
+    m = Manticore(args.argv[0], argv=args.argv[1:], env=env, entry_symbol=args.entrysymbol, workspace_url=args.workspace, policy=args.policy, concrete_start=args.data, input_size=args.input_size)
 
     # Default plugins for now.. FIXME REMOVE!
     m.register_plugin(InstructionCounter())

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -34,6 +34,9 @@ from .utils import log
 logger = logging.getLogger(__name__)
 log.init_logging()
 
+# Default symbolic input size
+STDIN_INPUT_DEFAULT_SIZE = 256
+
 
 def make_decree(program, concrete_start='', **kwargs):
     constraints = ConstraintSet()
@@ -48,7 +51,7 @@ def make_decree(program, concrete_start='', **kwargs):
     return initial_state
 
 
-def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=256):
+def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=STDIN_INPUT_DEFAULT_SIZE):
     env = {} if env is None else env
     argv = [] if argv is None else argv
     env = [f'{k}={v}' for k, v in env.items()]
@@ -229,7 +232,7 @@ class Manticore(Eventful):
             self.unregister_plugin(plugin)
 
     @classmethod
-    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=256, **kwargs):
+    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=STDIN_INPUT_DEFAULT_SIZE, **kwargs):
         """
         Constructor for Linux binary analysis.
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -48,7 +48,7 @@ def make_decree(program, concrete_start='', **kwargs):
     return initial_state
 
 
-def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start='', input_size=256):
+def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=256):
     env = {} if env is None else env
     argv = [] if argv is None else argv
     env = [f'{k}={v}' for k, v in env.items()]
@@ -87,7 +87,7 @@ def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=N
     platform.input.write(concrete_start)
 
     # set stdin input...
-    platform.input.write(initial_state.symbolicate_buffer('+' * input_size,
+    platform.input.write(initial_state.symbolicate_buffer('+' * stdin_size,
                                                           label='STDIN'))
     return initial_state
 
@@ -229,7 +229,7 @@ class Manticore(Eventful):
             self.unregister_plugin(plugin)
 
     @classmethod
-    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', input_size=256, **kwargs):
+    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', stdin_size=256, **kwargs):
         """
         Constructor for Linux binary analysis.
 
@@ -243,13 +243,13 @@ class Manticore(Eventful):
         :param symbolic_files: Filenames to mark as having symbolic input
         :type symbolic_files: list[str]
         :param str concrete_start: Concrete stdin to use before symbolic input
-        :param int input_size: stdin input size to use
+        :param int stdin_size: symbolic stdin size to use
         :param kwargs: Forwarded to the Manticore constructor
         :return: Manticore instance, initialized with a Linux State
         :rtype: Manticore
         """
         try:
-            return cls(make_linux(path, argv, envp, entry_symbol, symbolic_files, concrete_start, input_size), **kwargs)
+            return cls(make_linux(path, argv, envp, entry_symbol, symbolic_files, concrete_start, stdin_size), **kwargs)
         except elftools.common.exceptions.ELFError:
             raise Exception(f'Invalid binary: {path}')
 

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -48,7 +48,7 @@ def make_decree(program, concrete_start='', **kwargs):
     return initial_state
 
 
-def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start=''):
+def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=None, concrete_start='', input_size=256):
     env = {} if env is None else env
     argv = [] if argv is None else argv
     env = [f'{k}={v}' for k, v in env.items()]
@@ -87,7 +87,7 @@ def make_linux(program, argv=None, env=None, entry_symbol=None, symbolic_files=N
     platform.input.write(concrete_start)
 
     # set stdin input...
-    platform.input.write(initial_state.symbolicate_buffer('+' * 256,
+    platform.input.write(initial_state.symbolicate_buffer('+' * input_size,
                                                           label='STDIN'))
     return initial_state
 
@@ -229,7 +229,7 @@ class Manticore(Eventful):
             self.unregister_plugin(plugin)
 
     @classmethod
-    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', **kwargs):
+    def linux(cls, path, argv=None, envp=None, entry_symbol=None, symbolic_files=None, concrete_start='', input_size=256, **kwargs):
         """
         Constructor for Linux binary analysis.
 
@@ -243,12 +243,13 @@ class Manticore(Eventful):
         :param symbolic_files: Filenames to mark as having symbolic input
         :type symbolic_files: list[str]
         :param str concrete_start: Concrete stdin to use before symbolic input
+        :param int input_size: stdin input size to use
         :param kwargs: Forwarded to the Manticore constructor
         :return: Manticore instance, initialized with a Linux State
         :rtype: Manticore
         """
         try:
-            return cls(make_linux(path, argv, envp, entry_symbol, symbolic_files, concrete_start), **kwargs)
+            return cls(make_linux(path, argv, envp, entry_symbol, symbolic_files, concrete_start, input_size), **kwargs)
         except elftools.common.exceptions.ELFError:
             raise Exception(f'Invalid binary: {path}')
 


### PR DESCRIPTION
**Summary:** 
Fixes #170 --> add new cli argument for input_size and change function calls to include this argument

**Changes:**
* **Default value:** set default value for argument to 256 as hardcoded before
* **__main__.py:** add new argument for input_size 
* **make_linux, linux:** function call changes

**Clarification:**
* Default value for input_size to `256`? (as hardcoded before)
* Variable name set to `input_size`?
* The default value for argument is set at both argument `definition at arg parse` and `function definitions - make_linux, linux` which might be redundant? (make_linux call has a number of default arguments and linux function is a classmethod)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1192)
<!-- Reviewable:end -->
