### PR TITLE
Use the address of symbolic conditional instructions

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -30,14 +30,14 @@ def instruction(body):
 
         should_execute = cpu.should_execute_conditional()
 
-        if cpu._at_symbolic_conditional:
-            cpu._at_symbolic_conditional = False
+        if cpu._at_symbolic_conditional == cpu.instruction.address:
+            cpu._at_symbolic_conditional = None
             should_execute = True
         else:
             if issymbolic(should_execute):
                 # Let's remember next time we get here we should not do this again
-                cpu._at_symbolic_conditional = True
-                i_size = cpu.address_bit_size // 8
+                cpu._at_symbolic_conditional = cpu.instruction.address
+                i_size = cpu.instruction.size
                 cpu.PC = Operators.ITEBV(cpu.address_bit_size, should_execute, cpu.PC - i_size,
                                          cpu.PC)
                 return
@@ -358,7 +358,7 @@ class Armv7Cpu(Cpu):
     def __init__(self, memory):
         self._it_conditional = list()
         self._last_flags = {'C': 0, 'V': 0, 'N': 0, 'Z': 0, 'GE': 0}
-        self._at_symbolic_conditional = False
+        self._at_symbolic_conditional = None
         self._mode = cs.CS_MODE_ARM
         super().__init__(Armv7RegisterFile(), memory)
 

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -195,6 +195,11 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.code = self.mem.mmap(0x1000, 0x1000, 'rwx')
         self.data = self.mem.mmap(0xd000, 0x1000, 'rw')
         self.stack = self.mem.mmap(0xf000, 0x1000, 'rw')
+
+        # it doesn't really matter what's the starting address of code
+        # as long as it's known and constant for all the tests;
+        # we start it at +4 as it is convenient for some tests to use pc-4 reference
+        # (see e.g. test_bl_neg test)
         start = self.code + 4
         if multiple_insts:
             offset = 0


### PR DESCRIPTION
When two symbolic conditional instructions follow sequentially, the two paths of
the first instruction will be explored. But when the exploration reaches the
second instruction, because the at_symbolic_conditional flag has already been
set by the first one, only one of the two possible paths will be explored.

This commit fixes this issue by replacing the boolean flag by the address of the
instruction, which ensure the flag has been set for the current instruction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1239)
<!-- Reviewable:end -->
