### PR TITLE
Remove Py3 redundant object inheritance

### DIFF
--- a/manticore/core/executor.py
+++ b/manticore/core/executor.py
@@ -40,7 +40,7 @@ def sync(f):
     return newFunction
 
 
-class Policy(object):
+class Policy:
     ''' Base class for prioritization of state search '''
 
     def __init__(self, executor, *args, **kwargs):

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ConstraintSet(object):
+class ConstraintSet:
     ''' Constraint Sets
 
         An object containing a set of constraints. Serves also as a factory for

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -2,7 +2,7 @@ from functools import reduce
 import uuid
 
 
-class Expression(object):
+class Expression:
     ''' Abstract taintable Expression. '''
 
     def __init__(self, taint=()):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -6,7 +6,7 @@ import operator
 logger = logging.getLogger(__name__)
 
 
-class Visitor(object):
+class Visitor:
     ''' Class/Type Visitor
 
        Inherit your class visitor from this one and get called on a different

--- a/manticore/ethereum/abi.py
+++ b/manticore/ethereum/abi.py
@@ -12,7 +12,7 @@ from ..exceptions import EthereumError
 logger = logging.getLogger(__name__)
 
 
-class ABI(object):
+class ABI:
     """
         This class contains methods to handle the ABI.
         The Application Binary Interface is the standard way to interact with

--- a/manticore/ethereum/account.py
+++ b/manticore/ethereum/account.py
@@ -8,7 +8,7 @@ from ..exceptions import EthereumError
 HashesEntry = namedtuple('HashesEntry', 'signature func_id')
 
 
-class EVMAccount(object):
+class EVMAccount:
     def __init__(self, address=None, manticore=None, name=None):
         """ Encapsulates an account.
 

--- a/manticore/ethereum/solidity.py
+++ b/manticore/ethereum/solidity.py
@@ -6,7 +6,7 @@ from .abi import ABI
 from ..utils.deprecated import deprecated
 
 
-class SolidityMetadata(object):
+class SolidityMetadata:
 
     @staticmethod
     def function_signature_for_name_and_inputs(name: str, inputs: Sequence[Mapping[str, Any]]) -> str:

--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -96,11 +96,11 @@ class ConcretizeArgument(CpuException):
 SANE_SIZES = {8, 16, 32, 64, 80, 128, 256}
 
 
-class Operand(object):
+class Operand:
     """This class encapsulates how to access operands (regs/mem/immediates) for
     different CPUs
     """
-    class MemSpec(object):
+    class MemSpec:
         '''
         Auxiliary class wraps capstone operand 'mem' attribute. This will
         return register names instead of Ids
@@ -182,7 +182,7 @@ class Operand(object):
 #  only from the cpu implementation
 
 
-class RegisterFile(object):
+class RegisterFile:
     def __init__(self, aliases=None):
         # dict mapping from alias register name ('PC') to actual register
         # name ('RIP')
@@ -235,7 +235,7 @@ class RegisterFile(object):
         return self._alias(register) in self.all_registers
 
 
-class Abi(object):
+class Abi:
     '''
     Represents the ability to extract arguments from the environment and write
     back a result.

--- a/manticore/native/cpu/cpufactory.py
+++ b/manticore/native/cpu/cpufactory.py
@@ -2,7 +2,7 @@ from .x86 import AMD64Cpu, I386Cpu, AMD64LinuxSyscallAbi, I386LinuxSyscallAbi, I
 from .arm import Armv7Cpu, Armv7CdeclAbi, Armv7LinuxSyscallAbi
 
 
