### PR TITLE
Fix emulation being performed in the wrong mode

### DIFF
--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -248,7 +248,10 @@ class UnicornEmulator(object):
         saved_PC = self._cpu.PC
 
         try:
-            self._emu.emu_start(self._cpu.PC, self._cpu.PC + instruction.size, count=1)
+            pc = self._cpu.PC
+            if self._uc_mode == UC_MODE_THUMB:
+                pc |= 1
+            self._emu.emu_start(pc, self._cpu.PC + instruction.size, count=1)
         except UcError as e:
             # We request re-execution by signaling error; if we we didn't set
             # _should_try_again, it was likely an actual error

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -249,7 +249,7 @@ class UnicornEmulator(object):
 
         try:
             pc = self._cpu.PC
-            if self._uc_mode == UC_MODE_THUMB:
+            if self._cpu.arch == CS_ARCH_ARM and self._uc_mode == UC_MODE_THUMB:
                 pc |= 1
             self._emu.emu_start(pc, self._cpu.PC + instruction.size, count=1)
         except UcError as e:

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -200,6 +200,8 @@ class UnicornEmulator(object):
         '''
         A single attempt at executing an instruction.
         '''
+        logger.debug("0x%x:\t%s\t%s"
+                     % (instruction.address, instruction.mnemonic, instruction.op_str))
 
         registers = set(self._cpu.canonical_registers)
 

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -1321,6 +1321,7 @@ class Armv7UnicornInstructions(unittest.TestCase):
         self.rf.write('R2', 0x5678)
         emulate_next(self.cpu)
         self.assertEqual(self.rf.read('R0'), 0x1234 + 0x5678)
+        self.assertEqual(self.cpu.mode, CS_MODE_THUMB)
 
 
 class UnicornConcretization(unittest.TestCase):

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -14,6 +14,7 @@ from manticore.utils.emulate import UnicornEmulator
 from capstone.arm import *
 from capstone import CS_MODE_THUMB, CS_MODE_ARM
 from keystone import Ks, KS_ARCH_ARM, KS_MODE_ARM, KS_MODE_THUMB
+from unicorn import UC_QUERY_MODE, UC_MODE_THUMB
 
 ks = Ks(KS_ARCH_ARM, KS_MODE_ARM)
 ks_thumb = Ks(KS_ARCH_ARM, KS_MODE_THUMB)
@@ -44,6 +45,7 @@ def emulate_next(cpu):
     cpu.decode_instruction(cpu.PC)
     emu = UnicornEmulator(cpu)
     emu.emulate(cpu.instruction)
+    return emu
 
 
 def itest(asm):
@@ -1319,9 +1321,9 @@ class Armv7UnicornInstructions(unittest.TestCase):
         self.rf.write('R0', 0)
         self.rf.write('R1', 0x1234)
         self.rf.write('R2', 0x5678)
-        emulate_next(self.cpu)
+        emu = emulate_next(self.cpu)
         self.assertEqual(self.rf.read('R0'), 0x1234 + 0x5678)
-        self.assertEqual(self.cpu.mode, CS_MODE_THUMB)
+        self.assertEqual(emu._emu.query(UC_QUERY_MODE), UC_MODE_THUMB)
 
 
 class UnicornConcretization(unittest.TestCase):


### PR DESCRIPTION
After the merge of the PR referenced at the end of this message into the master
branch of Unicorn in July 2016, the emulation mode is set according to the
least significant of bit of the program counter when it is updated.

When an instruction is not implemented at Manticore's level and emulation is
used, the PC value passed to the emu_start() function will trigger a switch of
the current mode, setting it back to ARM mode instead of Thumb mode. This commit
fixes this issue by ensuring that the least significant bit of the PC is set
when Thumb mode emulation is performed.

See https://github.com/unicorn-engine/unicorn/pull/592

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1240)
<!-- Reviewable:end -->
