### PR TITLE
Fix eth private func calls

### DIFF
--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -8,14 +8,14 @@ from ..exceptions import EthereumError
 HashesEntry = namedtuple('HashesEntry', 'signature func_id')
 
 
-class EVMAccount(object):
+class EVMAccount:
     def __init__(self, address=None, manticore=None, name=None):
-        """ Encapsulates an account.
+        """
+        Encapsulates an account.
 
-            :param address: the address of this account
-            :type address: 160 bit long integer
-            :param manticore: the controlling Manticore
-
+        :param address: the address of this account
+        :type address: 160 bit long integer
+        :param manticore: the controlling Manticore
         """
         self._manticore = manticore
         self._address = address
@@ -31,8 +31,8 @@ class EVMAccount(object):
     @property
     def name_(self):
         """
-        This is named this way to avoid naming collisions with Solidity functions/data, since EVMContract inherits
-        this.
+        This is named this way to avoid naming collisions with Solidity functions/data,
+        since EVMContract inherits this.
         """
         return self._name
 
@@ -48,41 +48,38 @@ class EVMAccount(object):
 
 
 class EVMContract(EVMAccount):
-    """ An EVM account
-
-        Note: The private methods of this class begin with a double underscore to
-        avoid function name collisions with Solidity functions that begin with
-        a single underscore
     """
+    An EVM account
 
+    Note: The private methods of this class begin with a double underscore to avoid function
+    name collisions with Solidity functions that begin with a single underscore.
+    """
     def __init__(self, default_caller=None, **kwargs):
-        """ Encapsulates a contract account.
-            :param default_caller: the default caller address for any transaction
+        """
+        Encapsulates a contract account.
 
+        :param default_caller: the default caller address for any transaction
         """
         super().__init__(**kwargs)
         self._default_caller = default_caller
         self._hashes = None
+        self._initialized = False
 
     def add_function(self, signature):
         func_id = ABI.function_selector(signature)
         func_name = str(signature.split('(')[0])
-        if func_name.startswith('__') or func_name in {'add_function', 'address', 'name_'}:
-            # TODO(mark): is this actually true? is there anything actually wrong with a solidity name beginning w/ an underscore?
-            raise EthereumError("Function name ({}) is internally reserved".format(func_name))
+        if func_name.startswith('_EVMContract__') or func_name in {'add_function', 'address', 'name_'}:
+            raise EthereumError(f"Function name ({func_name}) is internally reserved")
         entry = HashesEntry(signature, func_id)
         if func_name in self._hashes:
             self._hashes[func_name].append(entry)
             return
         if func_id in {entry.func_id for entries in self._hashes.values() for entry in entries}:
-            raise EthereumError("A function with the same hash as {} is already defined".format(func_name))
+            raise EthereumError(f"A function with the same hash as {func_name} is already defined")
         self._hashes[func_name] = [entry]
 
-    def __null_func(self):
-        pass
-
     def __init_hashes(self):
-        #initializes self._hashes lazy
+        # initializes self._hashes lazy
         if self._hashes is None and self._manticore is not None:
             self._hashes = {}
             md = self._manticore.get_metadata(self._address)
@@ -90,51 +87,51 @@ class EVMContract(EVMAccount):
                 for signature in md.function_signatures:
                     self.add_function(signature)
             # It was successful, no need to re-run. _init_hashes disabled
-            self.__init_hashes = self.__null_func
+            self._initialized = True
 
-    def __getattribute__(self, name):
-        """ If this is a contract account of which we know the functions hashes,
-            this will build the transaction for the function call.
-
-            Example use::
-
-                #call function `add` on contract_account with argument `1000`
-                contract_account.add(1000)
-
+    def __getattr__(self, name):
         """
-        if not name.startswith('_'):
+        If this is a contract account of which we know the functions hashes,
+        this will build the transaction for the function call.
+
+        Example use:
+            # call function `add` on contract_account with argument `1000`
+            contract_account.add(1000)
+        """
+        if not self._initialized:
             self.__init_hashes()
