### PR TITLE
Fix handling of overloaded functions and some other issues in SolidityMetadata

### DIFF
--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -137,6 +137,8 @@ class ABI(object):
     def _serialize_tuple(types, value, dyn_offset=None):
         result = bytearray()
         dyn_result = bytearray()
+        if len(types) != len(value):
+            raise ValueError(f"The number of values to serialize is {'less' if len(value) < len(types) else 'greater'} than the number of types")
         for ty_i, value_i in zip(types, value):
             result_i, dyn_result_i = ABI._serialize(ty_i, value_i, dyn_offset + len(dyn_result))
             result += result_i

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -83,7 +83,7 @@ class EVMContract(EVMAccount):
             self._hashes = {}
             md = self._manticore.get_metadata(self._address)
             if md is not None:
-                for signature in md.functions:
+                for signature in md.function_signatures:
                     self.add_function(signature)
             # It was successful, no need to re-run. _init_hashes disabled
             self.__init_hashes = self.__null_func

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -183,7 +183,7 @@ class SolidityMetadata(object):
         The content of the returned dict is described at https://solidity.readthedocs.io/en/latest/abi-spec.html#json_
         """
         if not isinstance(hsh, (bytes, bytearray)):
-            raise ValueError('The selector argument must be a concrete byte array')
+            raise TypeError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         if sig is not None:
             return dict(self._function_abi_items_by_signature[sig])
@@ -200,7 +200,7 @@ class SolidityMetadata(object):
         the empty tuple type signature ``'()'`` is returned.
         """
         if not isinstance(hsh, (bytes, bytearray)):
-            raise ValueError('The selector argument must be a concrete byte array')
+            raise TypeError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         return '()' if sig is None else sig[sig.find('('):]
 
@@ -212,7 +212,7 @@ class SolidityMetadata(object):
         the empty tuple type signature ``'()'`` is returned.
         """
         if not isinstance(hsh, (bytes, bytearray)):
-            raise ValueError('The selector argument must be a concrete byte array')
+            raise TypeError('The selector argument must be a concrete byte array')
         abi = self.get_abi(hsh)
         outputs = abi.get('outputs')
         return '()' if outputs is None else SolidityMetadata.tuple_signature_for_components(outputs)
@@ -222,7 +222,7 @@ class SolidityMetadata(object):
         or ``'{fallback}'`` if no such function exists.
         """
         if not isinstance(hsh, (bytes, bytearray)):
-            raise ValueError('The selector argument must be a concrete byte array')
+            raise TypeError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         return '{fallback}' if sig is None else sig[:sig.find('(')]
 
@@ -233,7 +233,7 @@ class SolidityMetadata(object):
         This function returns ``None`` for any selector that will be dispatched to a fallback function.
         """
         if not isinstance(hsh, (bytes, bytearray)):
-            raise ValueError('The selector argument must be a concrete byte array')
+            raise TypeError('The selector argument must be a concrete byte array')
         return self._function_signatures_by_selector.get(hsh)
 
     @deprecated("Use `abi.ABI.function_selector` instead.")
@@ -286,9 +286,9 @@ class SolidityMetadata(object):
         if returndata is None:
             returndata = bytes()
         if not isinstance(calldata, (bytes, bytearray)):
-            raise ValueError("calldata must be a concrete array")
+            raise TypeError("calldata must be a concrete byte array")
         if not isinstance(returndata, (bytes, bytearray)):
-            raise ValueError("returndata must be a concrete array")
+            raise TypeError("returndata must be a concrete byte array")
         calldata = bytes(calldata)
         returndata = bytes(returndata)
         function_id = calldata[:4]

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -182,6 +182,8 @@ class SolidityMetadata(object):
 
         The content of the returned dict is described at https://solidity.readthedocs.io/en/latest/abi-spec.html#json_
         """
+        if not isinstance(hsh, (bytes, bytearray)):
+            raise ValueError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         if sig is not None:
             return dict(self._function_abi_items_by_signature[sig])
