### PR TITLE
Fix solidity relative path issue

### DIFF
--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -342,7 +342,7 @@ class ManticoreEVM(Manticore):
         relative_filepath = source_file.name
 
         if not working_dir:
-            working_dir = os.path.abspath(relative_filepath)[:-len(relative_filepath)]
+            working_dir = os.path.dirname(os.path.abspath(relative_filepath))
         elif relative_filepath.startswith(working_dir):
             relative_filepath = relative_filepath[len(working_dir) + 1:]
 

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -342,7 +342,7 @@ class ManticoreEVM(Manticore):
         relative_filepath = source_file.name
 
         if not working_dir:
-            working_dir = os.path.dirname(os.path.abspath(relative_filepath))
+            working_dir = os.getcwd()
         elif relative_filepath.startswith(working_dir):
             relative_filepath = relative_filepath[len(working_dir) + 1:]
 


### PR DESCRIPTION
I ran into a situation where `source_file` was something like `../my/relative/path`, so the current code truncated the `working_dir`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1263)
<!-- Reviewable:end -->
