### PR TITLE
Fix logging regressions

### DIFF
--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,8 +1,6 @@
 from .utils import config, log
 from .utils.helpers import issymbolic, istainted
 
-log.init_logging()
-
 consts = config.get_group('main')
 consts.add('stdin_size', default=256, description='Maximum symbolic stdin size')
 

--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -509,7 +509,6 @@ class Executor(Eventful):
                     # Notify this worker is done
                     self._publish('will_terminate_state', current_state, current_state_id, e)
                     current_state = None
-                    logger.setState(None)
 
             assert current_state is None or self.is_shutdown()
 

--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -25,8 +25,6 @@ from ..utils.helpers import issymbolic
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 
 logger = logging.getLogger(__name__)
-log.init_logging()
-
 
 class ManticoreBase(Eventful):
     '''

--- a/manticore/ethereum/detectors.py
+++ b/manticore/ethereum/detectors.py
@@ -9,7 +9,6 @@ from ..core.plugin import Plugin
 
 
 logger = logging.getLogger(__name__)
-log.init_logging()
 
 
 class DetectorClassification:

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -28,7 +28,6 @@ from ..utils import config, log
 from ..utils.helpers import PickleSerializer, issymbolic
 
 logger = logging.getLogger(__name__)
-log.init_logging()
 
 
 def flagged(flag):

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -12,7 +12,6 @@ from ..utils import log, config
 from ..utils.helpers import issymbolic
 
 logger = logging.getLogger(__name__)
-log.init_logging()
 
 consts = config.get_group('main')
 

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -6,7 +6,7 @@ manticore_verbosity = 0
 DEFAULT_LOG_LEVEL = logging.WARNING
 all_loggers = set()
 default_factory = logging.getLogRecordFactory()
-logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s %(message)s")
+logfmt = ("%(asctime)s: [%(process)d] %(name)s:%(levelname)s %(message)s")
 handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter(logfmt)
 handler.setFormatter(formatter)
@@ -50,9 +50,6 @@ class ContextFilter(logging.Filter):
             return self.colored_levelname_format.format(self.color_map[levelname], levelname)
 
     def filter(self, record):
-        if hasattr(self, 'stateid') and isinstance(self.stateid, int):
-            record.stateid = f'[{self.stateid}]'
-
         record.name = self.summarized_name(record.name)
         record.levelname = self.colored_level_name(record.levelname)
         return True
@@ -61,10 +58,9 @@ class ContextFilter(logging.Filter):
 ctxfilter = ContextFilter()
 
 
-class LoggerWithStateId(logging.Logger):
+class CustomLogger(logging.Logger):
     '''
-    Custom Logger class that can grab the correct verbosity level from this module, and has a 'stateid' field
-    so that the ContextFilter won't break custom loggers.
+    Custom Logger class that can grab the correct verbosity level from this module
     '''
 
     def __init__(self, name, level=DEFAULT_LOG_LEVEL, *args):
@@ -77,20 +73,8 @@ class LoggerWithStateId(logging.Logger):
             self.addFilter(ctxfilter)
             self.propagate = False
 
-    def setState(self, stateid):
-        self.filters[0].stateid = stateid
 
-
-logging.setLoggerClass(LoggerWithStateId)
-
-
-def factory(name, *args, **kwargs):
-    record = default_factory(name, *args, **kwargs)
-    record.stateid = ''
-    return record
-
-
-logging.setLogRecordFactory(factory)
+logging.setLoggerClass(CustomLogger)
 
 
 def disable_colors():

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -2,11 +2,21 @@ import logging
 import sys
 import types
 
+manticore_verbosity = 0
+DEFAULT_LOG_LEVEL = logging.WARNING
+all_loggers = set()
+default_factory = logging.getLogRecordFactory()
+logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s %(message)s")
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(logfmt)
+handler.setFormatter(formatter)
+
 
 class ContextFilter(logging.Filter):
     '''
     This is a filter which injects contextual information into the log.
     '''
+
     def summarized_name(self, name):
         '''
         Produce a summarized record name
@@ -18,10 +28,10 @@ class ContextFilter(logging.Filter):
 
     colors_disabled = False
 
-    coloring = {u'DEBUG':u'magenta', u'WARNING':u'yellow',
-        u'ERROR':u'red', u'INFO':u'blue'}
-    colors =  dict(zip([u'black', u'red', u'green', u'yellow',
-        u'blue', u'magenta', u'cyan', u'white'], map(str, range(30, 30 + 8))))
+    coloring = {u'DEBUG': u'magenta', u'WARNING': u'yellow',
+                u'ERROR': u'red', u'INFO': u'blue'}
+    colors = dict(zip([u'black', u'red', u'green', u'yellow',
+                       u'blue', u'magenta', u'cyan', u'white'], map(str, range(30, 30 + 8))))
 
     color_map = {}
     for k, v in coloring.items():
@@ -42,57 +52,55 @@ class ContextFilter(logging.Filter):
     def filter(self, record):
         if hasattr(self, 'stateid') and isinstance(self.stateid, int):
             record.stateid = f'[{self.stateid}]'
