### PR TITLE
Added STMDA and STMDB instructions semantics

### DIFF
--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -1066,14 +1066,21 @@ class Armv7Cpu(Cpu):
         address = base.read()
         if insn_id == cs.arm.ARM_INS_STMIB:
             address += 4
+        if insn_id == cs.arm.ARM_INS_STMDB:
+            address -= 4
 
         for reg in regs:
             cpu.write_int(address, reg.read(), cpu.address_bit_size)
-            address += 4
+            if insn_id in (cs.arm.ARM_INS_STM, cs.arm.ARM_INS_STMIB):
+                address += 4
+            if insn_id in (cs.arm.ARM_INS_STMDA, cs.arm.ARM_INS_STMDB):
+                address -= 4
 
         # Undo the last addition if we're in STMIB
         if insn_id == cs.arm.ARM_INS_STMIB:
             address -= 4
+        if insn_id == cs.arm.ARM_INS_STMDB:
+            address += 4
 
         if cpu.instruction.writeback:
             base.writeback(address)
@@ -1085,6 +1092,14 @@ class Armv7Cpu(Cpu):
     @instruction
     def STMIB(cpu, base, *regs):
         cpu._STM(cs.arm.ARM_INS_STMIB, base, regs)
+
+    @instruction
+    def STMDA(cpu, base, *regs):
+        cpu._STM(cs.arm.ARM_INS_STMDA, base, regs)
+
+    @instruction
+    def STMDB(cpu, base, *regs):
+        cpu._STM(cs.arm.ARM_INS_STMDB, base, regs)
 
     def _bitwise_instruction(cpu, operation, dest, op1, *op2):
         if op2:

--- a/manticore/core/cpu/arm.py
+++ b/manticore/core/cpu/arm.py
@@ -1037,19 +1037,43 @@ class Armv7Cpu(Cpu):
 
     def _LDM(cpu, insn_id, base, regs):
         """
-        It's technically UNKNOWN if you writeback to a register you loaded into,
-        but we let it slide.
+        LDM (Load Multiple) loads a non-empty subset, or possibly all, of the general-purpose registers from
+        sequential memory locations. It is useful for block loads, stack operations and procedure exit sequences.
+
+        :param int insn_id: should be one of ARM_INS_LDM, ARM_INS_LDMIB, ARM_INS_LDMDA, ARM_INS_LDMDB
+        :param Armv7Operand base: Specifies the base register.
+        :param list[Armv7Operand] regs:
+            Is a list of registers. It specifies the set of registers to be loaded by the LDM instruction.
+            The registers are loaded in sequence, the lowest-numbered register from the lowest memory
+            address (start_address), through to the highest-numbered register from the highest memory
+            address (end_address). If the PC is specified in the register list (opcode bit[15] is set),
+            the instruction causes a branch to the address (data) loaded into the PC.
+
+        It's technically UNKNOWN if you writeback to a register you loaded into, but we let it slide.
         """
+        if cpu.instruction.usermode:
+            raise NotImplementedError("Use of the S bit is not supported")
+
+        increment = insn_id in (cs.arm.ARM_INS_LDM, cs.arm.ARM_INS_LDMIB)
+        after = insn_id in (cs.arm.ARM_INS_LDM, cs.arm.ARM_INS_LDMDA)
+
         address = base.read()
-        if insn_id == cs.arm.ARM_INS_LDMIB:
-            address += cpu.address_bit_size // 8
 
         for reg in regs:
