### PR TITLE
Fix fallback function matching in ethereum.FilterFunctions

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -100,7 +100,7 @@ class FilterFunctions(Plugin):
             selected_functions = []
 
             for func_hsh in md.hashes:
-                if func_hsh == '00000000':
+                if func_hsh == b'\0\0\0\0':
                     continue
                 abi = md.get_abi(func_hsh)
                 func_name = md.get_func_name(func_hsh)
@@ -113,7 +113,7 @@ class FilterFunctions(Plugin):
                 selected_functions.append(func_hsh)
 
             if self._fallback:
-                selected_functions.append('00000000')
+                selected_functions.append(b'\0\0\0\0')
 
             if self._include:
                 # constrain the input so it can take only the interesting values

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -36,8 +36,8 @@ def make_mock_evm_state():
     return fakestate
 
 @contextmanager
-def disposable_mevm(**kwargs):
-    mevm = ManticoreEVM(**kwargs)
+def disposable_mevm(*args, **kwargs):
+    mevm = ManticoreEVM(*args, **kwargs)
     try:
         yield mevm
     finally:


### PR DESCRIPTION
This PR fixes issue #1196.

This PR also adds a test for the FilterFunctions fallback function hash matching to a new `EthPluginTests` class in `tests/eth_general.py`. Let me know if you the test to be moved elsewhere or done differently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1197)
<!-- Reviewable:end -->
