### PR TITLE
Fixing "TypeError: unsupported format string"

### DIFF
--- a/manticore/core/cpu/abstractcpu.py
+++ b/manticore/core/cpu/abstractcpu.py
@@ -898,6 +898,7 @@ class Cpu(Eventful):
         value = self.read_register(reg_name)
 
         if issymbolic(value):
+            value = str(value)  # coerce the value into a string
             aux = f"{reg_name:3s}: {value:16s}"
             result += aux
         elif isinstance(value, int):


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/trailofbits/manticore/issues/1236 by coercing the symbolic register value into a string prior to rendering it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1250)
<!-- Reviewable:end -->