-            reg.write(cpu.read_int(address, cpu.address_bit_size))
-            address += reg.size // 8
+            if not after:
+                address += (1 if increment else -1) * (reg.size // 8)
 
-        if insn_id == cs.arm.ARM_INS_LDMIB:
-            address -= reg.size // 8
+            reg.write(cpu.read_int(address, reg.size))
+            if reg.reg in ('PC', 'R15'):
+                # The general-purpose registers loaded can include the PC. If they do, the word loaded for the PC is
+                # treated as an address and a branch occurs to that address. In ARMv5 and above, bit[0] of the loaded
+                # value determines whether execution continues after this branch in ARM state or in Thumb state, as
+                # though a BX instruction had been executed.
+                cpu._set_mode_by_val(cpu.PC)
+                cpu.PC = cpu.PC & ~1
+
+            if after:
+                address += (1 if increment else -1) * (reg.size // 8)
 
         if cpu.instruction.writeback:
             base.writeback(address)
@@ -1062,25 +1086,43 @@ class Armv7Cpu(Cpu):
     def LDMIB(cpu, base, *regs):
         cpu._LDM(cs.arm.ARM_INS_LDMIB, base, regs)
 
+    @instruction
+    def LDMDA(cpu, base, *regs):
+        cpu._LDM(cs.arm.ARM_INS_LDMDA, base, regs)
+
+    @instruction
+    def LDMDB(cpu, base, *regs):
+        cpu._LDM(cs.arm.ARM_INS_LDMDB, base, regs)
+
     def _STM(cpu, insn_id, base, regs):
+        """
+        STM (Store Multiple) stores a non-empty subset (or possibly all) of the general-purpose registers to
+        sequential memory locations.
+
+        :param int insn_id: should be one of ARM_INS_STM, ARM_INS_STMIB, ARM_INS_STMDA, ARM_INS_STMDB
+        :param Armv7Operand base: Specifies the base register.
+        :param list[Armv7Operand] regs:
+            Is a list of registers. It specifies the set of registers to be stored by the STM instruction.
+            The registers are stored in sequence, the lowest-numbered register to the lowest
+            memory address (start_address), through to the highest-numbered register to the
+            highest memory address (end_address).
+        """
+        if cpu.instruction.usermode:
+            raise NotImplementedError("Use of the S bit is not supported")
+
+        increment = insn_id in (cs.arm.ARM_INS_STM, cs.arm.ARM_INS_STMIB)
+        after = insn_id in (cs.arm.ARM_INS_STM, cs.arm.ARM_INS_STMDA)
+
         address = base.read()
-        if insn_id == cs.arm.ARM_INS_STMIB:
-            address += 4
-        if insn_id == cs.arm.ARM_INS_STMDB:
-            address -= 4
 
         for reg in regs:
-            cpu.write_int(address, reg.read(), cpu.address_bit_size)
-            if insn_id in (cs.arm.ARM_INS_STM, cs.arm.ARM_INS_STMIB):
-                address += 4
-            if insn_id in (cs.arm.ARM_INS_STMDA, cs.arm.ARM_INS_STMDB):
-                address -= 4
+            if not after:
+                address += (1 if increment else -1) * (reg.size // 8)
 
-        # Undo the last addition if we're in STMIB
-        if insn_id == cs.arm.ARM_INS_STMIB:
-            address -= 4
-        if insn_id == cs.arm.ARM_INS_STMDB:
-            address += 4
+            cpu.write_int(address, reg.read(), reg.size)
+
+            if after:
+                address += (1 if increment else -1) * (reg.size // 8)
 
         if cpu.instruction.writeback:
             base.writeback(address)
@@ -1278,7 +1320,7 @@ class Armv7Cpu(Cpu):
 
     @instruction
     def VLDMIA(cpu, base, *regs):
-        cpu._LDM(cs.arm.ARM_INS_VLDMIA, base, regs)
+        cpu._LDM(cs.arm.ARM_INS_LDM, base, regs)
 
     @instruction
     def STCL(cpu, *operands):

--- a/tests/test_armv7cpu.py
+++ b/tests/test_armv7cpu.py
@@ -1101,6 +1101,8 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_sbc_thumb(self):
         self.assertEqual(self.rf.read('R0'), 0)
 
+    # LDM/LDMIB/LDMDA/LDMDB
+
     @itest_custom("ldm sp, {r1, r2, r3}")
     def test_ldm(self):
         self.cpu.stack_push(0x41414141)
@@ -1125,37 +1127,139 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.rf.read('R3'), 0x41414141)
         self.assertEqual(self.cpu.STACK, pre_sp + 12)
 
-    @itest_setregs("R1=2", "R2=42", "R3=0x42424242")
+    @itest_setregs("R0=0xd100")
+    @itest_custom("ldmia r0!, {r1, r2, r3}")
+    def test_ldmia(self):
+        # IA - Increment After
+        # so the first value read should be at 0xd100
+        self.cpu.write_int(0xd100+0x0, 1, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100+0x4, 2, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100+0x8, 3, self.cpu.address_bit_size)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read('R1'), 1)
+        self.assertEqual(self.rf.read('R2'), 2)
+        self.assertEqual(self.rf.read('R3'), 3)
+        # and the writeback should be 0xd10c
+        self.assertEqual(self.rf.read('R0'), 0xd100+0xc)
+
+    @itest_setregs("R0=0xd100")
+    @itest_custom("ldmib r0!, {r1, r2, r3}")
+    def test_ldmib(self):
+        # IB - Increment Before
+        # so the first value read should be at 0xd104
+        self.cpu.write_int(0xd100+0x4, 1, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100+0x8, 2, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100+0xc, 3, self.cpu.address_bit_size)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read('R1'), 1)
+        self.assertEqual(self.rf.read('R2'), 2)
+        self.assertEqual(self.rf.read('R3'), 3)
+        # and the writeback should be 0xd10c
+        self.assertEqual(self.rf.read('R0'), 0xd100+0xc)
+
+    @itest_setregs("R0=0xd100")
+    @itest_custom("ldmda r0!, {r1, r2, r3}")
+    def test_ldmda(self):
+        # DA - Decrement After
+        # so the first value read should be at 0xd100
+        self.cpu.write_int(0xd100-0x0, 1, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100-0x4, 2, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100-0x8, 3, self.cpu.address_bit_size)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read('R1'), 1)
+        self.assertEqual(self.rf.read('R2'), 2)
+        self.assertEqual(self.rf.read('R3'), 3)
+        # and the writeback should be 0xd0f8
+        self.assertEqual(self.rf.read('R0'), 0xd100-0xc)
+
+    @itest_setregs("R0=0xd100")
+    @itest_custom("ldmdb r0!, {r1, r2, r3}")
+    def test_ldmdb(self):
+        # DB - Decrement Before
+        # so the first value read should be at 0xd0fc
+        self.cpu.write_int(0xd100-0x4, 1, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100-0x8, 2, self.cpu.address_bit_size)
+        self.cpu.write_int(0xd100-0xc, 3, self.cpu.address_bit_size)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read('R1'), 1)
+        self.assertEqual(self.rf.read('R2'), 2)
+        self.assertEqual(self.rf.read('R3'), 3)
+        # and the writeback should be 0xd0f8
+        self.assertEqual(self.rf.read('R0'), 0xd100-0xc)
+
+    # STM/STMIB/STMDA/STMDB
+
+    @itest_setregs("R1=42", "R2=2", "R3=0x42424242")
     @itest_custom("stm sp, {r1, r2, r3}")
     def test_stm(self):
         self.cpu.STACK -= 12
         pre_sp = self.cpu.STACK
         self.cpu.execute()
