### PR TITLE
make_evmtests: Add missing account_address to test body.

### DIFF
--- a/tests/auto/make_evmtests.py
+++ b/tests/auto/make_evmtests.py
@@ -108,6 +108,7 @@ def gen_test(testcase, filename, skip):
         account_balance = i(account['balance'])
 
         output += f'''
+        account_address = {hex(account_address)}
         bytecode = unhexlify('{account_code}')
         world.create_account(address={hex(account_address)},
                              balance={account_balance},


### PR DESCRIPTION
Some tests that required account_address were failing due to not defined variable.

Refs: https://github.com/trailofbits/manticore/issues/1167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1193)
<!-- Reviewable:end -->
