### PR TITLE
Generates a more sensible symbolic default for constructor arguments

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -580,12 +580,12 @@ class ManticoreEVM(ManticoreBase):
         from . import abitypes
         return self._make_symbolic_arguments(abitypes.parse(types))
 
-
     def _make_symbolic_arguments(self, ty):
         ''' This makes a tuple of symbols to be used as arguments of type ty'''
 
         # If the types describe an string or an array this will produce strings
         # or arrays of a default size.
+        #TODO: add a configuration constant for these two
         default_string_size = 32
         default_array_size = 32
         if ty[0] in ('int', 'uint'):
@@ -606,14 +606,13 @@ class ManticoreEVM(ManticoreBase):
             result = []
             rep = ty[1]
             if rep is None:
-                rep = default_array_size # ?
+                rep = default_array_size
             for _ in range(rep):
                 result.append(self._make_symbolic_arguments(ty[2]))
         else:
             raise NotImplemented
 
         return result
-
 
     def json_create_contract(self, jfile, owner=None, name=None, contract_name=None, balance=0, gas=None, network_id=None, args=()):
         """ Creates a solidity contract based on a truffle json artifact.

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -577,8 +577,43 @@ class ManticoreEVM(ManticoreBase):
         """
             Make a reasonable serialization of the symbolic argument types
         """
-        # FIXME this is more naive than reasonable.
-        return ABI.deserialize(types, self.make_symbolic_buffer(32, name='INITARGS', avoid_collisions=True))
+        from . import abitypes
+        return self._make_symbolic_arguments(abitypes.parse(types))
+
+
+    def _make_symbolic_arguments(self, ty):
+        ''' This makes a tuple of symbols to be used as arguments of type ty'''
+
+        # If the types describe an string or an array this will produce strings
+        # or arrays of a default size.
+        default_string_size = 32
+        default_array_size = 32
+        if ty[0] in ('int', 'uint'):
+            result = self.make_symbolic_value()
+        elif ty[0] == 'bytesM':
+            result = self.make_symbolic_buffer(size=ty[1])
+        elif ty[0] == 'function':
+            address = self.make_symbolic_value()
+            func_id = self.make_symbolic_buffer(size=4)
+            result = (address, func_id)
+        elif ty[0] in ('bytes', 'string'):
+            result = self.make_symbolic_buffer(size=default_string_size)
+        elif ty[0] == 'tuple':
+            result = ()
+            for ty_i in ty[1]:
+                result += (self._make_symbolic_arguments(ty_i), )
+        elif ty[0] == 'array':
+            result = []
+            rep = ty[1]
+            if rep is None:
+                rep = default_array_size # ?
+            for _ in range(rep):
+                result.append(self._make_symbolic_arguments(ty[2]))
+        else:
+            raise NotImplemented
+
+        return result
+
 
     def json_create_contract(self, jfile, owner=None, name=None, contract_name=None, balance=0, gas=None, network_id=None, args=()):
         """ Creates a solidity contract based on a truffle json artifact.

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -473,6 +473,15 @@ class EthTests(unittest.TestCase):
 
         self.assertEqual(str(e.exception), 'The number of values to serialize is greater than the number of types')
 
+    def test_create_contract_with_string_args(self):
+        source_code = 'contract DontWork1{ string s; constructor(string memory s_) public{ s = s_;} }'
+        owner = self.mevm.create_account()
+
+        sym_args = self.mevm.make_symbolic_arguments('(string)')
+        contract = self.mevm.solidity_create_contract(source_code, owner=owner, args=sym_args)
+        self.assertIsNotNone(contract)
+        self.assertEqual(self.mevm.count_states(), 1)
+
     def test_create_contract_two_instances(self):
         source_code = 'contract A { constructor(uint32 arg) {} }'
         owner = self.mevm.create_account()


### PR DESCRIPTION
When types consumed by a constructor are known this patch generates a reasonable set of arguments. Notably restricting the  size of dynamic arguments. 

Fix #1412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1414)
<!-- Reviewable:end -->
