### PR TITLE
More informative errors for unimplemented EVM features

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2532,7 +2532,7 @@ class EVMWorld(Platform):
         sort, address, price, data, caller, value, gas = self._pending_transaction
 
         if sort not in {'CALL', 'CREATE', 'DELEGATECALL', 'CALLCODE'}:
-            raise EVMException('Type of transaction not supported')
+            raise EVMException(f"Transaction type '{sort}' not supported")
 
         if self.depth > 0:
             assert price is None, "Price should not be used in internal transactions"

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2533,6 +2533,7 @@ class EVMWorld(Platform):
 
         if sort not in {'CALL', 'CREATE', 'DELEGATECALL', 'CALLCODE'}:
             if sort == 'STATICCALL':
+                # TODO: Remove this once Issue #1168 is resolved
                 raise EVMException(f"The STATICCALL opcode is not yet supported; see https://github.com/trailofbits/manticore/issues/1168")
             else:
                 raise EVMException(f"Transaction type '{sort}' not supported")

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2532,7 +2532,10 @@ class EVMWorld(Platform):
         sort, address, price, data, caller, value, gas = self._pending_transaction
 
         if sort not in {'CALL', 'CREATE', 'DELEGATECALL', 'CALLCODE'}:
-            raise EVMException(f"Transaction type '{sort}' not supported")
+            if sort == 'STATICCALL':
+                raise EVMException(f"The STATICCALL opcode is not yet supported; see https://github.com/trailofbits/manticore/issues/1168")
+            else:
+                raise EVMException(f"Transaction type '{sort}' not supported")
 
         if self.depth > 0:
             assert price is None, "Price should not be used in internal transactions"


### PR DESCRIPTION
For example, this provides a much more informative error about the lack of support for `STATICCALL` (see #1168).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1387)
<!-- Reviewable:end -->