-class CpuFactory(object):
+class CpuFactory:
     _cpus = {
         'i386': I386Cpu,
         'amd64': AMD64Cpu,

--- a/manticore/native/cpu/disasm.py
+++ b/manticore/native/cpu/disasm.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 import capstone as cs
 
 
-class Instruction(object):
+class Instruction:
     """Capstone-like instruction to be used internally
     """
     @property
@@ -43,7 +43,7 @@ class Instruction(object):
         pass
 
 
-class Disasm(object):
+class Disasm:
     """Abstract class for different disassembler interfaces"""
 
     def __init__(self, disasm):

--- a/manticore/native/cpu/register.py
+++ b/manticore/native/cpu/register.py
@@ -1,7 +1,7 @@
 from ...core.smtlib import Operators, BitVec, Bool
 
 
-class Register(object):
+class Register:
     '''
     Generic variable width register. For 1 bit registers, allows writes of types
     bool and int, but always reads back bools.

--- a/manticore/platforms/decree.py
+++ b/manticore/platforms/decree.py
@@ -29,7 +29,7 @@ class SymbolicSyscallArgument(ConcretizeRegister):
         super().__init__(cpu, reg_name, message, policy)
 
 
-class Socket(object):
+class Socket:
     @staticmethod
     def pair():
         a = Socket()
@@ -1056,7 +1056,7 @@ class SDecree(Decree):
         return 0
 
 
-class DecreeEmu(object):
+class DecreeEmu:
 
     RANDOM = 0
 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -50,7 +50,7 @@ def to_signed(i):
     return Operators.ITEBV(256, i < TT255, i, i - TT256)
 
 
-class Transaction(object):
+class Transaction:
     __slots__ = '_sort', 'address', 'price', 'data', 'caller', 'value', 'depth', '_return_data', '_result', 'gas'
 
     def __init__(self, sort, address, price, data, caller, value, gas=0, depth=None, result=None, return_data=None):
@@ -408,7 +408,7 @@ class EVM(Eventful):
                          'evm_read_code',
                          'decode_instruction', 'execute_instruction', 'concrete_sha3', 'symbolic_sha3'}
 
-    class transact(object):
+    class transact:
         "Emulate PyProperty_Type() in Objects/descrobject.c"
 
         def __init__(self, pre=None, pos=None, doc=None):

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -62,7 +62,7 @@ def mode_from_flags(file_flags):
     return {os.O_RDWR: 'rb+', os.O_RDONLY: 'rb', os.O_WRONLY: 'wb'}[file_flags & 7]
 
 
-class File(object):
+class File:
     def __init__(self, path, flags):
         # TODO: assert file is seekable; otherwise we should save what was
         # read from/written to the state
@@ -305,7 +305,7 @@ class SymbolicFile(File):
             self.array[i] = data[i - self.pos]
 
 
-class SocketDesc(object):
+class SocketDesc:
     '''
     Represents a socket descriptor (i.e. value returned by socket(2)
     '''
@@ -316,7 +316,7 @@ class SocketDesc(object):
         self.protocol = protocol
 
 
-class Socket(object):
+class Socket:
     def stat(self):
         from collections import namedtuple
         stat_result = namedtuple('stat_result', ['st_mode', 'st_ino', 'st_dev', 'st_nlink', 'st_uid', 'st_gid',

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -15,7 +15,7 @@ from capstone import *
 logger = logging.getLogger(__name__)
 
 
-class UnicornEmulator(object):
+class UnicornEmulator:
     '''
     Helper class to emulate a single instruction via Unicorn.
     '''

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -130,7 +130,7 @@ class CacheDict(OrderedDict):
         self._hits -= purge_count
 
 
-class StateSerializer(object):
+class StateSerializer:
     """
     StateSerializer can serialize and deserialize :class:`~manticore.core.state.State` objects from and to
     stream-like objects.

--- a/manticore/utils/nointerrupt.py
+++ b/manticore/utils/nointerrupt.py
@@ -2,7 +2,7 @@ import signal
 import logging
 
 
-class WithKeyboardInterruptAs(object):
+class WithKeyboardInterruptAs:
     def __init__(self, callback):
         if callback is None:
             callback = lambda *args, **kwargs: None

--- a/scripts/binaryninja/manticore_viz/__init__.py
+++ b/scripts/binaryninja/manticore_viz/__init__.py
@@ -25,7 +25,7 @@ class Singleton(type):
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
 
-class TraceVisualizer(object):
+class TraceVisualizer:
     __metaclass__ = Singleton
     def __init__(self, view, workspace, base=0x0, live=False):
         self.view = view

--- a/tests/auto/make_tests.py
+++ b/tests/auto/make_tests.py
@@ -66,7 +66,7 @@ def forAllTests(decorator):
 class CPUTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/mockmem.py
+++ b/tests/mockmem.py
@@ -9,7 +9,7 @@ class Memory:  # todo Mock
         raise NotImplementedError("putchar")
 
 
-class Mem(object):
+class Mem:
     ''' Mocking class for memory '''
 
     def __init__(self, mem):
@@ -44,7 +44,7 @@ class Mem(object):
         return True
 
 
-class SMem(object):
+class SMem:
     ''' Mocking class for memory '''
 
     def __init__(self, array, init):

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -411,7 +411,7 @@ class ABITest(unittest.TestCase):
         cpu.push(1, cpu.address_bit_size)
         cpu.push(0x1234, cpu.address_bit_size)
 
-        class Kls(object):
+        class Kls:
             def method(self, a, b):
                 return a+b
 

--- a/tests/test_cpu_automatic.py
+++ b/tests/test_cpu_automatic.py
@@ -7,7 +7,7 @@ from manticore.native.memory import *
 
 class CPUTest(unittest.TestCase):
     _multiprocess_can_split_ = True
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/test_cpu_manual.py
+++ b/tests/test_cpu_manual.py
@@ -11,7 +11,7 @@ from manticore.core.smtlib import BitVecOr, operator, Bool
 from tests import mockmem
 from functools import reduce
 
-class ROOperand(object):
+class ROOperand:
     ''' Mocking class for operand ronly '''
     def __init__(self, size, value):
         self.size = size
@@ -53,7 +53,7 @@ class SymCPUTest(unittest.TestCase):
         'OF': 0x00800,
         'IF': 0x00200,}
 
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -8,7 +8,7 @@ from manticore.native.memory import *
 
 class CPUTest(unittest.TestCase):
     _multiprocess_can_split_ = True
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -142,7 +142,7 @@ class LinuxTest(unittest.TestCase):
     def test_syscall_events(self):
         nr_fstat64 = 197
 
-        class Receiver(object):
+        class Receiver:
             def __init__(self):
                 self.nevents = 0
             def will_exec(self, pc, i):

--- a/tests/test_slam_regre.py
+++ b/tests/test_slam_regre.py
@@ -7,7 +7,7 @@ from manticore.native.memory import *
 
 class CPUTest(unittest.TestCase):
     _multiprocess_can_split_ = True
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7,7 +7,7 @@ from manticore.platforms import linux
 from manticore.utils.event import Eventful
 
 
-class FakeMemory(object):
+class FakeMemory:
     def __init__(self):
         self._constraints = None
 
@@ -29,7 +29,7 @@ class FakeCpu(Eventful):
     def memory(self):
         return self._memory
 
-class FakePlatform(object):
+class FakePlatform:
     def __init__(self):
         self._constraints = None
         self.procs = [FakeCpu()]

--- a/tests/test_x86.py
+++ b/tests/test_x86.py
@@ -38,7 +38,7 @@ class CPUTest(unittest.TestCase):
             b = bytes([ord(c) for c in b])
         return super().assertEqual(a, b)
 
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size

--- a/tests/test_x86_pcmpxstrx.py
+++ b/tests/test_x86_pcmpxstrx.py
@@ -34,7 +34,7 @@ def forAllTests(decorator):
 class CPUTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
-    class ROOperand(object):
+    class ROOperand:
         ''' Mocking class for operand ronly '''
         def __init__(self, size, value):
             self.size = size


### PR DESCRIPTION
There's no more old/new style classes in Py3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1307)
<!-- Reviewable:end -->