@@ -197,6 +199,8 @@ class SolidityMetadata(object):
         If no normal contract function has the specified selector,
         the empty tuple type signature ``'()'`` is returned.
         """
+        if not isinstance(hsh, (bytes, bytearray)):
+            raise ValueError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         return '()' if sig is None else sig[sig.find('('):]
 
@@ -207,6 +211,8 @@ class SolidityMetadata(object):
         If no normal contract function has the specified selector,
         the empty tuple type signature ``'()'`` is returned.
         """
+        if not isinstance(hsh, (bytes, bytearray)):
+            raise ValueError('The selector argument must be a concrete byte array')
         abi = self.get_abi(hsh)
         outputs = abi.get('outputs')
         return '()' if outputs is None else SolidityMetadata.tuple_signature_for_components(outputs)
@@ -215,6 +221,8 @@ class SolidityMetadata(object):
         """Returns the name of the normal function with the selector ``hsh``,
         or ``'{fallback}'`` if no such function exists.
         """
+        if not isinstance(hsh, (bytes, bytearray)):
+            raise ValueError('The selector argument must be a concrete byte array')
         sig = self._function_signatures_by_selector.get(hsh)
         return '{fallback}' if sig is None else sig[:sig.find('(')]
 
@@ -224,6 +232,8 @@ class SolidityMetadata(object):
 
         This function returns ``None`` for any selector that will be dispatched to a fallback function.
         """
+        if not isinstance(hsh, (bytes, bytearray)):
+            raise ValueError('The selector argument must be a concrete byte array')
         return self._function_signatures_by_selector.get(hsh)
 
     @deprecated("Use `abi.ABI.function_selector` instead.")

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -14,7 +14,18 @@ class SolidityMetadata(object):
         self._init_bytecode = init_bytecode
         self._runtime_bytecode = runtime_bytecode
         self._functions = hashes.keys()
-        self.abi = {item.get('name', '{fallback}'): item for item in abi}
+
+        abi_items_by_name = {}
+        for item in abi:
+            name = item.get('name')
+            if name is None:
+                type = item['type']
+                name = f'{{{type}}}'
+                assert name not in abi_items_by_name
+            # FIXME: Properly handle overloaded functions.
+            abi_items_by_name[name] = item
+        self.abi = abi_items_by_name
+
         self.warnings = warnings
         self.srcmap_runtime = self.__build_source_map(self.runtime_bytecode, srcmap_runtime)
         self.srcmap = self.__build_source_map(self.init_bytecode, srcmap)

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -1,10 +1,36 @@
+
+from typing import Any, Dict, Mapping, Optional, Sequence, Iterable, Tuple
 import pyevmasm as EVMAsm
 
 from .abi import ABI
 from ..exceptions import EthereumError
+from ..utils.deprecated import deprecated
 
 
 class SolidityMetadata(object):
+
+    @staticmethod
+    def function_signature_for_name_and_inputs(name: str, inputs: Sequence[Mapping[str, Any]]) -> str:
+        """Returns the function signature for the specified name and Solidity JSON metadata inputs array.
+
+        The ABI specification defines the function signature as the function name followed by the parenthesised list of
+        parameter types separated by single commas and no spaces.
+        See https://solidity.readthedocs.io/en/latest/abi-spec.html#function-selector
+        """
+        return name + SolidityMetadata.tuple_signature_for_components(inputs)
+
+    @staticmethod
+    def tuple_signature_for_components(components: Sequence[Mapping[str, Any]]) -> str:
+        """Equivalent to ``function_signature_for_name_and_inputs('', components)``."""
+        ts = []
+        for c in components:
+            t: str = c['type']
+            if t.startswith('tuple'):
+                assert len(t) == 5 or t[5] == '['
+                t = SolidityMetadata.tuple_signature_for_components(c['components']) + t[5:]
+            ts.append(t)
+        return f'({",".join(ts)})'
+
     def __init__(self, name, source_code, init_bytecode, runtime_bytecode, srcmap, srcmap_runtime, hashes, abi, warnings):
         """ Contract metadata for Solidity-based contracts """
         self.name = name
@@ -13,57 +39,43 @@ class SolidityMetadata(object):
         self.source_code = source_code
         self._init_bytecode = init_bytecode
         self._runtime_bytecode = runtime_bytecode
-        self._functions = hashes.keys()
 
-        abi_items_by_name = {}
+        self._function_signatures_by_selector = {bytes.fromhex(sel): sig for sig, sel in hashes.items()}
+
+        fallback_selector = b'\0\0\0\0'
+        while fallback_selector in self._function_signatures_by_selector:
+            fallback_selector = (int.from_bytes(fallback_selector, 'big') + 1).to_bytes(4, 'big')
+        self._fallback_function_selector = fallback_selector
+
+        self._constructor_abi_item = None
+        self._fallback_function_abi_item = None
+        function_items = {}
+        event_items = {}
         for item in abi:
-            name = item.get('name')
-            if name is None:
-                type = item['type']
-                name = f'{{{type}}}'
-                assert name not in abi_items_by_name
-            # FIXME: Properly handle overloaded functions.
-            abi_items_by_name[name] = item
-        self.abi = abi_items_by_name
+            type = item['type']
+            if type == 'function':
+                signature = self.function_signature_for_name_and_inputs(item['name'], item['inputs'])
+                function_items[signature] = item
+            elif type == 'event':
+                signature = self.function_signature_for_name_and_inputs(item['name'], item['inputs'])
+                event_items[signature] = item
+            elif type == 'constructor':
+                assert not self._constructor_abi_item, "A constructor cannot be overloaded"
+                self._constructor_abi_item = item
+            elif type == 'fallback':
+                assert not self._fallback_function_abi_item, "There can only be one fallback function"
+                self._fallback_function_abi_item = item
+        self._function_abi_items_by_signature = function_items
+        self._event_abi_items_by_signature = event_items
 
         self.warnings = warnings
         self.srcmap_runtime = self.__build_source_map(self.runtime_bytecode, srcmap_runtime)
         self.srcmap = self.__build_source_map(self.init_bytecode, srcmap)
 
-    def get_constructor_arguments(self):
-        for fun in self.abi.values():
-            if fun['type'] == 'constructor':
-                constructor_inputs = fun['inputs']
-                break
-        else:
-            constructor_inputs = ()
-
-        def process(spec):
-            if spec['type'].startswith('tuple'):
-                types = []
-                for component in spec['components']:
-                    types.append(process(component))
-                return '({}){:s}'.format(','.join(types), spec['type'][5:])
-            else:
-                return spec['type']
-        inputs = {'components': constructor_inputs, 'type': 'tuple'}
-        return process(inputs)
-
-    def add_function(self, method_name_and_signature):
-        if not isinstance(method_name_and_signature, str):
-            raise ValueError("method_name_and_signature needs to be a string")
-        #TODO: use re, and check it's sane
-        name = method_name_and_signature.split('(')[0]
-        if name in self.abi:
-            raise EthereumError("Function already defined")
-        hsh = ABI.function_selector(method_name_and_signature)
-        self._functions.add(method_name_and_signature)
-
-        input_types = method_name_and_signature.split('(')[1].split(')')[0].split(',')
-        output_types = method_name_and_signature.split(')')[1].split(',')
-        self.abi[name] = {'inputs': [{'type': ty} for ty in input_types],
-                          'name': name,
-                          'outputs': [{'type': ty} for ty in output_types]}
+    def get_constructor_arguments(self) -> str:
+        """Returns the tuple type signature for the arguments of the contract constructor."""
+        item = self._constructor_abi_item
+        return '()' if item is None else self.tuple_signature_for_components(item['inputs'])
 
     @staticmethod
     def _without_metadata(bytecode):
@@ -139,41 +151,125 @@ class SolidityMetadata(object):
         return self.srcmap_runtime if runtime else self.srcmap
 
     @property
-    def signatures(self):
-        return dict(((self.get_hash(f), f) for f in self._functions))
+    def signatures(self) -> Dict[bytes, str]:
+        """Returns a new dict mapping contract function selectors to the function signatures.
 
