### PR TITLE
Refactor solver

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -14,22 +14,20 @@
 # Once you Solver.check() it the status is changed to sat or unsat (or unknown+exception)
 # You can create new symbols operate on them. The declarations will be sent to the smtlib process when needed.
 # You can add new constraints. A new constraint may change the state from {None, sat} to {sat, unsat, unknown}
-from abc import ABCMeta, abstractmethod
-from subprocess import PIPE, Popen, check_output
-
-from ...exceptions import Z3NotFoundError, SolverError, SolverUnknown, TooManySolutions
-from . import operators as Operators
-from .expression import *
-from .constraints import *
-import logging
-import re
+import collections
 import shlex
 import time
+from subprocess import PIPE, Popen
+
+import re
+from abc import ABCMeta, abstractmethod
+
+from . import operators as Operators
+from .constraints import *
 from .visitors import *
-from ...utils.helpers import issymbolic, istainted, taint_with, get_taints
+from ...exceptions import Z3NotFoundError, SolverError, SolverUnknown, TooManySolutions
 from ...utils import config
-import io
-import collections
+from ...utils.helpers import issymbolic
 
 logger = logging.getLogger(__name__)
 

--- a/manticore/ethereum/detectors.py
+++ b/manticore/ethereum/detectors.py
@@ -2,9 +2,8 @@ import hashlib
 import logging
 from contextlib import contextmanager
 
-from ..utils import log
-from ..core.smtlib import Operators, taint_with, get_taints, Constant
-from ..utils.helpers import istainted, issymbolic
+from ..core.smtlib import Operators, Constant
+from ..utils.helpers import istainted, issymbolic, taint_with, get_taints
 from ..core.plugin import Plugin
 
 


### PR DESCRIPTION
Gives love to the solver:
* reorganised imports (PyCharm auto optimize imports)
* compile regular expressions just once (!)
* refactored docstrings: fixed some parameter specifications, more type adnotations, use `"""` instead of `'''` (see https://www.python.org/dev/peps/pep-0257/)
* refactored the `_recv` method - moved its internal `readline` method to `__readline_and_count` method (so the `readline` method is not recreated each time we call `_recv`)
* refactored `_check()` method: it is now named `_is_sat()` and returns bool (or raises a `SolverUnknown` exception) instead of returning `'sat'` or `'unsat'` string

As a side effect of optimizing imports, detectors file imports have been fixed.

Note that some of the changes should speed up the solver a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1334)
<!-- Reviewable:end -->
