### PR TITLE
Fix command.sh not saved in ethereum

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -9,6 +9,7 @@ from multiprocessing import Process
 from threading import Timer
 
 import functools
+import shlex
 import types
 
 from ..core.executor import Executor
@@ -522,8 +523,11 @@ class ManticoreBase(Eventful):
         self._coverage_file = path
 
     def _did_finish_run_callback(self):
+        self._save_run_data()
+
+    def _save_run_data(self):
         with self._output.save_stream('command.sh') as f:
-            f.write(' '.join(sys.argv))
+            f.write(' '.join(map(shlex.quote, sys.argv)))
 
         with self._output.save_stream('manticore.yml') as f:
             config.save(f)

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1421,8 +1421,7 @@ class ManticoreEVM(ManticoreBase):
                         global_findings.write('    '.join(source_code_snippet.splitlines(True)))
                         global_findings.write('\n')
 
-        with self._output.save_stream('manticore.yml') as f:
-            config.save(f)
+        self._save_run_data()
 
         with self._output.save_stream('global.summary') as global_summary:
             # (accounts created by contract code are not in this list )
@@ -1497,8 +1496,6 @@ class ManticoreEVM(ManticoreBase):
         with self.locked_context('ethereum') as eth_context:
             eth_context['_saved_states'] = set()
             eth_context['_final_states'] = set()
-
-        logger.info("Results in %s", self.workspace)
 
     def global_coverage(self, account):
         """ Returns code coverage for the contract on `account_address`.

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -152,7 +152,8 @@ class IntegrationTest(unittest.TestCase):
         self.assertIn(b'm.main:INFO: Beginning analysis', output[1])
         self.assertIn(b'm.e.manticore:INFO: Starting symbolic create contract', output[2])
 
-        self.assertIn(b'm.e.manticore:INFO: Results in ', output[-1])
+        self.assertIn(b'm.c.manticore:INFO: Results in ', output[-2])
+        self.assertIn(b'm.c.manticore:INFO: Total time: ', output[-1])
 
         # Since we count the total time of Python process that runs Manticore, it takes a bit more time
         # e.g. for some finalization like generation of testcases


### PR DESCRIPTION
For native binaries Manticore saves `command.sh` and `manticore.yml` in
a `_did_finish_run_callback`: https://github.com/trailofbits/manticore/blob/c29f7cf8672014cf02cfc1271ec1d0a3cb3983af/manticore/core/manticore.py#L524-L533

For ethereum smart contracts this callback is
called two times (not sure why), so we supress it instead: https://github.com/trailofbits/manticore/blob/c29f7cf8672014cf02cfc1271ec1d0a3cb3983af/manticore/ethereum/manticore.py#L1523-L1526

This PR moves this logic to a `ManticoreBase._save_run_data` method, so
it can be used in both native and ethereum Manticore engines.

As a result:
* native engine works as it worked
* ethereum engine will now save `command.sh` file
* ethereum engine will now print the elapsed time

Additionally, a bug with `command.sh` output has been fixed: when one
passed argument that had spaces, e.g.:
```
manticore "path to contract/with_spaces.sol"
```

this resulted in a `command.sh` having such content:

```
manticore path to contract/with_spaces.sol
```

which is wrong as it shall be `manticore "path to contract/with_spaces.sol"` or `manticore 'path to contract/with_spaces.sol'`.

This has been fixed by processing all arguments with `shlex.quote`, so
they are quoted properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1289)
<!-- Reviewable:end -->
