### PR TITLE
Added ADR, ADDW and SUBW instructions semantics

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -935,6 +935,29 @@ class Armv7Cpu(Cpu):
         return result, carry, overflow
 
     @instruction
+    def ADR(cpu, dest, src):
+        aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
+        dest.write(aligned_pc + src.read())
+
+    @instruction
+    def ADDW(cpu, dest, src, add):
+        aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
+        if src.type == 'register' and src.reg in ('PC', 'R15'):
+            src = aligned_pc
+        else:
+            src = src.read()
+        dest.write(src + add.read())
+
+    @instruction
+    def SUBW(cpu, dest, src, add):
+        aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
+        if src.type == 'register' and src.reg in ('PC', 'R15'):
+            src = aligned_pc
+        else:
+            src = src.read()
+        dest.write(src - add.read())
+
+    @instruction
     def B(cpu, dest):
         cpu.PC = dest.read()
 

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -936,11 +936,32 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def ADR(cpu, dest, src):
+        """
+        Address to Register adds an immediate value to the PC value, and writes the result to the destination register.
+
+        :param ARMv7Operand dest: Specifies the destination register.
+        :param ARMv7Operand src:
+            Specifies the label of an instruction or literal data item whose address is to be loaded into
+            <Rd>. The assembler calculates the required value of the offset from the Align(PC,4)
+            value of the ADR instruction to this label.
+        """
         aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
         dest.write(aligned_pc + src.read())
 
     @instruction
     def ADDW(cpu, dest, src, add):
+        """
+        This instruction adds an immediate value to a register value, and writes the result to the destination register.
+        It doesn't update the condition flags.
+
+        :param ARMv7Operand dest: Specifies the destination register. If omitted, this register is the same as src.
+        :param ARMv7Operand src:
+            Specifies the register that contains the first operand. If the SP is specified for dest, see ADD (SP plus
+            immediate). If the PC is specified for dest, see ADR.
+        :param ARMv7Operand add:
+            Specifies the immediate value to be added to the value obtained from src. The range of allowed values is
+            0-4095.
+        """
         aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
         if src.type == 'register' and src.reg in ('PC', 'R15'):
             src = aligned_pc
@@ -950,6 +971,18 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def SUBW(cpu, dest, src, add):
+        """
+        This instruction subtracts an immediate value from a register value, and writes the result to the destination
+        register. It can optionally update the condition flags based on the result.
+
+        :param ARMv7Operand dest: Specifies the destination register. If omitted, this register is the same as src.
+        :param ARMv7Operand src:
+            Specifies the register that contains the first operand. If the SP is specified for dest, see ADD (SP plus
+            immediate). If the PC is specified for dest, see ADR.
+        :param ARMv7Operand add:
+            Specifies the immediate value to be added to the value obtained from src. The range of allowed values is
+            0-4095.
+        """
         aligned_pc = (cpu.instruction.address + 4) & 0xfffffffc
         if src.type == 'register' and src.reg in ('PC', 'R15'):
             src = aligned_pc

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -976,33 +976,33 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_adr(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('R0'), pre_pc + 4 + 16)
+        self.assertEqual(self.rf.read('R0'), (pre_pc + 4) + 16)  # adr is 4 bytes long
 
     # ADDW
 
     @itest_setregs("R1=0x1234")
-    @itest_thumb("addw r0, r1, 0x2a")
+    @itest_thumb("addw r0, r1, #0x2a")
     def test_addw(self):
-        self.assertEqual(self.rf.read('R0'), 0x1234 + 42)
+        self.assertEqual(self.rf.read('R0'), 0x1234 + 0x2a)
 
-    @itest_custom("addw r0, pc, 0x2a", mode=CS_MODE_THUMB)
+    @itest_custom("addw r0, pc, #0x2a", mode=CS_MODE_THUMB)
     def test_addw_pc_relative(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('R0'), pre_pc + 4 + 42)
+        self.assertEqual(self.rf.read('R0'), (pre_pc + 4) + 0x2a)  # addw is 4 bytes long
 
     # SUBW
 
     @itest_setregs("R1=0x1234")
-    @itest_thumb("subw r0, r1, 0x2a")
+    @itest_thumb("subw r0, r1, #0x2a")
     def test_subw(self):
-        self.assertEqual(self.rf.read('R0'), 0x1234 - 42)
+        self.assertEqual(self.rf.read('R0'), 0x1234 - 0x2a)
 
-    @itest_custom("subw r0, pc, 0x2a", mode=CS_MODE_THUMB)
+    @itest_custom("subw r0, pc, #0x2a", mode=CS_MODE_THUMB)
     def test_subw_pc_relative(self):
         pre_pc = self.rf.read('PC')
         self.cpu.execute()
-        self.assertEqual(self.rf.read('R0'), pre_pc + 4 - 42)
+        self.assertEqual(self.rf.read('R0'), (pre_pc + 4) - 0x2a)  # subw is 4 bytes long
 
     # BL
 


### PR DESCRIPTION
These 3 instructions can be used to load PC-relative addresses. The ADDW and
SUBW instructions can also be used with other source registers. When the PC
register is used as the source, the ARM documentation specifies that the offset
is added or subtracted from ALIGN(pc, 4).

See also the ARM Architecture Reference Manual Thumb-2 Supplement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1244)
<!-- Reviewable:end -->
