### PR TITLE
Copy event system state during state fork

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -117,7 +117,9 @@ class State(Eventful):
         self.platform.constraints = new_state.constraints
         new_state._input_symbols = list(self._input_symbols)
         new_state._context = copy.copy(self._context)
-        new_state._forwards = copy.copy(self._forwards)  # copy over event system related state
+
+        self.copy_event_state(new_state)
+
         self._child = new_state
         assert new_state.platform.constraints is new_state.constraints
 

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -118,7 +118,7 @@ class State(Eventful):
         new_state._input_symbols = list(self._input_symbols)
         new_state._context = copy.copy(self._context)
 
-        self.copy_event_state(new_state)
+        self.copy_eventful_state(new_state)
 
         self._child = new_state
         assert new_state.platform.constraints is new_state.constraints

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -117,6 +117,7 @@ class State(Eventful):
         self.platform.constraints = new_state.constraints
         new_state._input_symbols = list(self._input_symbols)
         new_state._context = copy.copy(self._context)
+        new_state._forwards = copy.copy(self._forwards)  # copy over event system related state
         self._child = new_state
         assert new_state.platform.constraints is new_state.constraints
 

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -123,7 +123,6 @@ class State(Eventful):
         self._child = new_state
         assert new_state.platform.constraints is new_state.constraints
 
-        # fixme NEW State won't inherit signals (pro: added signals to new_state wont affect parent)
         return new_state
 
     def __exit__(self, ty, value, traceback):

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -1023,6 +1023,7 @@ class ManticoreEVM(Manticore):
         with self.locked_context('ethereum') as context:
             if len(context['_saved_states']) == 1:
                 self._initial_state = self._executor._workspace.load_state(context['_saved_states'].pop(), delete=True)
+                self._executor.forward_events_from(self._initial_state, True)
                 context['_saved_states'] = set()
                 assert self._running_state_ids == (-1,)
 

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -157,6 +157,6 @@ class Eventful(object, metaclass=EventsGatherMetaclass):
             raise TypeError
         self._forwards[sink] = include_source
 
-    def copy_event_state(self, new_object: Eventful):
+    def copy_eventful_state(self, new_object: Eventful):
         new_object._forwards = copy.copy(self._forwards)
         new_object._signals = copy.copy(self._signals)

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -157,6 +157,6 @@ class Eventful(object, metaclass=EventsGatherMetaclass):
             raise TypeError
         self._forwards[sink] = include_source
 
-    def copy_eventful_state(self, new_object: Eventful):
+    def copy_eventful_state(self, new_object: 'Eventful'):
         new_object._forwards = copy.copy(self._forwards)
         new_object._signals = copy.copy(self._signals)

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import logging
 from itertools import takewhile
@@ -155,3 +156,6 @@ class Eventful(object, metaclass=EventsGatherMetaclass):
         if not isinstance(sink, Eventful):
             raise TypeError
         self._forwards[sink] = include_source
+
+    def copy_event_state(self, new_object: Eventful):
+        new_object._forwards = copy.copy(self._forwards)

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -42,6 +42,10 @@ class Eventful(object, metaclass=EventsGatherMetaclass):
           - publish an event with arbitrary arguments to its subscribers
           - let foreign objects subscribe their methods to events emitted here
           - forward events to/from other eventful objects
+
+        Any time an Eventful object is unserialized:
+          - All previous subscriptions need to be resubscribed
+          - All objects that would previously receive forwarded events need to be reconnected
     '''
 
     # Maps an Eventful subclass with a set of all the events it publishes.

--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -159,3 +159,4 @@ class Eventful(object, metaclass=EventsGatherMetaclass):
 
     def copy_event_state(self, new_object: Eventful):
         new_object._forwards = copy.copy(self._forwards)
+        new_object._signals = copy.copy(self._signals)


### PR DESCRIPTION
We previously did not copy the event system state such as

- `_signals`: the various event subscriptions
- `_forwards`: the various objects that events needed to be forwarded to

when a State object was copied.

This causes bugs like `State.generate_testcase` not working because the events are not forwarded to the `Executor` class.

This also adds a `forward_events_from` call in one place we forgot it.

This does a full copy of the `_signals` and `_forwards` so further mutation of the child state does not affect the parent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1215)
<!-- Reviewable:end -->