-        else:
-            record.stateid = ''
 
         record.name = self.summarized_name(record.name)
         record.levelname = self.colored_level_name(record.levelname)
         return True
 
 
-manticore_verbosity = 0
-all_loggers = []
+ctxfilter = ContextFilter()
+
+
+class LoggerWithStateId(logging.Logger):
+    '''
+    Custom Logger class that can grab the correct verbosity level from this module, and has a 'stateid' field
+    so that the ContextFilter won't break custom loggers.
+    '''
+
+    def __init__(self, name, level=DEFAULT_LOG_LEVEL, *args):
+        super().__init__(name, min(get_verbosity(name), level), *args)
+        all_loggers.add(name)
+        self.initialized = False
+
+        if name.startswith('manticore'):
+            self.addHandler(handler)
+            self.addFilter(ctxfilter)
+            self.propagate = False
+
+    def setState(self, stateid):
+        self.filters[0].stateid = stateid
+
+
+logging.setLoggerClass(LoggerWithStateId)
+
+
+def factory(name, *args, **kwargs):
+    record = default_factory(name, *args, **kwargs)
+    record.stateid = ''
+    return record
+
+
+logging.setLogRecordFactory(factory)
 
 
 def disable_colors():
     ContextFilter.colors_disabled = True
 
 
