### PR TITLE
Add missing `f`-string

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1450,7 +1450,7 @@ class Linux(Platform):
             f = self._sys_open_get_file(filename, flags)
             logger.debug(f"Opening file {filename} for real fd {f.fileno()}")
         except IOError as e:
-            logger.warning("Could not open file {filename}. Reason: {e!s}")
+            logger.warning(f"Could not open file {filename}. Reason: {e!s}")
             return -e.errno if e.errno is not None else -errno.EINVAL
 
         return self._open(f)


### PR DESCRIPTION
Currently warns with an uninterpreted string instead of a useful error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1281)
<!-- Reviewable:end -->
