### PR TITLE
Internal failed tx fix

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2580,9 +2580,8 @@ class EVMWorld(Platform):
 
         if failed:
             self._close_transaction('TXERROR', rollback=True)
-
         #Transaction to normal account
-        if sort in ('CALL', 'DELEGATECALL', 'CALLCODE') and not self.get_code(address):
+        elif sort in ('CALL', 'DELEGATECALL', 'CALLCODE') and not self.get_code(address):
             self._close_transaction('STOP')
             
     def dump(self, stream, state, mevm, message):


### PR DESCRIPTION
Failed internal transactions mistakenly used to pop 2 tx from the callstack and leave a STOP instead 
Fixes issue #1391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1392)
<!-- Reviewable:end -->
