### PR TITLE
Fix setstate reference before assignment

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -159,7 +159,7 @@ class State(Eventful):
             expression = self.cpu.read_int(e.address, e.size)
 
             def setstate(state, value):
-                state.cpu.write_int(setstate.e.address, value, e.size)
+                state.cpu.write_int(setstate.e.address, value, setstate.e.size)
             setstate.e = e
             raise Concretize(str(e),
                              expression=expression,


### PR DESCRIPTION
```
2018-11-15 20:57:38,874: [15061] m.c.executor:ERROR: Exception: free variable 'e' referenced before assignment in enclosing scope
Traceback (most recent call last):
  File "/home/vagrant/manticore/manticore/core/state.py", line 143, in execute
    result = self._platform.execute()
  File "/home/vagrant/manticore/manticore/platforms/linux.py", line 2230, in execute
    self.current.execute()
  File "/home/vagrant/manticore/manticore/core/cpu/abstractcpu.py", line 847, in execute
    self.emulate(insn)
  File "/home/vagrant/manticore/manticore/core/cpu/abstractcpu.py", line 875, in emulate
    emu.emulate(insn)
  File "/home/vagrant/manticore/manticore/utils/emulate.py", line 187, in emulate
    "Concretizing for emulation")
manticore.core.memory.ConcretizeMemory: Concretizing for emulation
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/vagrant/manticore/manticore/core/executor.py", line 467, in run
    if not current_state.execute():
  File "/home/vagrant/manticore/manticore/core/state.py", line 167, in execute
    policy=e.policy)
manticore.core.state.Concretize

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/vagrant/manticore/manticore/core/executor.py", line 480, in run
    current_state = self.fork(current_state, e.expression, e.policy, e.setstate)
  File "/home/vagrant/manticore/manticore/core/executor.py", line 408, in fork
    setstate(new_state, new_value)
  File "/home/vagrant/manticore/manticore/core/state.py", line 162, in setstate
    state.cpu.write_int(setstate.e.address, value, e.size)
NameError: free variable 'e' referenced before assignment in enclosing scope
```

Adds fix to `setstate` scope exception, ensuring that `e` is referenced correctly within its scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1270)
<!-- Reviewable:end -->
