### PR TITLE
Add support for cross directory imports

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -308,7 +308,7 @@ class ManticoreEVM(Manticore):
         return bytearray(binascii.unhexlify(hex_contract))
 
     @staticmethod
-    def _run_solc(source_file, solc_bin=None, solc_remaps=[]):
+    def _run_solc(source_file, solc_bin=None, solc_remaps=[], working_dir=None):
         """ Compile a source file with the Solidity compiler
 
             :param source_file: a file object for the source file
@@ -340,7 +340,9 @@ class ManticoreEVM(Manticore):
         # https://solidity.readthedocs.io/en/latest/layout-of-source-files.html
 
         relative_filepath = source_file.name
-        working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
+
+        if not working_dir:
+            working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
 
         # If someone pass an absolute path to the file, we don't have to put cwd
         additional_kwargs = {'cwd': working_dir} if working_dir else {}

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -344,7 +344,7 @@ class ManticoreEVM(Manticore):
         if not working_dir:
             working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
         elif relative_filepath.startswith(working_dir):
-            relative_filepath = relative_filepath[len(working_dir)+1:]
+            relative_filepath = relative_filepath[len(working_dir) + 1:]
 
         # If someone pass an absolute path to the file, we don't have to put cwd
         additional_kwargs = {'cwd': working_dir} if working_dir else {}

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -342,13 +342,16 @@ class ManticoreEVM(Manticore):
         relative_filepath = source_file.name
         working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
 
+        # If someone pass an absolute path to the file, we don't have to put cwd
+        additional_kwargs = {'cwd': working_dir} if working_dir else {}
+
         solc_invocation = [solc] + list(solc_remaps) + [
             '--combined-json', 'abi,srcmap,srcmap-runtime,bin,hashes,bin-runtime',
             '--allow-paths', '.',
             relative_filepath
         ]
 
-        p = Popen(solc_invocation, stdout=PIPE, stderr=PIPE, cwd=working_dir)
+        p = Popen(solc_invocation, stdout=PIPE, stderr=PIPE, **additional_kwargs)
         stdout, stderr = p.communicate()
 
         stdout, stderr = stdout.decode(), stderr.decode()

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -362,7 +362,7 @@ class ManticoreEVM(Manticore):
 
         # See #1123 - solc fails when run within snap
         # and https://forum.snapcraft.io/t/interfaces-allow-access-tmp-directory/5129
-        if stdout == '' and '""%s"" is not found' % relative_filepath in stderr:
+        if stdout == '' and f'""{relative_filepath}"" is not found' in stderr:
             raise EthereumError(
                 'Solidity compilation failed with error: {}\n'
                 'Did you install solc from snap Linux universal packages?\n'

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -343,6 +343,8 @@ class ManticoreEVM(Manticore):
 
         if not working_dir:
             working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
+        elif relative_filepath.startswith(working_dir):
+            relative_filepath = relative_filepath[len(working_dir)+1:]
 
         # If someone pass an absolute path to the file, we don't have to put cwd
         additional_kwargs = {'cwd': working_dir} if working_dir else {}

--- a/tests/binaries/imports_issue/main/main.sol
+++ b/tests/binaries/imports_issue/main/main.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.25;
+
+import '../utils/DirImported.sol';
+import 'utils/DirImported2.sol';
+
+contract C {}

--- a/tests/binaries/imports_issue/main/main.sol
+++ b/tests/binaries/imports_issue/main/main.sol
@@ -1,5 +1,3 @@
-pragma solidity ^0.4.25;
-
 import '../utils/DirImported.sol';
 import 'utils/DirImported2.sol';
 

--- a/tests/binaries/imports_issue/utils/DirImported.sol
+++ b/tests/binaries/imports_issue/utils/DirImported.sol
@@ -1,0 +1,1 @@
+contract Imported {}

--- a/tests/binaries/imports_issue/utils/DirImported2.sol
+++ b/tests/binaries/imports_issue/utils/DirImported2.sol
@@ -1,0 +1,1 @@
+contract Imported2 {}

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -44,7 +44,8 @@ class EthDetectorTest(unittest.TestCase):
         """
         mevm = self.mevm
 
-        filename = os.path.join(THIS_DIR, 'binaries', 'detectors', f'{name}.sol')
+        dir = os.path.join(THIS_DIR, 'binaries', 'detectors')
+        filepath = os.path.join(dir, f'{name}.sol')
 
         if use_ctor_sym_arg:
             ctor_arg = (mevm.make_symbolic_value(),)
@@ -52,7 +53,7 @@ class EthDetectorTest(unittest.TestCase):
             ctor_arg = ()
 
         self.mevm.register_detector(self.DETECTOR_CLASS())
