### PR TITLE
Fix multiple symbolic args solidity_create_contract

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -92,7 +92,7 @@ class ManticoreEVM(ManticoreBase):
             m.finalize()
     """
 
-    def make_symbolic_buffer(self, size, name=None):
+    def make_symbolic_buffer(self, size, name=None, avoid_collisions=False):
         """ Creates a symbolic buffer of size bytes to be used in transactions.
             You can operate on it normally and add constraints to manticore.constraints
             via manticore.constrain(constraint_expression)
@@ -106,10 +106,10 @@ class ManticoreEVM(ManticoreBase):
                                 data=symbolic_data,
                                 value=100000 )
         """
-        avoid_collisions = False
         if name is None:
             name = 'TXBUFFER'
             avoid_collisions = True
+
         return self.constraints.new_array(index_bits=256, name=name, index_max=size, value_bits=8, taint=frozenset(), avoid_collisions=avoid_collisions)
 
     def make_symbolic_value(self, nbits=256, name=None):
@@ -384,8 +384,6 @@ class ManticoreEVM(ManticoreBase):
         self._executor.subscribe('on_symbolic_sha3', self._on_symbolic_sha3_callback)
         self._executor.subscribe('on_concrete_sha3', self._on_concrete_sha3_callback)
 
-        self._initargs_id = -1
-
     @property
     def world(self):
         """ The world instance or None if there is more than one state """
@@ -541,8 +539,7 @@ class ManticoreEVM(ManticoreBase):
             Make a reasonable serialization of the symbolic argument types
         """
         # FIXME this is more naive than reasonable.
-        self._initargs_id += 1
-        return ABI.deserialize(types, self.make_symbolic_buffer(32, name=f'INITARGS{self._initargs_id}'))
+        return ABI.deserialize(types, self.make_symbolic_buffer(32, name='INITARGS', avoid_collisions=True))
 
     def solidity_create_contract(self, source_code, owner, name=None, contract_name=None, libraries=None,
                                  balance=0, address=None, args=(), solc_bin=None, solc_remaps=[],


### PR DESCRIPTION
The `test_create_contract_two_instances` test was crashing before
this PR, due to calling `make_symbolic_buffer` twice with the same
buffer name (`'INITARGS'`) in `make_symbolic_arguments`.

Here's an example of such crash (from a bit different test code/when I
was developing it, but the idea/error is the same):
```
Error
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/home/dc/manticore_project/tests/eth_general.py", line 432, in test_create_two_instances_of_contract_no_args
    contract2 = self.mevm.solidity_create_contract(source_code, owner=owner, args=None)
  File "/home/dc/manticore_project/manticore/ethereum/manticore.py", line 587, in solidity_create_contract
    args = self.make_symbolic_arguments(constructor_types)
  File "/home/dc/manticore_project/manticore/ethereum/manticore.py", line 542, in make_symbolic_arguments
    return ABI.deserialize(types, self.make_symbolic_buffer(32, name="INITARGS"))
  File "/home/dc/manticore_project/manticore/ethereum/manticore.py", line 113, in make_symbolic_buffer
    return self.constraints.new_array(index_bits=256, name=name, index_max=size, value_bits=8, taint=frozenset(), avoid_collisions=avoid_collisions)
  File "/home/dc/manticore_project/manticore/core/smtlib/constraints.py", line 348, in new_array
    raise ValueError(f'Name {name} already used')
ValueError: Name INITARGS already used
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1294)
<!-- Reviewable:end -->
