### PR TITLE
Allow file offsets not aligned on page size

### DIFF
--- a/manticore/utils/mappings.py
+++ b/manticore/utils/mappings.py
@@ -59,10 +59,12 @@ def mmap(fd, offset, size):
 
 
 def munmap(address, size):
-    # When unmapping the memory area, we need to recover the pointer that was returned by mmap().
-    # It's only a matter of aligning it back to the page size, which requires some ctypes casting.
-    aligned_address = ctypes.cast(address, ctypes.c_void_p)
-    aligned_address = aligned_address.value & ~0xfff
+    # When unmapping the memory area, we need to recover the pointer and the size that were given
+    # to mmap(). The pointer can be recovered by aligning it on the page size. The size needs to be
+    # increased by that difference to account for cases where the requested memory area was larger.
+    address = ctypes.cast(address, ctypes.c_void_p).value
+    aligned_address = address & ~0xfff
+    size += address - aligned_address
     aligned_address = ctypes.cast(aligned_address, ctypes.POINTER(ctypes.c_char))
 
     result = munmap_function(aligned_address, size)

--- a/manticore/utils/mappings.py
+++ b/manticore/utils/mappings.py
@@ -67,6 +67,7 @@ def munmap(address, size):
     aligned_address = address & ~0xfff
     size += address - aligned_address
     assert size > 0
+    aligned_address = ctypes.cast(aligned_address, ctypes.POINTER(ctypes.c_char))
 
     result = munmap_function(aligned_address, size)
     assert result == 0

--- a/manticore/utils/mappings.py
+++ b/manticore/utils/mappings.py
@@ -42,7 +42,7 @@ def mmap(fd, offset, size):
     flags = MMAP.MAP_PRIVATE
 
     # When trying to map the contents of a file into memory, the offset must be a multiple of the
-    # page size. So we need to align it before passing it to mmap(). But doing so also increases
+    # page size (see `man mmap`). So we need to align it before passing it to mmap(). Doing so also increases
     # the size of the memory area needed, so we need to account for that difference.
     aligned_offset = offset & ~0xfff
     size += offset - aligned_offset
@@ -54,7 +54,7 @@ def mmap(fd, offset, size):
     result = mmap_function(0, size, prot, flags, fd, aligned_offset)
 
     # Now when returning the pointer to the user, we need to skip the corrected offset so that the
-    # user doesn't end up with a pointer to an other region of the file than the one he requested.
+    # user doesn't end up with a pointer to other region of the file than the one they requested.
     return ctypes.cast(result + offset - aligned_offset, ctypes.POINTER(ctypes.c_char))
 
 

--- a/manticore/utils/mappings.py
+++ b/manticore/utils/mappings.py
@@ -46,10 +46,15 @@ def mmap(fd, offset, size):
 
     assert size > 0
 
-    result = mmap_function(0, size, prot, flags, fd, offset)
-    return ctypes.cast(result, ctypes.POINTER(ctypes.c_char))
+    aligned_offset = offset & ~0xfff
+    result = mmap_function(0, size, prot, flags, fd, aligned_offset)
+    return ctypes.cast(result + offset - aligned_offset, ctypes.POINTER(ctypes.c_char))
 
 
 def munmap(address, size):
-    result = munmap_function(address, size)
+    aligned_address = ctypes.cast(address, ctypes.c_void_p)
+    aligned_address = aligned_address.value & ~0xfff
+    aligned_address = ctypes.cast(aligned_address, ctypes.POINTER(ctypes.c_char))
+
+    result = munmap_function(aligned_address, size)
     assert result == 0

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -248,15 +248,11 @@ class IntegrationTest(unittest.TestCase):
         filename = os.path.join(os.path.dirname(__file__), 'binaries', 'basic_linux_amd64')
         with open(filename, 'rb') as f:
             for addr, size in [
-                (0x1, 0x1000),
-                (0x1, 0x1fffe),
-                (0x1, 0x1ffff),
-                (0xfff, 0x1),
-                (0xfff, 0x2),
-                (0xfff, 0x1000)
+                (0x0001, 0xfffe), (0x0001, 0x0fff), (0x0001, 0x1000),
+                (0x0fff, 0x0001), (0x0fff, 0x0002), (0x0fff, 0x1000),
             ]:
-                ret = mmap(f.fileno(), addr, size)
-                munmap(ret, size)  # assertion should not be triggered here
+                # No assert should be triggered on the following line
+                munmap(mmap(f.fileno(), addr, size), size)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When mapping into memory uncommon ELF executables having their segments file
offsets not aligned on the system page size, the call to mmap_function() will
fail silently. It will actually return 0xffffffff, which isn't checked anywhere
and will only be detected when trying to read/write/free the memory area.

Because this ELF files triggering this issue are programmatically crafted from
binaries into a proprietary format, it won't be happening for all other
executables. But Manticore should support binaries as generic as possible.

This commit allows mapping into memory files having offsets not aligned on the
system page size by simply aligning the file offset when mmap'ing, and returning
a pointer shifted from the necessary correction. When munmap'ing the memory, the
address is aligned again to recovery the initial one given when mmap'ing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1242)
<!-- Reviewable:end -->
