### PR TITLE
Preconstrain the data of symbolic human transactions

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -116,6 +116,9 @@ def parse_arguments():
     eth_flags.add_argument('--txaccount', type=str, default="attacker",
                            help='Account used as caller in the symbolic transactions, either "attacker" or "owner"')
 
+    eth_flags.add_argument('--txpreconstrain', action='store_true',
+                           help='Constrain human transactions to avoid exceptions in the contract function dispatcher')
+
     eth_flags.add_argument('--contract', type=str,
                            help='Contract name to analyze in case of multiple contracts')
 

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -48,7 +48,9 @@ def ethereum_main(args, logger):
     logger.info("Beginning analysis")
 
     with m.shutdown_timeout(args.timeout):
-        m.multi_tx_analysis(args.argv[0], contract_name=args.contract, tx_limit=args.txlimit, tx_use_coverage=not args.txnocoverage, tx_send_ether=not args.txnoether, tx_account=args.txaccount)
+        m.multi_tx_analysis(args.argv[0], contract_name=args.contract, tx_limit=args.txlimit,
+                            tx_use_coverage=not args.txnocoverage, tx_send_ether=not args.txnoether,
+                            tx_account=args.txaccount, tx_preconstrain=args.txpreconstrain)
 
     # TODO unregister all plugins
 

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -5,7 +5,7 @@ import string
 from multiprocessing import Queue, Process
 from queue import Empty as EmptyQueue
 from subprocess import check_output, Popen, PIPE
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import io
 import os
@@ -16,7 +16,7 @@ import sha3
 import tempfile
 
 from ..core.manticore import ManticoreBase
-from ..core.smtlib import ConstraintSet, Array, ArrayProxy, BitVec, Operators
+from ..core.smtlib import ConstraintSet, Array, ArrayProxy, BitVec, Operators, BoolConstant, BoolOperation, Expression
 from ..core.state import TerminateState, AbandonState
 from .account import EVMContract, EVMAccount, ABI
 from .detectors import Detector
@@ -886,9 +886,52 @@ class ManticoreEVM(ManticoreBase):
 
         return address
 
+    def preconstraint_for_call_transaction(self, address: Union[int, EVMAccount], data: Array,
+                                           value: Optional[Union[int, Expression]] = None,
+                                           contract_metadata: Optional[SolidityMetadata] = None) -> BoolOperation:
+        """ Returns a constraint that excludes combinations of value and data that would cause an exception in the EVM
+            contract dispatcher.
+            :param address: address of the contract to call
+            :param value: balance to be transferred (optional)
+            :param data: symbolic transaction data
+            :param contract_metadata: SolidityMetadata for the contract (optional)
+        """
+        if isinstance(address, EVMAccount):
+            address = int(address)
+        if not isinstance(address, int):
+            raise TypeError("invalid address type")
+
+        if not issymbolic(data):
+            raise TypeError("data must be a symbolic array")
+
+        if contract_metadata is None:
+            contract_metadata = self.metadata.get(address)
+            if contract_metadata is None:
+                raise TypeError("no Solidity metadata available for the contract address")
+
+        selectors = contract_metadata.function_selectors
+        if not selectors or len(data) <= 4:
+            return BoolConstant(True)
+
+        symbolic_selector = data[:4]
+
+        value_is_symbolic = issymbolic(value)
+
+        constraint = None
+        for selector in selectors:
+            c = symbolic_selector == selector
+            if value_is_symbolic and not contract_metadata.get_abi(selector)['payable']:
+                c = Operators.AND(c, value == 0)
+            if constraint is None:
+                constraint = c
+            else:
+                constraint = Operators.OR(constraint, c)
+
+        return constraint
+
     def multi_tx_analysis(self, solidity_filename, working_dir=None, contract_name=None,
                           tx_limit=None, tx_use_coverage=True,
-                          tx_send_ether=True, tx_account="attacker", args=None):
+                          tx_send_ether=True, tx_account="attacker", tx_preconstrain=False, args=None):
         owner_account = self.create_account(balance=1000, name='owner')
         attacker_account = self.create_account(balance=1000, name='attacker')
 
@@ -925,6 +968,12 @@ class ManticoreEVM(ManticoreBase):
                     value = self.make_symbolic_value()
                 else:
                     value = 0
