### PR TITLE
Add combo1 to txaccount cli description

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -114,7 +114,8 @@ def parse_arguments():
                            help='Do not attempt to send ether to contract')
 
     eth_flags.add_argument('--txaccount', type=str, default="attacker",
-                           help='Account used as caller in the symbolic transactions, either "attacker" or "owner"')
+                           help='Account used as caller in the symbolic transactions, either "attacker" or '
+                                '"owner" or "combo1" (uses both)')
 
     eth_flags.add_argument('--contract', type=str,
                            help='Contract name to analyze in case of multiple contracts')


### PR DESCRIPTION
We inform about `combo1` when one passes a wrong `--txaccount` anyway, so we should also have it in `--help`:
```
$ manticore --txnocoverage --contract ModifierEntrancy --detect-reentrancy --txaccount asd ./test.sol
2018-12-10 02:43:11,831: [10019] m.main:INFO: Beginning analysis
2018-12-10 02:43:11,832: [10019] m.ethereum:INFO: Starting symbolic create contract
Traceback (most recent call last):
(...)
    raise EthereumError('The account to perform the symbolic exploration of the contract should be "attacker", "owner" or "combo1"')
manticore.exceptions.EthereumError: The account to perform the symbolic exploration of the contract should be "attacker", "owner" or "combo1"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1292)
<!-- Reviewable:end -->
