### PR TITLE
Make is_human a property

### DIFF
--- a/manticore/ethereum/detectors.py
+++ b/manticore/ethereum/detectors.py
@@ -217,7 +217,7 @@ class DetectReentrancySimple(Detector):
         return f'{self.name}.call_locations'
 
     def will_open_transaction_callback(self, state, tx):
-        if tx.is_human():
+        if tx.is_human:
             state.context[self._context_key] = []
 
     def will_evm_execute_instruction_callback(self, state, instruction, arguments):
@@ -277,14 +277,14 @@ class DetectReentrancyAdvanced(Detector):
 
     def will_open_transaction_callback(self, state, tx):
         # Reset reading log on new human transactions
-        if tx.is_human():
+        if tx.is_human:
             state.context[self._read_storage_name] = set()
             state.context['{:s}.locations'.format(self.name)] = dict()
 
     def did_close_transaction_callback(self, state, tx):
         world = state.platform
         #Check if it was an internal tx
-        if not tx.is_human():
+        if not tx.is_human:
             # Check is the tx was successful
             if tx.result:
                 # Check if gas was enough for a reentrancy attack
@@ -482,7 +482,7 @@ class DetectIntegerOverflow(Detector):
             self._check_finding(state, what)
         elif mnemonic == 'RETURN':
             world = state.platform
-            if world.current_transaction.is_human():
+            if world.current_transaction.is_human:
                 # If an overflowded value is returned to a human
                 offset, size = arguments
                 data = world.current_vm.read_buffer(offset, size)
@@ -528,7 +528,7 @@ class DetectUnusedRetVal(Detector):
 
     def will_open_transaction_callback(self, state, tx):
         # Reset reading log on new human transactions
-        if tx.is_human():
+        if tx.is_human:
             state.context[self._stack_name] = []
         state.context[self._stack_name].append(set())
 

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1175,7 +1175,7 @@ class ManticoreEVM(ManticoreBase):
 
         #we initiated the Tx; we need process the outcome for now.
         #Fixme incomplete.
-        if tx.is_human():
+        if tx.is_human:
             if tx.sort == 'CREATE':
                 if tx.result == 'RETURN':
                     world.set_code(tx.address, tx.return_data)

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -200,14 +200,14 @@ class Transaction:
     @property
     def is_human(self):
         """
-        Returns whether this is a human or internal transaction.
+        Returns whether this is a transaction made by human (in a script).
 
         As an example for:
             contract A { function a(B b) { b.b(); } }
             contract B { function b() {} }
 
-        The A.a(B) call made in a script is a human transaction
-        but the call it makes: b.b() makes an internal transaction.
+        Calling `B.b()` makes a human transaction.
+        Calling `A.a(B)` makes a human transaction which makes an internal transaction (b.b()).
         """
         return self.depth == 0
 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -200,7 +200,7 @@ class Transaction:
     @property
     def is_human(self):
         """
-        Whether it is a human or internal transaction.
+        Returns whether this is a human or internal transaction.
 
         As an example for:
             contract A { function a(B b) { b.b(); } }

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -197,7 +197,18 @@ class Transaction:
     def result(self):
         return self._result
 
+    @property
     def is_human(self):
+        """
+        Whether it is a human or internal transaction.
+
+        As an example for:
+            contract A { function a(B b) { b.b(); } }
+            contract B { function b() {} }
+
+        The A.a(B) call made in a script is a human transaction
+        but the call it makes: b.b() makes an internal transaction.
+        """
         return self.depth == 0
 
     @property
@@ -1867,7 +1878,7 @@ class EVMWorld(Platform):
                 # Increment the nonce if this transaction created a contract, or if it was called by a non-contract account
                 self.increase_nonce(tx.caller)
 
-        if tx.is_human():
+        if tx.is_human:
             for deleted_account in self._deleted_accounts:
                 if deleted_account in self._world_state:
                     del self._world_state[deleted_account]


### PR DESCRIPTION
This PR changes the `Transaction.is_human` method to a property and adds a docstring that explains what we understand as a "human transaction" along with an example.

The motivation for this change is that we had two places in the codebase where we used it **as if it would be a property while it wasn't**. This code is probably bugged - probably as I hadn't confirmed it with an example but certainly making `if tx.is_human:` would always be true:

https://github.com/trailofbits/manticore/blob/580b358678c471b252c381d1733b98a6a2ad9bde/manticore/ethereum/plugins.py#L51-L54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1323)
<!-- Reviewable:end -->