-    def get_abi(self, hsh):
-        func_name = self.get_func_name(hsh)
-        default_fallback_abi = {'stateMutability': 'nonpayable', 'payable': False, 'type': 'fallback'}
-        return self.abi.get(func_name, default_fallback_abi)
+        The dict does not include an item for the default or non-default fallback function.
+        """
+        return dict(self._function_signatures_by_selector)
 
-    def get_func_argument_types(self, hsh):
+    @property
+    def has_non_default_constructor(self) -> bool:
+        """Indicates whether the contract has an explicitly defined constructor."""
+        return self._fallback_function_abi_item is not None
+
+    @property
+    def constructor_abi(self) -> Dict[str, Any]:
+        """Returns a copy of the Solidity JSON ABI item for the contract constructor.
+
+        The content of the returned dict is described at https://solidity.readthedocs.io/en/latest/abi-spec.html#json_
+        """
+        item = self._constructor_abi_item
+        if item:
+            return dict(item)
+        return {'inputs': [], 'payable': False, 'stateMutability': 'nonpayable', 'type': 'constructor'}
+
+    def get_abi(self, hsh: bytes) -> Dict[str, Any]:
+        """Returns a copy of the Solidity JSON ABI item for the function associated with the selector ``hsh``.
+
+        If no normal contract function has the specified selector, a dict describing the default or non-default
+        fallback function is returned.
+
+        The content of the returned dict is described at https://solidity.readthedocs.io/en/latest/abi-spec.html#json_
+        """
+        sig = self._function_signatures_by_selector.get(hsh)
+        if sig is not None:
+            return dict(self._function_abi_items_by_signature[sig])
+        item = self._fallback_function_abi_item
+        if item is not None:
+            return dict(item)
+        # An item describing the default fallback function.
+        return {'payable': False, 'stateMutability': 'nonpayable', 'type': 'fallback'}
+
+    def get_func_argument_types(self, hsh: bytes):
+        """Returns the tuple type signature for the arguments of the function associated with the selector ``hsh``.
+
+        If no normal contract function has the specified selector,
+        the empty tuple type signature ``'()'`` is returned.
+        """
+        return self._function_signatures_by_selector.get(hsh, '()')
+
+    def get_func_return_types(self, hsh: bytes) -> str:
+        """Returns the tuple type signature for the output values of the function
+        associated with the selector ``hsh``.
+
+        If no normal contract function has the specified selector,
+        the empty tuple type signature ``'()'`` is returned.
+        """
         abi = self.get_abi(hsh)
-        return '(' + ','.join(x['type'] for x in abi.get('inputs', [])) + ')'
+        outputs = abi.get('outputs')
+        return '()' if outputs is None else SolidityMetadata.tuple_signature_for_components(outputs)
 
-    def get_func_return_types(self, hsh):
-        abi = self.get_abi(hsh)
-        return '(' + ','.join(x['type'] for x in abi.get('outputs', [])) + ')'
+    def get_func_name(self, hsh: bytes) -> str:
+        """Returns the name of the normal function with the selector ``hsh``,
+        or ``'{fallback}'`` if no such function exists.
+        """
+        sig = self._function_signatures_by_selector.get(hsh)
+        return '{fallback}' if sig is None else sig[:sig.find('(')]
 
-    def get_func_name(self, hsh):
-        signature = self.signatures.get(hsh, '{fallback}()')
-        return signature.split('(')[0]
+    def get_func_signature(self, hsh: bytes) -> Optional[str]:
+        """Returns the signature of the normal function with the selector ``hsh``,
+        or ``None`` if no such function exists.
 
