### PR TITLE
Exclude tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/trailofbits/manticore',
     author='Trail of Bits',
     version='0.2.2',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     python_requires='>=3.6',
     install_requires=[
         'capstone>=3.0.5',


### PR DESCRIPTION
TLDR: We package Manticore with tests files and not even their binaries, so it is redundant.

This can be observed with:
```
$ ls $VIRTUAL_ENV/lib/python*/site-packages/manticore*/
EGG-INFO  manticore  tests

$ ls $VIRTUAL_ENV/lib/python*/site-packages/manticore*/tests
EVM               eth_detectors.py  test_armv7_bitwise.py  test_config.py         test_dyn.py        test_memory.py    test_slam_regre.py  test_workspace.py
__init__.py       eth_general.py    test_armv7cpu.py       test_cpu_automatic.py  test_events.py     test_models.py    test_smtlibv2.py    test_x86.py
__pycache__       mockmem.py        test_armv7rf.py        test_cpu_manual.py     test_linux.py      test_register.py  test_state.py       test_x86_pcmpxstrx.py
eth_benchmark.py  test_abi.py       test_binaries.py       test_driver.py         test_manticore.py  test_rlp.py       test_unicorn.py
```

It can also be observed when building the package with `python setup.py sdist`.

Before this PR:
```
$ rm -rf dist manticore.egg-info/
$ python setup.py sdist 2>/dev/null 1>&2
$ cat manticore.egg-info/SOURCES.txt | grep tests
tests/__init__.py
tests/eth_benchmark.py
tests/eth_detectors.py
tests/eth_general.py
(... - output truncated as it was long)
```

After this PR:
```
$ rm -rf dist manticore.egg-info/
$ python setup.py sdist 2>/dev/null 1>&2
$ cat manticore.egg-info/SOURCES.txt | grep tests
$
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1248)
<!-- Reviewable:end -->