-def init_logging(default_level=logging.WARNING):
-    global all_loggers
-    loggers = logging.getLogger().manager.loggerDict.keys()
-
-    ctxfilter = ContextFilter()
-    logfmt = ("%(asctime)s: [%(process)d]%(stateid)s %(name)s:%(levelname)s"
-              " %(message)s")
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(logfmt)
-    handler.setFormatter(formatter)
-    for name in loggers:
-        logger = logging.getLogger(name)
-        if not name.startswith('manticore'):
-            continue
-        if name in all_loggers:
-            continue
-        logger.addHandler(handler)
-        logger.propagate = False
-        logger.setLevel(default_level)
-        logger.addFilter(ctxfilter)
-        logger.setState = types.MethodType(loggerSetState, logger)
-        all_loggers.append(name)
-    set_verbosity(manticore_verbosity)
-
-
-def loggerSetState(logger, stateid):
-    logger.filters[0].stateid = stateid
-
-
-def set_verbosity(setting):
-    global manticore_verbosity, all_loggers
-    zero = [(x, logging.WARNING) for x in all_loggers]
-    levels = [
+def get_levels():
+    return [
         # 0
-        zero,
+        [(x, DEFAULT_LOG_LEVEL) for x in all_loggers],
         # 1
         [
             ('manticore.manticore', logging.INFO),
@@ -128,6 +136,8 @@ def set_verbosity(setting):
         ]
     ]
 
+
+def get_verbosity(logger_name):
     def match(name, pattern):
         '''
         Pseudo globbing that only supports full fields. 'a.*.d' matches 'a.b.d'
@@ -143,18 +153,19 @@ def set_verbosity(setting):
                 return False
         return True
 
-    def glob(lst, expression):
-        return [name for name in lst if match(name, expression)]
+    for level in range(manticore_verbosity, 0, -1):
+        for pattern, log_level in get_levels()[level]:
+            if match(logger_name, pattern):
+                return log_level
+    return DEFAULT_LOG_LEVEL
 
-    # Takes a value and ensures it's in a certain range
-    def clamp(val, minimum, maximum):
-        return sorted((minimum, val, maximum))[1]
 
-    clamped = clamp(setting, 0, len(levels) - 1)
-    for level in range(clamped + 1):
-        for pattern, log_level in levels[level]:
-            for logger_name in glob(all_loggers, pattern):
-                logger = logging.getLogger(logger_name)
-                logger.setLevel(log_level)
-
-    manticore_verbosity = clamped
+def set_verbosity(setting):
+    global manticore_verbosity
+    manticore_verbosity = min(max(setting, 0), len(get_levels()) - 1)
+    for logger_name in all_loggers:
+        logger = logging.getLogger(logger_name)
+        # min because more verbosity == lower numbers
+        # This means if you explicitly call setLevel somewhere else in the source, and it's *more*
+        # verbose, it'll stay that way even if manticore_verbosity is 0.
+        logger.setLevel(min(get_verbosity(logger_name), logger.getEffectiveLevel()))

--- a/tests/eth_benchmark.py
+++ b/tests/eth_benchmark.py
@@ -13,12 +13,6 @@ from manticore.ethereum import ManticoreEVM, DetectInvalid, DetectIntegerOverflo
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-# FIXME(mark): Remove these two lines when logging works for ManticoreEVM
-from manticore.utils.log import init_logging, set_verbosity
-init_logging()
-set_verbosity(0)
-
-
 class EthBenchmark(unittest.TestCase):
     """ https://consensys.net/diligence/evm-analyzer-benchmark-suite/ """
     def setUp(self):

--- a/tests/eth_detectors.py
+++ b/tests/eth_detectors.py
@@ -16,12 +16,6 @@ from eth_general import make_mock_evm_state
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# FIXME(mark): Remove these two lines when logging works for ManticoreEVM
-from manticore.utils.log import init_logging, set_verbosity
-
-init_logging()
-set_verbosity(0)
-
 
 class EthDetectorTest(unittest.TestCase):
     """

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -297,6 +297,7 @@ class EthAbiTests(unittest.TestCase):
         selector = ABI.function_selector('memberId(address)')
         function_ref_data = address + selector + b'\0'*8
         # build tx call data
+        call_data = func_id + function_ref_data
         parsed_func_id, args = ABI.deserialize(spec, call_data)
         self.assertEqual(parsed_func_id, func_id)
         self.assertEqual(((0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359, selector),), args)

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -26,11 +26,6 @@ from manticore.utils.deprecated import ManticoreDeprecationWarning
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# FIXME(mark): Remove these two lines when logging works for ManticoreEVM
-from manticore.utils.log import init_logging
-
-init_logging()
-
 
 def make_mock_evm_state():
     cs = ConstraintSet()
@@ -86,7 +81,7 @@ class EthAbiTests(unittest.TestCase):
 
 
         calldata = binascii.unhexlify(b'9de4886f9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d9d')
-        returndata = b'' 
+        returndata = b''
         md = m.get_metadata(contract_account)
         self.assertEqual(md.parse_tx(calldata, returndata), 'test1(899826498278242188854817720535123270925417291165, 71291600040229971300002528024956868756719167029433602173313100742126907268509)')
 
@@ -302,7 +297,6 @@ class EthAbiTests(unittest.TestCase):
         selector = ABI.function_selector('memberId(address)')
         function_ref_data = address + selector + b'\0'*8
         # build tx call data
-        call_data = func_id + function_ref_data 
         parsed_func_id, args = ABI.deserialize(spec, call_data)
         self.assertEqual(parsed_func_id, func_id)
         self.assertEqual(((0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359, selector),), args)
@@ -623,7 +617,7 @@ class EthTests(unittest.TestCase):
                                                     owner=owner_account,
                                                     balance=0)
 
-        #Some global expression `sym_add1` 
+        #Some global expression `sym_add1`
         sym_add1 = m.make_symbolic_value(name='sym_add1')
         #Let's constrain it on the global fake constraintset
         m.constrain(sym_add1>0)
@@ -631,7 +625,7 @@ class EthTests(unittest.TestCase):
         #Symb tx 1
         contract_account.add(sym_add1, caller=attacker_account)
 
-        # A new!? global expression 
+        # A new!? global expression
         sym_add2 = m.make_symbolic_value(name='sym_add2')
         #constraints involve old expression.  Some states may get invalidated by this. Should this be accepted?
         m.constrain(sym_add1 > sym_add2)
@@ -1157,10 +1151,10 @@ class EthSolidityMetadataTests(unittest.TestCase):
     def test_overloaded_functions_and_events(self):
         with disposable_mevm() as m:
             source_code = '''
-            contract C {                
+            contract C {
                 function f() public payable returns (uint) {}
                 function f(string a) public {}
-                
+
                 event E(uint);
                 event E(uint, string);
             }
@@ -1226,14 +1220,14 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
 
     def test_jmpdest_check(self):
         '''
-            This test that jumping to a JUMPDEST in the operand of a PUSH should 
+            This test that jumping to a JUMPDEST in the operand of a PUSH should
             be treated as an INVALID instruction.
             https://github.com/trailofbits/manticore/issues/1169
         '''
-    
+
         constraints = ConstraintSet()
         world = evm.EVMWorld(constraints)
-    
+
         world.create_account(address=0xf572e5295c57f15886f9b263e2f6d2d6c7b5ec6,
                              balance=100000000000000000000000,
                              code=EVMAsm.assemble('PUSH1 0x5b\nPUSH1 0x1\nJUMP')
@@ -1243,7 +1237,7 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
         data = ''
         caller = 0xcd1722f3947def4cf144679da39c4c32bdc35681
         value = 1000000000000000000
-        bytecode = world.get_code(address)        
+        bytecode = world.get_code(address)
         gas = 100000
 
         new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, world=world, gas=gas)
@@ -1259,7 +1253,7 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
                 returndata = e.data
 
         self.assertEqual(result, 'THROW')
-        
+
 
     def test_delegatecall_env(self):
         '''
@@ -1346,7 +1340,7 @@ class EthPluginTests(unittest.TestCase):
             contract FallbackCounter {
                 uint public fallbackCounter = 123;
                 uint public otherCounter = 456;
-    
+
                 function other() {
                     otherCounter += 1;
                 }


### PR DESCRIPTION
The recent refactor required us to move around some of the import statements in order to avoid circular imports. This caused certain modules to only be imported (and thus, create loggers) _after_ the final call to `log.init_logging`. As as result, they'd stay on the default verbosity instead of the verbosity specified via `manticore.verbosity`. This patch creates a custom Logger class that will set the correct verbosity level for each logger at the time that it's initialized, so we no longer need a separate initialization routine. 

Should be ready to go, just waiting on Travis. 