### PR TITLE
Fix logic for solc relative path

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -253,7 +253,8 @@ class ManticoreEVM(ManticoreBase):
 
         if not working_dir:
             working_dir = os.getcwd()
-        elif relative_filepath.startswith(working_dir):
+
+        if relative_filepath.startswith(working_dir):
             relative_filepath = relative_filepath[len(working_dir) + 1:]
 
         # If someone pass an absolute path to the file, we don't have to put cwd


### PR DESCRIPTION
This allows solc-select (which runs in docker) to correctly access the relative path of a sol file.

I ran into an issue on Mac when using `solc-select` and running tests locally.

While this fix only makes _some_ tests cases pass, to get all `nosetests tests/ethereum` passing on Mac (and while using `solc-select`), crytic/solc-select/issues/8 needs to be resolved or taken into account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1393)
<!-- Reviewable:end -->
