### PR TITLE
evm: fix _check_jumpdest when run with detectors

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -972,7 +972,10 @@ class EVM(Eventful):
 
         if should_check_jumpdest:
             self._check_jumpdest = False
-            if self.pc not in self._valid_jumpdests:
+
+            pc = self.pc.value if isinstance(self.pc, Constant) else self.pc
+
+            if pc not in self._valid_jumpdests:
                 raise InvalidOpcode()
 
     def _advance(self, result=None, exception=False):

--- a/tests/eth_general.py
+++ b/tests/eth_general.py
@@ -582,6 +582,31 @@ class EthTests(unittest.TestCase):
         with self.assertRaises(EthereumError):
             contract_account.ret(self.mevm.make_symbolic_value())
 
+    def test_check_jumpdest_symbolic_pc(self):
+        """
+        In Manticore 0.2.4 (up to 6804661) when run with detector, the EVM.pc is a BitVecConstant and so a check
+        in EVM._check_jumpdest: `self.pc in self._valid_jumpdests` failed.
+
+        This test checks the fix for this issue.
+        """
+        class D(Detector):
+            pass
+
+        self.mevm.register_detector(D())
+        c = self.mevm.solidity_create_contract('''
+        contract C {
+            function mul(int256 a, int256 b) {
+                int256 c = a * b;
+                require(c / a == b);
+            }
+        }
+        ''', owner=self.mevm.create_account(balance=1000))
+
+        c.mul(1, 2)
+
+        self.assertEqual(self.mevm.count_running_states(), 1)
+        self.assertEqual(self.mevm.count_terminated_states(), 0)
+
     def test_gen_testcase_only_if(self):
         source_code = '''
         contract Test {


### PR DESCRIPTION
When ManticoreEVM is run with detectors, the self.pc in EVM is a `Constant` (as we need to taint it).

Because of that, the check:
```
            if pc not in self._valid_jumpdests:
                raise InvalidOpcode()
```
failed - i.e. we raised an `InvalidOpcode` because we checked if the list contains the `Constant` object and not its value.

This commit fixes this issue.