### PR TITLE
Add solver timeout CLI

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -4,6 +4,7 @@ import logging
 import argparse
 
 from . import Manticore
+from .core.smtlib.solver import solver
 from .utils import log, config
 
 # XXX(yan): This would normally be __name__, but then logger output will be pre-
@@ -47,6 +48,8 @@ def parse_arguments():
                         help="Path to program, and arguments ('+' in arguments indicates symbolic byte).")
     parser.add_argument('--timeout', type=int, default=0,
                         help='Timeout. Abort exploration after TIMEOUT seconds')
+    parser.add_argument('--solver-timeout', type=int,
+                        help='Timeout. Abort current solver query after SOLVER_TIMEOUT seconds')
     parser.add_argument('-v', action='count', default=1,
                         help='Specify verbosity level from -v to -vvvv')
     parser.add_argument('--workspace', type=str, default=None,
@@ -240,6 +243,11 @@ def main():
 
     if args.assertions:
         m.load_assertions(args.assertions)
+
+    if args.solver_timeout:
+        solver.init_timeout(args.solver_timeout)
+    else:
+        solver.init_timeout()
 
     @m.init
     def init(initial_state):

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -145,6 +145,15 @@ class Z3Solver(Solver):
         else:
             logger.debug(' Please install Z3 4.4.1 or newer to get optimization support')
 
+    def init_timeout(self, solver_timeout=consts.timeout * 1000):
+        '''
+        Used as an interface to alter the Z3 solver timeout baser on user-specified
+        input. Defaults to consts.timeout * 1000.
+
+        :param solver_timeout: time (in ms) to stop current solver query
+        '''
+        self._command = f'{consts.z3_bin} -t:{solver_timeout} -memory:{consts.memory} -smt2 -in'
+
     def _solver_version(self):
         '''
         If we


### PR DESCRIPTION
Adds support for a solver timeout option for the manticore CLI (as specified in https://github.com/trailofbits/manticore/issues/1015).

This enables the user to specify a solver timeout for Z3 as so:

```
$ manticore -v --solver-timeout 500000 ./binary
```

Let me know what you all think!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1217)
<!-- Reviewable:end -->