-        mevm.multi_tx_analysis(filename, contract_name='DetectThis', args=ctor_arg)
+        mevm.multi_tx_analysis(filepath, contract_name='DetectThis', args=ctor_arg, working_dir=dir)
 
         expected_findings = set(((finding, at_init) for finding, at_init in should_find))
         actual_findings = set(((finding, at_init) for _addr, _pc, finding, at_init in mevm.global_findings))

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -897,20 +897,19 @@ class EthSolidityCompilerTest(unittest.TestCase):
             function fromA() public { revert(); }
         }
         '''
-        d = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp()
         try:
-            with open(os.path.join(d, 'A.sol'), 'w') as a, open(os.path.join(d, 'B.sol'), 'w') as b:
+            with open(os.path.join(tmp_dir, 'A.sol'), 'w') as a, open(os.path.join(tmp_dir, 'B.sol'), 'w') as b:
                 a.write(source_a)
                 a.flush()
                 b.write(source_b)
                 b.flush()
-                output, warnings = ManticoreEVM._run_solc(a)
+                output, warnings = ManticoreEVM._run_solc(a, working_dir=tmp_dir)
                 source_list = output.get('sourceList', [])
                 self.assertIn(os.path.split(a.name)[-1], source_list)
                 self.assertIn(os.path.split(b.name)[-1], source_list)
         finally:
-            shutil.rmtree(d)
-
+            shutil.rmtree(tmp_dir)
 
     def test_run_solc_with_remappings(self):
         source_a = '''

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -927,21 +927,21 @@ class EthSolidityCompilerTest(unittest.TestCase):
             function fromA() public { revert(); }
         }
         '''
-        d = tempfile.mkdtemp()
-        lib_dir = os.path.join(d, 'lib')
+        tmp_dir = tempfile.mkdtemp()
+        lib_dir = os.path.join(tmp_dir, 'lib')
         os.makedirs(lib_dir)
         try:
-            with open(os.path.join(d, 'A.sol'), 'w') as a, open(os.path.join(lib_dir, 'B.sol'), 'w') as b:
+            with open(os.path.join(tmp_dir, 'A.sol'), 'w') as a, open(os.path.join(lib_dir, 'B.sol'), 'w') as b:
                 a.write(source_a)
                 a.flush()
                 b.write(source_b)
                 b.flush()
-                output, warnings = ManticoreEVM._run_solc(a, solc_remaps=['test=lib'])
+                output, warnings = ManticoreEVM._run_solc(a, solc_remaps=['test=lib'], working_dir=tmp_dir)
                 source_list = output.get('sourceList', [])
                 self.assertIn("A.sol", source_list)
                 self.assertIn("lib/B.sol", source_list)
         finally:
-            shutil.rmtree(d)
+            shutil.rmtree(tmp_dir)
 
 
 class EthSolidityMetadataTests(unittest.TestCase):

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -207,7 +207,6 @@ class IntegrationTest(unittest.TestCase):
                 in_directory=issue.get('in_directory')
             )
 
-
     def test_eth_705(self):
         # This test needs to run inside tests/binaries because the contract imports a file
         # that is in the tests/binaries dir

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -1,17 +1,32 @@
-import io
 import unittest
 import sys
 import shutil
 import tempfile
 import os
-import hashlib
 import subprocess
 import time
 from manticore.binary import Elf, CGCElf
+import subprocess
+import sys
+import time
+import unittest
+
+import os
+import shutil
+import tempfile
+
+from manticore.binary import Elf, CGCElf
+
 
 #logging.basicConfig(filename = "test.log",
 #                format = "%(asctime)s: %(name)s:%(levelname)s: %(message)s",
 #                level = logging.DEBUG)
+
+
+# TLDR: when we launch `python -m manticore` and one uses PyCharm remote interpreter
+# the `python` might not refer to proper interpreter. The `/proc/self/exe` is a workaround
+# so one doesn't have to set up virtualenv in a remote interpreter.
+PYTHON_BIN = '/proc/self/exe'
 
 
 class TestBinaryPackage(unittest.TestCase):
@@ -60,15 +75,19 @@ class IntegrationTest(unittest.TestCase):
 
         return set(vitems)
 
-    def _simple_cli_run(self, filename, contract=None, tx_limit=1):
+    def _simple_cli_run(self, filename, contract=None, tx_limit=1, in_directory=None):
         """
         Simply run the Manticore command line with `filename`
         :param filename: Name of file inside the `tests/binaries` directory
         :return:
         """
         dirname = os.path.dirname(__file__)
-        filename = os.path.join(dirname, 'binaries', filename)
-        command = ['python', '-m', 'manticore']
+        working_dir = os.path.join(dirname, 'binaries')
+
+        if in_directory:
+            working_dir = os.path.join(working_dir, in_directory)
+
+        command = [PYTHON_BIN, '-m', 'manticore']
 
         if contract:
             command.append('--contract')
@@ -77,7 +96,7 @@ class IntegrationTest(unittest.TestCase):
         command.append(str(tx_limit))
         command.append(filename)
 
-        subprocess.check_call(command, stdout=subprocess.PIPE)
+        subprocess.check_call(command, stdout=subprocess.PIPE, cwd=working_dir)
 
     def _runWithTimeout(self, procargs, logfile, timeout=1200):
 
@@ -102,7 +121,7 @@ class IntegrationTest(unittest.TestCase):
         workspace = os.path.join(self.test_dir, 'workspace')
         t = time.time()
         with open(os.path.join(os.pardir, self.test_dir, 'output.log'), "w") as output:
-            subprocess.check_call(['python', '-m', 'manticore',
+            subprocess.check_call([PYTHON_BIN, '-m', 'manticore',
                                 '--workspace', workspace,
                                 '--timeout', '1',
                                 '--procs', '4',
@@ -118,7 +137,7 @@ class IntegrationTest(unittest.TestCase):
 
         dirname = os.path.dirname(__file__)
         filename = os.path.join(dirname, 'binaries', 'basic_linux_amd64')
-        output = subprocess.check_output(['python', '-m', 'manticore', filename])
+        output = subprocess.check_output([PYTHON_BIN, '-m', 'manticore', filename])
         output_lines = output.splitlines()
         start_info = output_lines[:2]
         testcase_info = output_lines[2:-5]
@@ -140,7 +159,7 @@ class IntegrationTest(unittest.TestCase):
         with open(assertions, 'w') as output:
             output.write('0x0000000000401003 ZF == 1')
         with open(os.path.join(os.pardir, self.test_dir, 'output.log'), "w") as output:
-            subprocess.check_call(['python', '-m', 'manticore',
+            subprocess.check_call([PYTHON_BIN, '-m', 'manticore',
                                    '--workspace', workspace,
                                    '--proc', '4',
                                    '--assertions', assertions,
@@ -156,7 +175,7 @@ class IntegrationTest(unittest.TestCase):
         self.assertTrue(filename.startswith(os.getcwd()))
         filename = filename[len(os.getcwd())+1:]
         workspace = os.path.join(self.test_dir, 'workspace')
-        self._runWithTimeout(['python', '-m', 'manticore',
+        self._runWithTimeout([PYTHON_BIN, '-m', 'manticore',
                     '--workspace', workspace,
                     '--timeout', '20',
                     '--proc', '4',
@@ -179,11 +198,15 @@ class IntegrationTest(unittest.TestCase):
             {'number': 799, 'contract': 'C', 'txlimit': 1},
             {'number': 807, 'contract': 'C', 'txlimit': 1},
             {'number': 808, 'contract': 'C', 'txlimit': 1},
+            {'number': 'main/main', 'contract': 'C', 'txlimit': 1, 'in_directory': 'imports_issue'}
         ]
 
         for issue in issues:
-            self._simple_cli_run(f'{issue["number"]}.sol',
-                                 contract=issue['contract'], tx_limit=issue['txlimit'])
+            self._simple_cli_run(
+                f'{issue["number"]}.sol', contract=issue['contract'], tx_limit=issue['txlimit'],
+                in_directory=issue.get('in_directory')
+            )
+
 
     def test_eth_705(self):
         # This test needs to run inside tests/binaries because the contract imports a file
@@ -199,7 +222,7 @@ class IntegrationTest(unittest.TestCase):
         dirname = os.path.dirname(__file__)
         filename = os.path.abspath(os.path.join(dirname, 'binaries', 'basic_linux_armv7'))
         workspace = os.path.join(self.test_dir, 'workspace')
-        output = subprocess.check_output(['python', '-m', 'manticore', '--workspace', workspace, filename])
+        output = subprocess.check_output([PYTHON_BIN, '-m', 'manticore', '--workspace', workspace, filename])
 
         with open(os.path.join(workspace, "test_00000000.stdout")) as f:
             self.assertIn("Message", f.read())
@@ -237,7 +260,7 @@ class IntegrationTest(unittest.TestCase):
         dirname = os.path.dirname(__file__)
         filename = os.path.abspath(os.path.join(dirname, 'binaries/brk_static_amd64'))
         workspace = f'{self.test_dir}/workspace'
-        output = subprocess.check_output(['python', '-m', 'manticore', '--workspace', workspace, filename])
+        output = subprocess.check_output([PYTHON_BIN, '-m', 'manticore', '--workspace', workspace, filename])
 
         with open(os.path.join(workspace, "test_00000000.messages")) as f:
             self.assertIn("finished with exit status: 0", f.read())


### PR DESCRIPTION
Having a `main.sol`:
```
pragma solidity ^0.4.25;

import '../utils/DirImported.sol';
import 'utils/DirImported2.sol';

contract C {}
```

and such directory structure:
```
$ tree
.
├── main
│   └── main.sol
└── utils
    ├── DirImported.sol
    └── DirImported2.sol

2 directories, 3 files
```

and launching `manticore [options] main/main.sol` Manticore didn't respect current working directory and launched `solc [options] --allow-paths . main.sol` in `main` directory. As a result Manticore was failing due to `solc` being unable to import code from `utils` directory.

This PR fixes that issue and so Manticore will launch `solc [options] --allow-paths . main/main.sol` instead. A testcase has been added for that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1233)
<!-- Reviewable:end -->
