### PR TITLE
Fix all ResourceWarnings triggered by the test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=db72f1ed59628c16eb0c00cbcd629c4c71f68aa1892ef42d18c7c2b8326f460a
     - JOB_COUNT=2 # Two jobs generate test coverage
-    - PYTHONWARNINGS="ignore::ResourceWarning" # Ignore unclosed file warnings
+    - PYTHONWARNINGS="default::ResourceWarning" # Enable ResourceWarnings
   matrix:
     - TEST_TYPE=examples
     - TEST_TYPE=tests

--- a/examples/evm/coverage.py
+++ b/examples/evm/coverage.py
@@ -3,7 +3,8 @@ from manticore.ethereum import ManticoreEVM
 m = ManticoreEVM()
 m.verbosity(3)
 # And now make the contract account to analyze
-source_code = open('coverage.sol').read()
+with open('coverage.sol') as f:
+    source_code = f.read()
 
 user_account = m.create_account(balance=1000)
 

--- a/manticore/abitypes.py
+++ b/manticore/abitypes.py
@@ -1,6 +1,9 @@
 # Minimal ethereum type signature parser.
 # This parses the signature and types used to calculate the function hash
+import warnings
+
 import ply.yacc as yacc
+
 # Lexer
 # ------------------------------------------------------------
 import ply.lex as lex
@@ -218,7 +221,10 @@ def p_error(p):
     #print(f"Syntax error at offset {lexer.lexpos:d}")
 
 
-parser = yacc.yacc()
+with warnings.catch_warnings():
+    # yacc.yacc() doesn't close the debuglog file after generating the parser table.
+    warnings.simplefilter('ignore', category='ResourceWarning')
+    parser = yacc.yacc()
 parse = parser.parse
 
 

--- a/manticore/binary/binary.py
+++ b/manticore/binary/binary.py
@@ -8,14 +8,16 @@ class Binary:
 
     def __new__(cls, path):
         if cls is Binary:
-            cl = cls.magics[open(path, 'rb').read(4)]
+            with open(path, 'rb') as f:
+                cl = cls.magics[f.read(4)]
             return cl(path)
         else:
             return super(Binary, cls).__new__(cls)
 
     def __init__(self, path):
         self.path = path
-        self.magic = Binary.magics[open(path, 'rb').read(4)]
+        with open(path, 'rb') as f:
+            self.magic = Binary.magics[f.read(4)]
 
     def arch(self):
         pass

--- a/manticore/manticore.py
+++ b/manticore/manticore.py
@@ -647,7 +647,7 @@ class Manticore(Eventful):
         # XXX(yan) This is a bit obtuse; once PE support is updated this should
         # be refactored out
         if self._binary_type == 'ELF':
-            self._binary_obj = ELFFile(open(self._binary))
+            self._binary_obj = ELFFile(open(self._binary, 'rb'))
 
         if self._binary_obj is None:
             return NotImplementedError("Symbols aren't supported")

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -467,7 +467,9 @@ class Decree(Platform):
                     logger.info("RANDOM: buf points to invalid address. Returning EFAULT")
                     return Decree.CGC_EFAULT
 
-                data = open("/dev/urandom", "r").read(count)
+                with open("/dev/urandom", "r") as f:
+                    data = f.read(count)
+
                 self.syscall_trace.append(("_random", -1, data))
                 cpu.write_bytes(buf, data)
 

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -467,7 +467,7 @@ class Decree(Platform):
                     logger.info("RANDOM: buf points to invalid address. Returning EFAULT")
                     return Decree.CGC_EFAULT
 
-                with open("/dev/urandom", "r") as f:
+                with open("/dev/urandom", "rb") as f:
                     data = f.read(count)
 
                 self.syscall_trace.append(("_random", -1, data))

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -899,7 +899,7 @@ class Linux(Platform):
                     interpreter_path_filename = os.path.join(mpath, os.path.basename(interpreter_filename))
                     logger.info(f"looking for interpreter {interpreter_path_filename}")
                     if os.path.exists(interpreter_path_filename):
-                        interpreter = ELFFile(open(interpreter_path_filename))
+                        interpreter = ELFFile(open(interpreter_path_filename, 'rb'))
                         break
             break
         if interpreter is not None:

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -720,7 +720,8 @@ class Linux(Platform):
     def load_vdso(self, bits):
         # load vdso #TODO or #IGNORE
         vdso_top = {32: 0x7fff0000, 64: 0x7fff00007fff0000}[bits]