-    def get_func_signature(self, hsh):
-        return self.signatures.get(hsh)
+        This function returns ``None`` for any selector that will be dispatched to a fallback function.
+        """
+        return self._function_signatures_by_selector.get(hsh)
 
-    def get_hash(self, method_name_and_signature):
-        #helper
+    @deprecated("Use `abi.ABI.function_selector` instead.")
+    def get_hash(self, method_name_and_signature) -> bytes:
         return ABI.function_selector(method_name_and_signature)
 
     @property
-    def functions(self):
-        return tuple(self._functions) + ('{fallback}()',)
+    def function_signatures(self) -> Iterable[str]:
+        """The signatures of all normal contract functions."""
+        return self._function_signatures_by_selector.values()
 
     @property
-    def hashes(self):
-        # \x00\x00\x00\x00 corresponds to {fallback}()
-        return tuple(map(self.get_hash, self._functions)) + (b'\x00\x00\x00\x00',)
+    @deprecated("Use `.function_signatures` instead, which does not return the `'{fallback}()'` pseudo-signature")
+    def functions(self) -> Tuple[str, ...]:
+        """The signatures of all normal contract functions, plus the ``'{fallback}()'`` pseudo-signature."""
+        return (*self._function_signatures_by_selector.values(), '{fallback}()')
+
+    @property
+    def has_non_default_fallback_function(self) -> bool:
+        """Indicates whether the contract has an explicitly defined fallback function."""
+        return self._fallback_function_abi_item is not None
+
+    @property
+    def fallback_function_selector(self) -> bytes:
+        """A function selector not associated with any of the non-fallback contract functions.
+
+        This selector is almost always ``b'\0\0\0\0'``.
+        """
+        return self._fallback_function_selector
+
+    @property
+    def function_selectors(self) -> Iterable[bytes]:
+        """The selectors of all normal contract functions,
+        plus ``self.fallback_function_selector`` if the contract has a non-default fallback function.
+        """
+        selectors = self._function_signatures_by_selector.keys()
+        if self._fallback_function_abi_item is None:
+            return selectors
+        return (*selectors, self.fallback_function_selector)
+
+    @property
+    @deprecated("Use `.function_selectors` instead, which only returns a fallback"
+                " function selector if the contract has a non-default fallback function.")
+    def hashes(self) -> Tuple[bytes, ...]:
+        """The selectors of all normal contract functions, plus ``self.fallback_function_selector``."""
+        selectors = self._function_signatures_by_selector.keys()
+        return (*selectors, self.fallback_function_selector)
 
     def parse_tx(self, calldata, returndata=None):
         if returndata is None:

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -197,7 +197,8 @@ class SolidityMetadata(object):
         If no normal contract function has the specified selector,
         the empty tuple type signature ``'()'`` is returned.
         """
