### PR TITLE
Added CBZ, TBB and TBH instructions semantics

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -953,11 +953,33 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def CBZ(cpu, op, dest):
+        """
+        Compare and Branch on Zero compares the value in a register with zero, and conditionally branches forward
+        a constant value. It does not affect the condition flags.
+
+        :param ARMv7Operand op: Specifies the register that contains the first operand.
+        :param ARMv7Operand dest:
+            Specifies the label of the instruction that is to be branched to. The assembler calculates the
+            required value of the offset from the PC value of the CBZ instruction to this label, then
+            selects an encoding that will set imm32 to that offset. Allowed offsets are even numbers in
+            the range 0 to 126.
+        """
         cpu.PC = Operators.ITEBV(cpu.address_bit_size,
                                  op.read(), cpu.PC, dest.read())
 
     @instruction
     def CBNZ(cpu, op, dest):
+        """
+        Compare and Branch on Non-Zero compares the value in a register with zero, and conditionally branches
+        forward a constant value. It does not affect the condition flags.
+
+        :param ARMv7Operand op: Specifies the register that contains the first operand.
+        :param ARMv7Operand dest:
+            Specifies the label of the instruction that is to be branched to. The assembler calculates the
+            required value of the offset from the PC value of the CBNZ instruction to this label, then
+            selects an encoding that will set imm32 to that offset. Allowed offsets are even numbers in
+            the range 0 to 126.
+        """
         cpu.PC = Operators.ITEBV(cpu.address_bit_size,
                                  op.read(), dest.read(), cpu.PC)
 
@@ -991,22 +1013,50 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def TBB(cpu, dest):
+        """
+        Table Branch Byte causes a PC-relative forward branch using a table of single byte offsets. A base register
+        provides a pointer to the table, and a second register supplies an index into the table. The branch length is
+        twice the value of the byte returned from the table.
+
+        :param ARMv7Operand dest: see below; register
+        """
+        # Capstone merges the two registers values into one operand, so we need to extract them back
+
+        # Specifies the base register. This contains the address of the table of branch lengths. This
+        # register is allowed to be the PC. If it is, the table immediately follows this instruction.
         base_addr = dest.get_mem_base_addr()
         if dest.mem.base in ('PC', 'R15'):
             base_addr = cpu.PC
 
+        # Specifies the index register. This contains an integer pointing to a single byte within the
+        # table. The offset within the table is the value of the index.
         offset = cpu.read_int(base_addr + dest.get_mem_offset(), 8)
         offset = Operators.ZEXTEND(offset, cpu.address_bit_size)
+
         cpu.PC += (offset << 1)
 
     @instruction
     def TBH(cpu, dest):
+        """
+        Table Branch Halfword causes a PC-relative forward branch using a table of single halfword offsets. A base
+        register provides a pointer to the table, and a second register supplies an index into the table. The branch
+        length is twice the value of the halfword returned from the table.
+
+        :param ARMv7Operand dest: see below; register
+        """
+        # Capstone merges the two registers values into one operand, so we need to extract them back
+
+        # Specifies the base register. This contains the address of the table of branch lengths. This
+        # register is allowed to be the PC. If it is, the table immediately follows this instruction.
         base_addr = dest.get_mem_base_addr()
         if dest.mem.base in ('PC', 'R15'):
             base_addr = cpu.PC
 
+        # Specifies the index register. This contains an integer pointing to a halfword within the table.
+        # The offset within the table is twice the value of the index.
         offset = cpu.read_int(base_addr + dest.get_mem_offset(), 16)
         offset = Operators.ZEXTEND(offset, cpu.address_bit_size)
+
         cpu.PC += (offset << 1)
 
     @instruction

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -952,6 +952,11 @@ class Armv7Cpu(Cpu):
                                  cpu.PC)
 
     @instruction
+    def CBZ(cpu, op, dest):
+        cpu.PC = Operators.ITEBV(cpu.address_bit_size,
+                                 op.read(), cpu.PC, dest.read())
+
+    @instruction
     def CBNZ(cpu, op, dest):
         cpu.PC = Operators.ITEBV(cpu.address_bit_size,
                                  op.read(), dest.read(), cpu.PC)
@@ -983,6 +988,26 @@ class Armv7Cpu(Cpu):
             cpu._swap_mode()
         elif dest.type == 'register':
             cpu._set_mode_by_val(dest.read())
+
+    @instruction
+    def TBB(cpu, dest):
+        base_addr = dest.get_mem_base_addr()
+        if dest.mem.base in ('PC', 'R15'):
+            base_addr = cpu.PC
+
+        offset = cpu.read_int(base_addr + dest.get_mem_offset(), 8)
+        offset = Operators.ZEXTEND(offset, cpu.address_bit_size)
+        cpu.PC += (offset << 1)
+
+    @instruction
+    def TBH(cpu, dest):
+        base_addr = dest.get_mem_base_addr()
+        if dest.mem.base in ('PC', 'R15'):
+            base_addr = cpu.PC
+
+        offset = cpu.read_int(base_addr + dest.get_mem_offset(), 16)
+        offset = Operators.ZEXTEND(offset, cpu.address_bit_size)
+        cpu.PC += (offset << 1)
 
     @instruction
     def CMP(cpu, reg, compare):

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -989,32 +989,32 @@ class Armv7CpuInstructions(unittest.TestCase):
     # CBZ/CBNZ
 
     @itest_setregs("R0=0")
