### PR TITLE
Add symbol resolution feature for binary analysis

### DIFF
--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -137,33 +137,6 @@ class Manticore(ManticoreBase):
         for cb in self._hooks.get(None, []):
             cb(state)
 
-    #############################################################################
-    #############################################################################
-    #############################################################################
-    # Move all the following elsewhere Not all manticores have this
-    def _get_symbol_address(self, symbol):
-        '''
-        Return the address of |symbol| within the binary
-        '''
-
-        # XXX(yan) This is a bit obtuse; once PE support is updated this should
-        # be refactored out
-        if self._binary_type == 'ELF':
-            self._binary_obj = ELFFile(open(self._binary, 'rb'))
-
-        if self._binary_obj is None:
-            return NotImplementedError("Symbols aren't supported")
-
-        for section in self._binary_obj.iter_sections():
-            if not isinstance(section, SymbolTableSection):
-                continue
-
-            symbols = section.get_symbol_by_name(symbol)
-            if not symbols:
-                continue
-
-            return symbols[0].entry['st_value']
-
 
 def _make_initial_state(binary_path, **kwargs):
     with open(binary_path, 'rb') as f:

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -102,6 +102,8 @@ class Decree(Platform):
         '''
         programs = programs.split(",")
         super().__init__(path=programs[0], **kwargs)
+
+        self.program = programs[0]
         self.clocks = 0
         self.files = []
         self.syscall_trace = []

--- a/tests/test_manticore.py
+++ b/tests/test_manticore.py
@@ -64,6 +64,11 @@ class ManticoreTest(unittest.TestCase):
             def tmp(state):
                 pass
 
+    def test_symbol_resolution(self):
+        dirname = os.path.dirname(__file__)
+        self.m = Manticore(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
+        self.assertTrue(self.m.resolve('sbrk'), 0x449ee0)
+
     def test_integration_basic_stdin(self):
         import struct
         dirname = os.path.dirname(__file__)

--- a/tests/test_manticore.py
+++ b/tests/test_manticore.py
@@ -69,6 +69,10 @@ class ManticoreTest(unittest.TestCase):
         self.m = Manticore(os.path.join(dirname, 'binaries', 'basic_linux_amd64'))
         self.assertTrue(self.m.resolve('sbrk'), 0x449ee0)
 
+    def test_symbol_resolution_fail(self):
+        with self.assertRaises(ValueError):
+            self.m.resolve("does_not_exist")
+
     def test_integration_basic_stdin(self):
         import struct
         dirname = os.path.dirname(__file__)


### PR DESCRIPTION
This PR adds symbol resolution through `core.Manticore.resolve()` for ELF binaries through DWARF debug information and symbol tables.

```
@m.hook(m.resolve('MyLib_function', line=4))
def hook(state):
    m.terminate()

@m.hook(m.resolve('MyLib_otherfunc'))
def hook(state):
    m.abort()
```

If the user does not supply a `line` argument, the first instance of the symbol will be resolved and its memory address will be hooked on.

I have yet to implement unit tests (if necessary), but this initial implementation seems to be working. Feedback for improvements and optimizations welcome!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1302)
<!-- Reviewable:end -->
