### PR TITLE
Ensure native deps (better error message)

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -40,6 +40,7 @@ def main():
     if args.argv[0].endswith('.sol'):
         ethereum_main(args, logger)
     else:
+        install_helper.ensure_native_deps()
         native_main(args, logger)
 
 


### PR DESCRIPTION
The error message for first time users can be a bit confusing ("NameError: name 'native_main' is not defined"), if native deps isn't installed and the user is running the program against a binary file.

```
$ pip3 install manticore
[...]
$ manticore ./app
Traceback (most recent call last):
  File "/home/user/.local/bin/manticore", line 11, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/manticore/__main__.py", line 43, in main
    native_main(args, logger)
NameError: name 'native_main' is not defined
```

After this patch, the code will instead return "ImportError: Missing some packages for native binary analysis. Please install them with pip install manticore[native]."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1367)
<!-- Reviewable:end -->