+
+                if tx_preconstrain:
+                    self.constrain(self.preconstraint_for_call_transaction(address=contract_account,
+                                                                           data=symbolic_data,
+                                                                           value=value))
+
                 self.transaction(caller=tx_account[min(tx_no, len(tx_account) - 1)],
                                  address=contract_account,
                                  data=symbolic_data,

--- a/tests/binaries/simple_int_overflow.sol
+++ b/tests/binaries/simple_int_overflow.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.15;
+
+contract Overflow {
+    uint private sellerBalance=0;
+    
+    function add(uint value) public {
+        sellerBalance += value; // complicated math with possible overflow
+
+        // possible auditor assert
+        assert(sellerBalance >= value);
+    }
+}

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -665,21 +665,18 @@ class EthTests(unittest.TestCase):
         class TestDetector(Detector):
             def did_evm_execute_instruction_callback(self, state, instruction, arguments, result):
                 if instruction.is_endtx:
-                    with self.locked_context('insns', dict) as d:
-                        d[instruction.semantics] = True
+                    with self.locked_context('endtx_instructions', set) as d:
+                        d.add(instruction.name)
 
         mevm = self.mevm
         p = TestDetector()
         mevm.register_detector(p)
 
-        filename = os.path.join(THIS_DIR, 'binaries/int_overflow.sol')
-        mevm.multi_tx_analysis(filename, tx_limit=2)
+        filename = os.path.join(THIS_DIR, 'binaries/simple_int_overflow.sol')
+        mevm.multi_tx_analysis(filename, tx_limit=2, tx_preconstrain=True)
 
-        self.assertIn('insns', p.context)
-        context = p.context['insns']
-        self.assertIn('STOP', context)
-        self.assertIn('RETURN', context)
-        self.assertIn('REVERT', context)
+        self.assertIn('endtx_instructions', p.context)
+        self.assertSetEqual(p.context['endtx_instructions'], {'INVALID', 'RETURN', 'STOP'})
 
     def test_call_with_concretized_args(self):
         """Test a CALL with symbolic arguments that will to be concretized.
@@ -918,6 +915,28 @@ class EthTests(unittest.TestCase):
 
         context = p.context.get('flags', {})
         self.assertTrue(context.get('found', False))
+
+    def test_preconstraints(self):
+        source_code = '''
+        contract C {
+            constructor() public {}
+            function f0() public {}
+            function f1(uint a) public payable {}
+        }
+        '''
+        m: ManticoreEVM = self.mevm
+
+        creator_account = m.create_account(balance=1000)
+        contract_account = m.solidity_create_contract(source_code, owner=creator_account, balance=0)
+
+        data = m.make_symbolic_buffer(320)
+        value = m.make_symbolic_value()
+        m.constrain(m.preconstraint_for_call_transaction(address=contract_account, data=data, value=value))
+        m.transaction(caller=creator_account, address=contract_account, data=data, value=value)
+
+        results = [state.platform.all_transactions[-1].result for state in m.all_states]
+        # The TXERROR indicates a state where the sent value is greater than the senders budget.
+        self.assertListEqual(sorted(results), ['STOP']*2 + ['TXERROR'])
 
 class EthHelpersTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR implements a feature (enabled by default) to preconstrain the data of symbolic human transactions to avoid triggering uninteresting exceptions in the Solidity contract function dispatcher.

This PR fixes issue #731.

I've implemented the feature directly in `ManticoreEVM` and not e.g. as a plugin or in `EVMWorld` because there I also can constrain the transaction value depending on the function selector and thus avoid the 'not enough funds' fork in `EVMWorld._process_pending_transaction` for states that would lead to immediate REVERTs anyway. Doing it there also has the advantage that the constraint expression only is constructed a single time, not once for every running state.

With this PR applied, Manticore avoids all 6 states leading to REVERTs when it is run with the default options on `examples/evm/simple_int_overflow.sol` and covers all interesting code path with only 3 states.

The new behaviour can be disabled with the `--explore-contract-function-dispatcher` command line flag or by setting the public `preconstrains_symbolic_tx_data` property on `ManticoreEVM`.

With this PR applied, the `eth_general.test_emit_did_execute_end_instructions` test fails. This could be fixed by setting `preconstrains_symbolic_tx_data` to false. However, the [doccomment in that test](https://github.com/trailofbits/manticore/blob/master/tests/eth_general.py#L616) makes me think that it uses the wrong `sol` test file and was actually meant to be run on a test case similar to `examples/evm/simple_int_overflow.sol`.

Another test that fails is [`eth_detectors.test_delegatecall_not_ok`](https://github.com/trailofbits/manticore/blob/master/tests/eth_detectors.py#L212). I believe that the test is incorrect, because the [delegatecall in the fallback function](https://github.com/trailofbits/manticore/blob/master/tests/binaries/detectors/delegatecall_not_ok.sol#L24) could only ever call itself, since by definition the fallback function is only reached if the function selector in the transaction data doesn't match any selector of a normal function.

While playing with possible fixes to the `delegatecall_not_ok` test I noticed that when preconstraining the transaction data, Manticore is not able to find a non-throwing path for the following simple contract
```
contract C {
    function f(bytes b) {
       require(b.length == 64);
    }
}
```

I suspect the problem here is the sampling strategy for the `calldataload` instruction, but I haven't looked into this any further.

One way to improve Manticore's behaviour for this and similar test cases would be to also preconstrain the offsets of function arguments with the 'dynamic' ABI encoding, but I'll probably have to leave that for a separate PR. (Doing that is also partially blocked by issue #1219).

I'd greatly appreciate any feedback on the implementation approach, the naming and default values of the configuration options and the best way to deal with the test failures. (CC @mossberg @feliam @disconnect3d)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1220)
<!-- Reviewable:end -->
