### PR TITLE
Minor state/platform refactor

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -89,9 +89,6 @@ class StateBase(Eventful):
         # Events are lost in serialization and fork !!
         self.forward_events_from(platform)
 
-        # FIXME(felipe) This should go into some event callback in a plugin (start_run?)
-        self._init_context()
-
     def __getstate__(self):
         state = super().__getstate__()
         state['platform'] = self._platform
@@ -418,24 +415,3 @@ class StateBase(Eventful):
                 else:
                     assert b != 0
         return data
-
-    @property
-    def cpu(self):
-        return self._platform.current
-
-    @property
-    def mem(self):
-        return self._platform.current.memory
-
-    # FIXME(felipe) Remove this
-    def _init_context(self):
-        self.context['branches'] = dict()
-
-    # FIXME(felipe) Remove this
-    def record_branch(self, target):
-        branches = self.context['branches']
-        branch = (self.cpu._last_pc, target)
-        if branch in branches:
-            branches[branch] += 1
-        else:
-            branches[branch] = 1

--- a/manticore/native/state.py
+++ b/manticore/native/state.py
@@ -3,6 +3,13 @@ from ..native.memory import ConcretizeMemory, MemoryException
 
 
 class State(StateBase):
+    @property
+    def cpu(self):
+        return self._platform.current
+
+    @property
+    def mem(self):
+        return self._platform.current.memory
 
     def execute(self):
         from .cpu.abstractcpu import ConcretizeRegister  # must be here, otherwise we get circular imports

--- a/manticore/platforms/platform.py
+++ b/manticore/platforms/platform.py
@@ -6,9 +6,10 @@ class OSException(Exception):
 
 
 class SyscallNotImplemented(OSException):
-    ''' Exception raised when you try to call an unimplemented
-        system call. Go to linux.py and add it!
-    '''
+    """
+    Exception raised when you try to call an unimplemented system call.
+    Go to linux.py and add it!
+    """
 
     def __init__(self, idx, name):
         msg = f'Syscall index "{idx}" ({name}) not implemented.'
@@ -24,9 +25,9 @@ class ConcretizeSyscallArgument(OSException):
 
 
 class Platform(Eventful):
-    '''
-    Base class for all operating system platforms.
-    '''
+    """
+    Base class for all platforms e.g. operating systems or virtual machines.
+    """
 
     def __init__(self, path, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
The `StateBase` class had two properties that are only used in native engines: `cpu` and `mem`.

Those two used `self._platform.current` and that `current` is a property in linux and decree platforms that returns current process platfrom (?).

The PR also removes unused/redundant code in `StateBase`: `_init_context` and `record_branch` methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1320)
<!-- Reviewable:end -->