-    @itest_custom("cbz r0, 0x2a", mode=CS_MODE_THUMB)
+    @itest_custom("cbz r0, #0x2a", mode=CS_MODE_THUMB)
     def test_cbz_taken(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 42)
+        self.assertEqual(self.rf.read('PC'), pre_pc + 0x2a)
 
     @itest_setregs("R0=1")
     @itest_custom("cbz r0, #0x2a", mode=CS_MODE_THUMB)
     def test_cbz_not_taken(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 2)
+        self.assertEqual(self.rf.read('PC'), pre_pc + 2)  # cbz is 2 bytes long
 
     @itest_setregs("R0=1")
-    @itest_custom("cbnz r0, 0x2a", mode=CS_MODE_THUMB)
+    @itest_custom("cbnz r0, #0x2a", mode=CS_MODE_THUMB)
     def test_cbnz_taken(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 42)
+        self.assertEqual(self.rf.read('PC'), pre_pc + 0x2a)
 
     @itest_setregs("R0=0")
     @itest_custom("cbnz r0, #0x2a", mode=CS_MODE_THUMB)
     def test_cbnz_not_taken(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 2)
+        self.assertEqual(self.rf.read('PC'), pre_pc + 2)  # cbnz is 2 bytes long
 
     # TBB/TBH
 
@@ -1022,49 +1022,49 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_custom("tbb [r0, r1]", mode=CS_MODE_THUMB)
     def test_tbb(self):
         # Write the table of offsets at 0xd000 (R0)
-        # Index is 1 (R1), offset will be 2x21 = 42
+        # Index is 1 (R1), offset will be 2 x 21 = 42
         for i, offset in enumerate([11, 21, 31]):
             self.mem.write(0xd000 + i, struct.pack('<B', offset))
 
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 4 + 42)
+        self.assertEqual(self.rf.read('PC'), (pre_pc + 4) + 42)  # tbb is 4 bytes long
 
     @itest_setregs("R1=1")
     @itest_custom("tbb [pc, r1]", mode=CS_MODE_THUMB)
     def test_tbb_pc_relative(self):
         # Write the table of offsets after the instruction
-        # Index is 1 (R1), offset will be 2x21 = 42
+        # Index is 1 (R1), offset will be 2 x 21 = 42
         for i, offset in enumerate([11, 21, 31]):
             self.mem.write(self.cpu.PC + 4 + i, struct.pack('<B', offset))
 
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 4 + 42)
+        self.assertEqual(self.rf.read('PC'), (pre_pc + 4) + 42)  # tbb is 4 bytes long
 
     @itest_setregs("R0=0xd000", "R1=1")
     @itest_custom("tbh [r0, r1, lsl #1]", mode=CS_MODE_THUMB)
     def test_tbh(self):
         # Write the table of offsets at 0xd000 (R0)
-        # Index is 1 (R1), offset will be 2x21 = 42
+        # Index is 1 (R1), offset will be 2 x 21 = 42
         for i, offset in enumerate([11, 21, 31]):
             self.mem.write(0xd000 + i * 2, struct.pack('<H', offset))
 
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 4 + 42)
+        self.assertEqual(self.rf.read('PC'), (pre_pc + 4) + 42)  # tbh is 4 bytes long
 
     @itest_setregs("R1=1")
     @itest_custom("tbh [pc, r1, lsl #1]", mode=CS_MODE_THUMB)
     def test_tbh_pc_relative(self):
         # Write the table of offsets after the instruction
-        # Index is 1 (R1), offset will be 2x21 = 42
+        # Index is 1 (R1), offset will be 2 x 21 = 42
         for i, offset in enumerate([11, 21, 31]):
             self.mem.write(self.cpu.PC + 4 + i * 2, struct.pack('<H', offset))
 
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('PC'), pre_pc + 4 + 42)
+        self.assertEqual(self.rf.read('PC'), (pre_pc + 4) + 42)  # tbh is 4 bytes long
 
     # CMP
 


### PR DESCRIPTION
CBZ was not implemented while CBNZ was. As far as Manticore is concerned, CBZ is
the same as CBNZ, but with two possible destination addresses exchanged.

TBB and TBH instructions are often used for switches. According to the ARM
documentation, the base register contains the address of a table of
bytes/half-words, and the index register contains an index into this table. The
selected value is then shifted left by one and zero-extended to 32-bits before
being added to the current PC. If the PC register is used as the base, the table
is then located immediately after the instruction.

See also ARM Architecture Reference Manual Thumb-2 Supplement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1243)
<!-- Reviewable:end -->
