### PR TITLE
Fix warning logic

### DIFF
--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -41,10 +41,14 @@ class ABI(object):
     @staticmethod
     def _check_and_warn_num_args(type_spec, *args):
         num_args = len(args)
-        num_sig_args = len(type_spec.split(','))
-        no_declared_args = '()' in type_spec
 
-        if no_declared_args and num_args or num_args != num_sig_args:
+        no_declared_args = '()' in type_spec
+        if no_declared_args:
+            num_sig_args = 0
+        else:
+            num_sig_args = len(type_spec.split(','))
+
+        if num_args != num_sig_args:
             logger.warning(f'Number of provided arguments ({num_args}) does not match number of arguments in signature: {type_spec}')
 
 


### PR DESCRIPTION
the problem: this should not warn!

```
In [16]: ABI.function_call('hi()')
2018-10-30 09:09:21,514: [8044] m.e.abi:WARNING: Number of provided arguments (0) does not match number of arguments in signature: hi()
Out[16]: b'\xa9\x9d\xca?'

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1227)
<!-- Reviewable:end -->