-            if self._hashes is not None and name in self._hashes.keys():
-                def f(*args, signature: Optional[str]=None, caller=None, value=0, gas=0xffffffffffff, **kwargs):
-                    try:
-                        if signature:
-                            if f'{name}{signature}' not in {entry.signature for entries in self._hashes.values() for entry in entries}:
-                                raise EthereumError(
-                                    f'Function: `{name}` has no such signature`\n'
-                                    f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
 
-                            tx_data = ABI.function_call(f'{name}{signature}', *args)
-                        else:
-                            entries = self._hashes[name]
-                            if len(entries) > 1:
-                                sig = entries[0].signature[len(name):]
-                                raise EthereumError(
-                                    f'Function: `{name}` has multiple signatures but `signature` is not '
-                                    f'defined! Example: `account.{name}(..., signature="{sig}")`\n'
-                                    f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
+        if name in self._hashes:
+            def f(*args, signature: Optional[str]=None, caller=None, value=0, gas=0xffffffffffff, **kwargs):
+                try:
+                    if signature:
+                        if f'{name}{signature}' not in {entry.signature for entries in self._hashes.values() for entry in entries}:
+                            raise EthereumError(
+                                f'Function: `{name}` has no such signature\n'
+                                f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
 
-                            tx_data = ABI.function_call(str(entries[0].signature), *args)
-                    except KeyError as e:
-                        raise e
+                        tx_data = ABI.function_call(f'{name}{signature}', *args)
+                    else:
+                        entries = self._hashes[name]
+                        if len(entries) > 1:
+                            sig = entries[0].signature[len(name):]
+                            raise EthereumError(
+                                f'Function: `{name}` has multiple signatures but `signature` is not '
+                                f'defined! Example: `account.{name}(..., signature="{sig}")`\n'
+                                f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
 
-                    if caller is None:
-                        caller = self._default_caller
+                        tx_data = ABI.function_call(str(entries[0].signature), *args)
+                except KeyError as e:
+                    raise e
 
-                    self._manticore.transaction(caller=caller,
-                                                address=self._address,
-                                                value=value,
-                                                data=tx_data,
-                                                gas=gas)
-                return f
+                if caller is None:
+                    caller = self._default_caller
 
-        return object.__getattribute__(self, name)
+                self._manticore.transaction(caller=caller,
+                                            address=self._address,
+                                            value=value,
+                                            data=tx_data,
+                                            gas=gas)
+            return f
+
+        raise AttributeError(f"The contract {self._name} doesn't have {name} function.")

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -105,7 +105,7 @@ class EVMContract(EVMAccount):
                         if f'{name}{signature}' not in {entry.signature for entries in self.__hashes.values() for entry in entries}:
                             raise EthereumError(
                                 f'Function: `{name}` has no such signature\n'
-                                f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
+                                f'Known signatures: {[entry.signature[len(name):] for entry in self.__hashes[name]]}')
 
                         tx_data = ABI.function_call(f'{name}{signature}', *args)
                     else:
@@ -115,7 +115,7 @@ class EVMContract(EVMAccount):
                             raise EthereumError(
                                 f'Function: `{name}` has multiple signatures but `signature` is not '
                                 f'defined! Example: `account.{name}(..., signature="{sig}")`\n'
-                                f'Known signatures: {[entry.signature[len(name):] for entry in self._hashes[name]]}')
+                                f'Known signatures: {[entry.signature[len(name):] for entry in self.__hashes[name]]}')
 
                         tx_data = ABI.function_call(str(entries[0].signature), *args)
                 except KeyError as e:

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -62,7 +62,7 @@ class EVMContract(EVMAccount):
         """
         super().__init__(**kwargs)
         self.__default_caller = default_caller
-        self.__hashes = None
+        self.__hashes = {}
         self.__initialized = False
 
     def add_function(self, signature):
@@ -79,15 +79,12 @@ class EVMContract(EVMAccount):
         self.__hashes[func_name] = [entry]
 
     def __init_hashes(self):
-        # initializes self._hashes lazy
-        if self.__hashes is None and self._manticore is not None:
-            self.__hashes = {}
-            md = self._manticore.get_metadata(self._address)
-            if md is not None:
-                for signature in md.function_signatures:
-                    self.add_function(signature)
-            # It was successful, no need to re-run. _init_hashes disabled
-            self.__initialized = True
+        md = self._manticore.get_metadata(self._address)
+        if md is not None:
+            for signature in md.function_signatures:
+                self.add_function(signature)
+        # It was successful, no need to re-run. _init_hashes disabled
+        self.__initialized = True
 
     def __getattr__(self, name):
         """

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -68,14 +68,19 @@ class EVMContract(EVMAccount):
     def add_function(self, signature):
         func_id = ABI.function_selector(signature)
         func_name = str(signature.split('(')[0])
-        if func_name.startswith('_EVMContract__') or func_name in {'add_function', 'address', 'name_'}:
+
+        if func_name in self.__dict__ or func_name in {'add_function', 'address', 'name_'}:
             raise EthereumError(f"Function name ({func_name}) is internally reserved")
+
         entry = HashesEntry(signature, func_id)
+
         if func_name in self.__hashes:
             self.__hashes[func_name].append(entry)
             return
+
         if func_id in {entry.func_id for entries in self.__hashes.values() for entry in entries}:
             raise EthereumError(f"A function with the same hash as {func_name} is already defined")
+
         self.__hashes[func_name] = [entry]
 
     def __init_hashes(self):

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -461,6 +461,25 @@ class EthTests(unittest.TestCase):
         self.assertEqual(len(contracts), len(set(c.address for c in contracts)))
         self.assertEqual(len(contracts), len(set(c.name_ for c in contracts)))
 
+    def test_contract_create_and_call_underscore_function(self):
+        source_code = 'contract A { function _f(uint x) returns (uint) { return x + 0x1234; } }'
+
+        owner = self.mevm.create_account()
+        contract = self.mevm.solidity_create_contract(source_code, owner=owner, args=[])
+
+        contract._f(123)
+
+    def test_contract_create_and_access_non_existing_function(self):
+        source_code = 'contract A {}'
+
+        owner = self.mevm.create_account()
+        contract = self.mevm.solidity_create_contract(source_code, owner=owner, args=[])
+
+        with self.assertRaises(AttributeError) as e:
+            _ = contract.xyz
+
+        self.assertEqual(str(e.exception), "The contract contract0 doesn't have xyz function.")
+
     def test_invalid_function_signature(self):
         source_code = '''
         contract Test{


### PR DESCRIPTION
Proper fix for the (https://github.com/trailofbits/manticore/pull/1303) bug where we couldn't call a contract function that was prefixed with an underscore.

Before this PR we checked for attributes starting with an underscore in `__getattribute__`. If we found one - we used `object.__getattribute__(self, name)`.

This PR removes the check and uses `__getattr__` instead. This way, we don't have to handle the cases when we want to access `EVMContract` attributes as they just work as is.

Side note: https://stackoverflow.com/questions/3278077/difference-between-getattr-vs-getattribute

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1306)
<!-- Reviewable:end -->
