### PR TITLE
Fix ethereum Manticore API issue, where creating a new account with the code field failed

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -744,7 +744,7 @@ class ManticoreEVM(ManticoreBase):
             :type balance: int or BitVecVariable
             :param address: the address for the new account (optional)
             :type address: int
-            :param code: the runtime code for the new account (None means normal account) (optional)
+            :param code: the runtime code for the new account (None means normal account), str or bytes (optional)
             :param name: a global account name eg. for use as reference in the reports (optional)
             :return: an EVMAccount
         """
@@ -767,7 +767,7 @@ class ManticoreEVM(ManticoreBase):
             raise EthereumError("Balance invalid type")
 
         if isinstance(code, str):
-            code = bytearray(code)
+            code = bytes(code, "utf-8")
         if code is not None and not isinstance(code, (bytearray, Array)):
             raise EthereumError("code bad type")
 

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -768,7 +768,7 @@ class ManticoreEVM(ManticoreBase):
 
         if isinstance(code, str):
             code = bytes(code, "utf-8")
-        if code is not None and not isinstance(code, (bytearray, Array)):
+        if code is not None and not isinstance(code, (bytes, Array)):
             raise EthereumError("code bad type")
 
         # Address check

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -530,6 +530,16 @@ class EthTests(unittest.TestCase):
         # is actually deleted at the end of the human tx
         self.assertEqual(ABI.deserialize('uint', to_constant(self.mevm.world.transactions[-1].return_data)), 42)
 
+    def test_create_bytecode_contract(self):
+        account = self.mevm.create_account(code="0x00AAFF")
+        self.assertIsNotNone(account)
+
+        account = self.mevm.create_account(code=bytes("0x00AAFF","utf-8"))
+        self.assertIsNotNone(account)
+
+        with self.assertRaises(EthereumError) as ctx:
+            self.mevm.create_account(code=bytearray("0x00AAFF", "utf-8"))
+
     def test_states_querying_1325(self):
         """
         Tests issue 1325.


### PR DESCRIPTION
Fixes #1370

I assumed bytes to be the correct type since the evm implementation uses it. Also the code field is immutable so it seemed like a good fit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1371)
<!-- Reviewable:end -->
