### PR TITLE
Explicitly require Python>=3.6 when using CLI

### DIFF
--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.version_info < (3, 6):
+    print('Manticore requires Python 3.6 or higher.')
+    sys.exit(-1)
+
 from .utils import config, log
 from .utils.helpers import issymbolic, istainted
 

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -7,10 +7,6 @@ import sys
 
 import pkg_resources
 
-if sys.version_info < (3, 6):
-    print('Manticore requires Python 3.6 or higher.')
-    sys.exit(-1)
-
 from .core.manticore import ManticoreBase
 from .utils import config, log
 

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -7,6 +7,10 @@ import sys
 
 import pkg_resources
 
+if sys.version_info < (3, 6):
+    print('Manticore requires Python 3.6 or higher.')
+    sys.exit(-1)
+
 from .core.manticore import ManticoreBase
 from .utils import config, log
 


### PR DESCRIPTION
We have this in setup.py python_requires but it doesn't work with old pip versions and we get reports that Manticore throws a SyntaxError (on a f-string literal :/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1331)
<!-- Reviewable:end -->