-        vdso_size = len(open(f'vdso{bits:2d}.dump').read())
+        with open(f'vdso{bits:2d}.dump') as f:
+            vdso_size = len(f.read())
         vdso_addr = self.memory.mmapFile(self.memory._floor(vdso_top - vdso_size),
                                          vdso_size,
                                          'r x',

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -428,6 +428,15 @@ class Linux(Platform):
             self._init_std_fds()
             self._execve(program, argv, envp)
 
+    def __del__(self):
+        elf = getattr(self, 'elf', None)
+        if elf is not None:
+            try:
+                # Prevents a ResourceWarning
+                elf.stream.close()
+            except IOError as e:
+               logger.error(str(e))
+
     @property
     def PC(self):
         return (self._current, self.procs[self._current].PC)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -435,7 +435,7 @@ class Linux(Platform):
                 # Prevents a ResourceWarning
                 elf.stream.close()
             except IOError as e:
-               logger.error(str(e))
+                logger.error(str(e))
 
     @property
     def PC(self):

--- a/scripts/gdb.py
+++ b/scripts/gdb.py
@@ -104,7 +104,9 @@ def getPid():
 
 
 def getStack():
-    maps = open(f"/proc/{correspond('info proc\n').split('\n')[0].split(' ')[-1]}/maps").read().split("\n")
+    p = correspond('info proc\n').split('\n')[0].split(' ')[-1]
+    with open(f"/proc/{p}/maps") as f:
+        maps = f.read().split("\n")
     i, o = [int(x, 16) for x in maps[-3].split(" ")[0].split('-')]
 
 

--- a/tests/auto/make_evmtests.py
+++ b/tests/auto/make_evmtests.py
@@ -199,7 +199,8 @@ class EVMTest_{os.path.split(sys.argv[1][:-5])[1])}(unittest.TestCase):
     _multiprocess_can_split_ = True
     maxDiff=None\n''')
 
-    js = open(filename).read()
+    with open(filename) as f:
+        js = f.read()
     tests = dict(json.loads(js))
 
     #print "#processed ", len(tests.keys()), tests.keys()

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -2,6 +2,7 @@ import binascii
 import shutil
 import struct
 import tempfile
+from pathlib import Path
 import unittest
 import os
 import sys
@@ -703,8 +704,8 @@ class EthTests(unittest.TestCase):
         listdir = os.listdir(worksp)
 
         def get_concatenated_files(directory, suffix, init):
-            paths = [os.path.join(directory, f) for f in listdir if f.endswith(suffix)]
-            concatenated = ''.join(open(path).read() for path in paths)
+            paths = [Path(directory, f) for f in listdir if f.endswith(suffix)]
+            concatenated = ''.join(path.read_text() for path in paths)
             result = set()
             for x in concatenated.split('\n'):
                 if ':' in x:

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -27,6 +27,7 @@ class TestBinaryPackage(unittest.TestCase):
         )
         self.assertTrue([('Running', {'EIP': 4196624})], list(f.threads()))
         self.assertIsNone(f.getInterpreter())
+        f.elf.stream.close()
 
     def test_decree(self):
         filename = os.path.join(os.path.dirname(__file__), 'binaries', 'cadet_decree_x86')
@@ -36,6 +37,7 @@ class TestBinaryPackage(unittest.TestCase):
             list(f.maps())
         )
         self.assertTrue([('Running', {'EIP': 134513708})], list(f.threads()))
+        f.elf.stream.close()
 
 
 class IntegrationTest(unittest.TestCase):

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -51,7 +51,8 @@ class IntegrationTest(unittest.TestCase):
     def _loadVisitedSet(self, visited):
 
         self.assertTrue(os.path.exists(visited))
-        vitems = open(visited, 'r').read().splitlines()
+        with open(visited, 'r') as f:
+            vitems = f.read().splitlines()
 
         vitems = [int(x[2:], 16) for x in vitems]
 
@@ -134,7 +135,8 @@ class IntegrationTest(unittest.TestCase):
         filename = filename[len(os.getcwd())+1:]
         workspace = os.path.join(self.test_dir, 'workspace')
         assertions = os.path.join(self.test_dir, 'assertions.txt')
-        open(assertions,'w').write('0x0000000000401003 ZF == 1')
+        with open(assertions, 'w') as output:
+            output.write('0x0000000000401003 ZF == 1')
         with open(os.path.join(os.pardir, self.test_dir, 'output.log'), "w") as output:
             subprocess.check_call(['python', '-m', 'manticore',
                                    '--workspace', workspace,


### PR DESCRIPTION
This PR fixes all ResourceWarnings that are emitted in my Linux VM when I run the Manticore test suite like this: `PYTHONWARNINGS=error::ResourceWarning nosetests tests`

Fixes issue #1121 (opened by @yan)

This PR also fixes three invalid file open modes for binary files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1224)
<!-- Reviewable:end -->