-        self.assertEqual(self.cpu.read_int(pre_sp, self.cpu.address_bit_size), 2)
-        self.assertEqual(self.cpu.read_int(pre_sp + 4, self.cpu.address_bit_size), 42)
-        self.assertEqual(self.cpu.read_int(pre_sp + 8, self.cpu.address_bit_size),
-                         0x42424242)
+        self.assertEqual(self.cpu.read_int(pre_sp, self.cpu.address_bit_size), 42)
+        self.assertEqual(self.cpu.read_int(pre_sp + 4, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(pre_sp + 8, self.cpu.address_bit_size), 0x42424242)
         self.assertEqual(self.cpu.STACK, pre_sp)
 
-    @itest_setregs("R1=2", "R2=42", "R3=0x42424242")
+    @itest_setregs("R1=42", "R2=2", "R3=0x42424242")
     @itest_custom("stm sp!, {r1, r2, r3}")
     def test_stm_wb(self):
         self.cpu.STACK -= 12
         pre_sp = self.cpu.STACK
         self.cpu.execute()
-        self.assertEqual(self.cpu.read_int(pre_sp, self.cpu.address_bit_size), 2)
-        self.assertEqual(self.cpu.read_int(pre_sp + 4, self.cpu.address_bit_size), 42)
-        self.assertEqual(self.cpu.read_int(pre_sp + 8, self.cpu.address_bit_size),
-                         0x42424242)
+        self.assertEqual(self.cpu.read_int(pre_sp, self.cpu.address_bit_size), 42)
+        self.assertEqual(self.cpu.read_int(pre_sp + 4, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(pre_sp + 8, self.cpu.address_bit_size), 0x42424242)
         self.assertEqual(self.cpu.STACK, pre_sp + 12)
 
-    @itest_custom("stmib   r3, {r2, r4}")
-    @itest_setregs("R1=1", "R2=2", "R4=4", "R3=0xd100")
-    def test_stmib_basic(self):
+    @itest_setregs("R0=0xd100", "R1=1", "R2=2", "R3=3")
+    @itest_custom("stmia r0!, {r1, r2, r3}")
+    def test_stmia(self):
+        # IA = Increment After
         self.cpu.execute()
-        addr = self.rf.read('R3')
-        self.assertEqual(self.cpu.read_int(addr + 4, self.cpu.address_bit_size), 2)
-        self.assertEqual(self.cpu.read_int(addr + 8, self.cpu.address_bit_size), 4)
+        # so the first value written should be at 0xd100
+        self.assertEqual(self.cpu.read_int(0xd100+0x0, self.cpu.address_bit_size), 1)
+        self.assertEqual(self.cpu.read_int(0xd100+0x4, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(0xd100+0x8, self.cpu.address_bit_size), 3)
+        # and the writeback should be 0xd100c
+        self.assertEqual(self.rf.read('R0'), 0xd100+0xc)
+
+    @itest_setregs("R0=0xd100", "R1=1", "R2=2", "R3=3")
+    @itest_custom("stmib r0!, {r1, r2, r3}")
+    def test_stmib(self):
+        # IB = Increment Before
+        self.cpu.execute()
+        # so the first value written should be at 0xd104
+        self.assertEqual(self.cpu.read_int(0xd100+0x4, self.cpu.address_bit_size), 1)
+        self.assertEqual(self.cpu.read_int(0xd100+0x8, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(0xd100+0xc, self.cpu.address_bit_size), 3)
+        # and the writeback should be 0xd100c
+        self.assertEqual(self.rf.read('R0'), 0xd100+0xc)
+
+    @itest_setregs("R0=0xd100", "R1=1", "R2=2", "R3=3")
+    @itest_custom("stmda r0!, {r1, r2, r3}")
+    def test_stmda(self):
+        # DA = Decrement After
+        self.cpu.execute()
+        # so the first value written should be at 0xd100
+        self.assertEqual(self.cpu.read_int(0xd100-0x0, self.cpu.address_bit_size), 1)
+        self.assertEqual(self.cpu.read_int(0xd100-0x4, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(0xd100-0x8, self.cpu.address_bit_size), 3)
+        # and the writeback should be 0xd0f8
+        self.assertEqual(self.rf.read('R0'), 0xd100-0xc)
+
+    @itest_setregs("R0=0xd100", "R1=1", "R2=2", "R3=3")
+    @itest_custom("stmdb r0!, {r1, r2, r3}")
+    def test_stmdb(self):
+        # DB = Decrement Before
+        self.cpu.execute()
+        # so the first value written should be at 0xd0fc
+        self.assertEqual(self.cpu.read_int(0xd100-0x4, self.cpu.address_bit_size), 1)
+        self.assertEqual(self.cpu.read_int(0xd100-0x8, self.cpu.address_bit_size), 2)
+        self.assertEqual(self.cpu.read_int(0xd100-0xc, self.cpu.address_bit_size), 3)
+        # and the writeback should be 0xd0f8
+        self.assertEqual(self.rf.read('R0'), 0xd100-0xc)
+
+    # BX
 
     @itest_custom("bx r1")
     @itest_setregs("R1=0x1008")


### PR DESCRIPTION
STM and STMIB are already implemented. STMDA and STMDB simply call the helper
function _STM(). This function is modified to support decrementing the address.

See also ARM Architecture Reference Manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1245)
<!-- Reviewable:end -->
