### PR TITLE
Fix constructor and fallback function handling in Solidity metadata import

### DIFF
--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -137,6 +137,8 @@ class ABI(object):
     def _serialize_tuple(types, value, dyn_offset=None):
         result = bytearray()
         dyn_result = bytearray()
+        if len(types) != len(value):
+            raise ValueError(f"The number of values to serialize is {'less' if len(value) < len(types) else 'greater'} than the number of types")
         for ty_i, value_i in zip(types, value):
             result_i, dyn_result_i = ABI._serialize(ty_i, value_i, dyn_offset + len(dyn_result))
             result += result_i

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -14,7 +14,18 @@ class SolidityMetadata(object):
         self._init_bytecode = init_bytecode
         self._runtime_bytecode = runtime_bytecode
         self._functions = hashes.keys()
-        self.abi = {item.get('name', '{fallback}'): item for item in abi}
+
+        abi_items_by_name = {}
+        for item in abi:
+            name = item.get('name')
+            if name is None:
+                type = item['type']
+                name = f'{{{type}}}'
+                assert name not in abi_items_by_name
+            # FIXME: Properly handle overloaded functions.
+            abi_items_by_name[name] = item
+        self.abi = abi_items_by_name
+
         self.warnings = warnings
         self.srcmap_runtime = self.__build_source_map(self.runtime_bytecode, srcmap_runtime)
         self.srcmap = self.__build_source_map(self.init_bytecode, srcmap)

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -905,7 +905,25 @@ class EthSolidityCompilerTest(unittest.TestCase):
         finally:
             shutil.rmtree(d)
 
+class EthSolidityMetadataTests(unittest.TestCase):
+    def test_abi_constructor_and_fallback_items(self):
+        with disposable_mevm() as m:
+            source_code = '''
+            contract C {
+                constructor(uint a) public {}
+                function() public payable {}
+            }
+            '''
+            user_account = m.create_account(balance=1000, name='user_account')
+            contract_account = m.solidity_create_contract(source_code, owner=user_account, name='contract_account', args = (0,))
+            md = m.get_metadata(contract_account)
 
+            self.assertEqual(md.get_constructor_arguments(), '(uint256)')
+
+            fallback = md.get_abi('')
+            self.assertEqual(fallback['type'], 'fallback')
+            self.assertIsNone(fallback.get('inputs'))
+            self.assertEqual(fallback['stateMutability'], 'payable')
 
 class EthSpecificTxIntructionTests(unittest.TestCase):
 


### PR DESCRIPTION
Also adds a tuple length check to `ABI._serialize_tuple`.

Fixes issue #1209.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1211)
<!-- Reviewable:end -->
