### PR TITLE
Convenient api for asserting invariant and generating testcase

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -301,6 +301,23 @@ class State(Eventful):
     def is_feasible(self):
         return self.can_be_true(True)
 
+    # alternate names:
+    # state.check
+    # state.verify
+    # state.ensure
+    # ...
+    def assert_(self, expression, testcase_message, testcase_name='Assertion Failed'):
+        """
+        Check that an expression is always true, and if it is not always true, generate a testcase where the
+        expression is false.
+
+        :param condition: Expression (condition) to be asserted as always true
+        """
+        with self as temp_state:
+            temp_state.constrain(expression == False)
+            if temp_state.is_feasible():
+                temp_state.generate_testcase(name=testcase_name, message=testcase_message)
+
     def can_be_true(self, expr):
         expr = self.migrate_expression(expr)
         return self._solver.can_be_true(self._constraints, expr)


### PR DESCRIPTION
A common use case for ethereum is checking that a certain condition is always true in a state, and generating a testcase if this is not so. Currently users need to implement this themselves using the various state methods (`state.can_be_true` etc) and `state.generate_testcase`, but since this is expected to be very common, we should implement it in the core.

Discussion 

- Is the API backwards? Should you specify the condition you want to never be able to happen?
- naming: is `assert_` a poor name? what would be better? verify, ensure, check, ... ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1214)
<!-- Reviewable:end -->
