### PR TITLE
Performance optimization : use set instead of list

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -454,9 +454,9 @@ class AMD64RegFile(RegisterFile):
         for name in ('AF', 'CF', 'DF', 'IF', 'OF', 'PF', 'SF', 'ZF'):
             self.write(name, False)
 
-        self._all_registers = tuple(self._table) + \
-            ('FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'EFLAGS', 'RFLAGS') + \
-            tuple(self._aliases)
+        self._all_registers = set(self._table.keys()) | \
+            set(['FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'EFLAGS', 'RFLAGS']) | \
+            set(self._aliases.keys())
 
     @property
     def all_registers(self):
@@ -467,7 +467,7 @@ class AMD64RegFile(RegisterFile):
         return self._canonical_registers
 
     def __contains__(self, register):
-        return register in self.all_registers
+        return register in self._all_registers
 
     def _set_bv(self, register_id, register_size, offset, size, reset, value):
         if isinstance(value, int):


### PR DESCRIPTION
Found by profiling ais3_crackme from manticore-examples

Profiling result ie
`cat cprof.txt | awk '{print $2 $0}' | sort -n | tail`
gives
```
1.929   825101    1.929    0.000    4.210    0.000 helpers.py:13(issymbolic)
2.862      277    2.862    0.010    2.866    0.010 {method 'readline' of '_io.TextIOWrapper' objects}
3.491  1173293    3.491    0.000    3.742    0.000 x86.py:469(__contains__)
8.196   161737    8.196    0.000    8.196    0.000 {built-in method posix.read}
```

So x86.py:469(__contains__) is the second place where we spend the most time

The patch replaces the list by a set to get better performance for the `in` operation : O(1) instead of O(n)

Thanks to https://stackoverflow.com/questions/20234935/python-in-operator-speed/20234990#20234990

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1415)
<!-- Reviewable:end -->
