### PR TITLE
Hardcode expected matching concrete registers

### DIFF
--- a/tests/native/test_unicorn_concrete.py
+++ b/tests/native/test_unicorn_concrete.py
@@ -55,7 +55,8 @@ class ManticornTest(unittest.TestCase):
                 concrete_regs[reg] = getattr(st.platform.current, reg)
 
         for reg in should_match:
-            self.assertEqual(concrete_regs[reg], normal_regs[reg])
+            self.assertEqual(concrete_regs[reg], normal_regs[reg],
+                             f"Mismatch in {reg}: {concrete_regs[reg]} != {normal_regs[reg]}")
 
     def test_integration_basic_stdout(self):
         self.m.run()

--- a/tests/native/test_unicorn_concrete.py
+++ b/tests/native/test_unicorn_concrete.py
@@ -35,39 +35,29 @@ class ManticornTest(unittest.TestCase):
         self.m.register_plugin(RegisterCapturePlugin())
         '''
 
-    @unittest.skip("Registers simply not matching for now")
     def test_register_comparison(self):
         self.m.run()
         self.concrete_instance.run()
 
+        should_match = {'RAX', 'RDX', 'RBX', 'RSP', 'RBP', 'RSI', 'RDI', 'R8', 'R9', 'R10', 'R12', 'R13', 'R14',
+                        'R15', 'RIP', 'YMM1', 'YMM2', 'YMM3', 'YMM5', 'YMM6', 'YMM7', 'YMM8', 'YMM11', 'YMM12',
+                        'YMM13', 'YMM14', 'YMM15', 'CS', 'DS', 'ES', 'SS', 'FS', 'GS', 'AF', 'CF', 'DF', 'IF', 'OF',
+                        'SF', 'FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'FPSW', 'FPCW'}
 
         concrete_regs = {}
         normal_regs = {}
         for st in self.m.all_states:
-            all_regs = st.platform.current.all_registers
-            for reg in all_regs:
+            for reg in should_match:
                 normal_regs[reg] = getattr(st.platform.current, reg)
 
         for st in self.concrete_instance.all_states:
-            all_regs = st.platform.current.canonical_registers
-            for reg in all_regs:
+            for reg in should_match:
                 concrete_regs[reg] = getattr(st.platform.current, reg)
 
-        for reg in concrete_regs:
-            print (reg, concrete_regs[reg], normal_regs[reg])
-
-        for reg in concrete_regs:
+        for reg in should_match:
             self.assertEqual(concrete_regs[reg], normal_regs[reg])
 
-        '''
-        concrete_regs = self.concrete_instance.context['regs']
-        normal_regs = self.m.context['regs']
-        for reg in concrete_regs.keys():
-            self.assertEqual(concrete_regs[reg],normal_regs[reg])
-        '''
-
-
-    def test_integration_basic_stdin(self):
+    def test_integration_basic_stdout(self):
         self.m.run()
         self.concrete_instance.run()
 

--- a/tests/native/test_unicorn_concrete.py
+++ b/tests/native/test_unicorn_concrete.py
@@ -40,8 +40,7 @@ class ManticornTest(unittest.TestCase):
         self.concrete_instance.run()
 
         should_match = {'RAX', 'RDX', 'RBX', 'RSP', 'RBP', 'RSI', 'RDI', 'R8', 'R9', 'R10', 'R12', 'R13', 'R14',
-                        'R15', 'RIP', 'YMM1', 'YMM2', 'YMM3', 'YMM5', 'YMM6', 'YMM7', 'YMM8', 'YMM11', 'YMM12',
-                        'YMM13', 'YMM14', 'YMM15', 'CS', 'DS', 'ES', 'SS', 'FS', 'GS', 'AF', 'CF', 'DF', 'IF', 'OF',
+                        'R15', 'RIP', 'CS', 'DS', 'ES', 'SS', 'FS', 'GS', 'AF', 'CF', 'DF', 'IF', 'OF',
                         'SF', 'FP0', 'FP1', 'FP2', 'FP3', 'FP4', 'FP5', 'FP6', 'FP7', 'FPSW', 'FPCW'}
 
         concrete_regs = {}


### PR DESCRIPTION
Rather than skipping this unit test, we should check that the set of known-matching registers still match in order to avoid any regressions.

Ideally, we should figure out why _all_ of the registers don't match, but it's yet unclear whether this is an actual issue, or if the final register differences are natural discrepancies that we can safely ignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1437)
<!-- Reviewable:end -->