-        return self._function_signatures_by_selector.get(hsh, '()')
+        sig = self._function_signatures_by_selector.get(hsh)
+        return '()' if sig is None else sig[sig.find('('):]
 
     def get_func_return_types(self, hsh: bytes) -> str:
         """Returns the tuple type signature for the output values of the function

--- a/manticore/utils/deprecated.py
+++ b/manticore/utils/deprecated.py
@@ -1,0 +1,30 @@
+
+from functools import wraps
+import inspect
+import warnings
+
+# DeprecationWarning is ignored by default, so we define a subcategory that we can give a different default.
+
+
+class ManticoreDeprecationWarning(DeprecationWarning):
+    """The deprecation warning class used by Manticore."""
+    pass
+
+
+warnings.simplefilter('default', category=ManticoreDeprecationWarning)
+
+
+def deprecated(message: str):
+    """A decorator for marking functions as deprecated. """
+    assert isinstance(message, str), "The deprecated decorator requires a message string argument."
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(f"`{func.__qualname__}` is deprecated. {message}",
+                          category=ManticoreDeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/eth_benchmark.py
+++ b/tests/eth_benchmark.py
@@ -41,7 +41,7 @@ class EthBenchmark(unittest.TestCase):
         self.mevm=None
         shutil.rmtree(self.worksp)
 
-    def _test(self, name, should_find):
+    def _test(self, name, should_find, use_ctor_sym_arg=False):
         """
         Tests DetectInvalid over the consensys benchmark suite
         """
@@ -52,8 +52,12 @@ class EthBenchmark(unittest.TestCase):
 
         filename = os.path.join(THIS_DIR, 'binaries', 'benchmark', f'{name}.sol')
 
+        if use_ctor_sym_arg:
+            ctor_arg = (mevm.make_symbolic_value(),)
+        else:
+            ctor_arg = ()
 
-        mevm.multi_tx_analysis(filename, contract_name='Benchmark', args=(mevm.make_symbolic_value(),))
+        mevm.multi_tx_analysis(filename, contract_name='Benchmark', args=ctor_arg)
 
         expected_findings = set(( (c, d) for b, c, d in should_find))
         actual_findings = set(( (c, d) for a, b, c, d in mevm.global_findings))
@@ -66,10 +70,10 @@ class EthBenchmark(unittest.TestCase):
         self._test('assert_constructor', {(23, 'INVALID instruction', True)})
 
     def test_assert_multitx_1(self):
-        self._test('assert_multitx_1', set())
+        self._test('assert_multitx_1', set(), True)
 
     def test_assert_multitx_2(self):
-        self._test('assert_multitx_2', {(150, 'INVALID instruction', False)})
+        self._test('assert_multitx_2', {(150, 'INVALID instruction', False)}, True)
 
     def test_integer_overflow_minimal(self):
         self._test('integer_overflow_minimal', {(163, 'Unsigned integer overflow at SUB instruction', False)})

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -41,7 +41,7 @@ class EthDetectorTest(unittest.TestCase):
         self.mevm = None
         shutil.rmtree(self.worksp)
 
-    def _test(self, name, should_find):
+    def _test(self, name, should_find, use_ctor_sym_arg=False):
         """
         Tests DetectInvalid over the consensys benchmark suit
         """
@@ -49,8 +49,13 @@ class EthDetectorTest(unittest.TestCase):
 
         filename = os.path.join(THIS_DIR, 'binaries', 'detectors', f'{name}.sol')
 
+        if use_ctor_sym_arg:
+            ctor_arg = (mevm.make_symbolic_value(),)
+        else:
+            ctor_arg = ()
+
         self.mevm.register_detector(self.DETECTOR_CLASS())
-        mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=(mevm.make_symbolic_value(),))
+        mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=ctor_arg)
 
         expected_findings = set(((c, d) for b, c, d in should_find))
         actual_findings = set(((c, d) for a, b, c, d in mevm.global_findings))

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -905,7 +905,25 @@ class EthSolidityCompilerTest(unittest.TestCase):
         finally:
             shutil.rmtree(d)
 
+class EthSolidityMetadataTests(unittest.TestCase):
+    def test_abi_constructor_and_fallback_items(self):
+        with disposable_mevm() as m:
+            source_code = '''
+            contract C {
+                constructor(uint a) public {}
+                function() public payable {}
+            }
+            '''
+            user_account = m.create_account(balance=1000, name='user_account')
+            contract_account = m.solidity_create_contract(source_code, owner=user_account, name='contract_account', args = (0,))
+            md = m.get_metadata(contract_account)
 
+            self.assertEqual(md.get_constructor_arguments(), '(uint256)')
+
+            fallback = md.get_abi('')
+            self.assertEqual(fallback['type'], 'fallback')
+            self.assertIsNone(fallback.get('inputs'))
+            self.assertEqual(fallback['stateMutability'], 'payable')
 
 class EthSpecificTxIntructionTests(unittest.TestCase):
 


### PR DESCRIPTION
This draft PR is my proposed fix for issue #1210. It builds on PR #1211.

This PR currently

1. Rewrites `SolidityMetadata.__init__` to fix the handling of overloaded functions.
2. Separates the abi items for functions, events, constructor and fallback function into separate properties (though the event items are not yet publicly exposed).
3. Removes the `abi` property.
4. Removes the `add_function` method.
5. Adds a decorator for deprecating functions.
6. Deprecates the `functions` and `hashes` properties due to their problematic handling of the fallback function and adds `function_signatures` and `function_selectors` as replacements.
7. Deprecates the `get_hash` method, which seems redundant in its current form.
8. Adds static methods for constructing function and tuple type signatures that can handle ABIv2 tuple arguments.
9. Adds the `constructor_abi`, `has_non_default_constructor` and `has_non_default_fallback_function` properties.
10. Adds some docstrings and type annotations.

I can of course split this PR up or remove changes, change names, etc. if you'd like me to.

If you're OK with the direction of this PR, I could add more tests for `SolidityMetadata`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1212)
<!-- Reviewable:end -->
