### PR TITLE
Unicorn dependency update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL dockerfile_maintenance=trailofbits
 
 ENV LANG C.UTF-8
 
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip git wget
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip git wget python
 
 # Install solc 0.4.25 and validate it
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
@@ -16,6 +16,8 @@ RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-sta
 
 # If this fails, the solc-static-linux binary has changed while it should not.
 RUN [ "c9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580  /usr/bin/solc" = "$(sha256sum /usr/bin/solc)" ]
+
+RUN pip3 install -U pip
 
 ADD . /manticore
 RUN cd manticore && pip3 install .[native]

--- a/manticore/utils/emulate.py
+++ b/manticore/utils/emulate.py
@@ -101,6 +101,9 @@ class ConcreteUnicornEmulator:
         self.registers = set(self._cpu.canonical_registers)
         # The last 8 canonical registers of x86 are individual flags; replace with the eflags
         self.registers -= self.flag_registers
+        # TODO(eric_k): unicorn@778171fc9546c1fc3d1341ff1151eab379848ea0 doesn't like writing to
+        # the FS register, and it will segfault or hang.
+        self.registers -= {'FS'}
         self.registers.add('EFLAGS')
 
         for reg in self.registers:
@@ -343,6 +346,11 @@ class ConcreteUnicornEmulator:
             return
         if reg in self.flag_registers:
             self._emu.reg_write(self._to_unicorn_id('EFLAGS'), self._cpu.read_register('EFLAGS'))
+            return
+        # TODO(eric_k): unicorn@778171fc9546c1fc3d1341ff1151eab379848ea0 doesn't like writing to
+        # the FS register, and it will segfault or hang.
+        if reg in {'FS'}:
+            logger.warning(f"Skipping {reg} write. Unicorn unsupported register write.")
             return
         self._emu.reg_write(self._to_unicorn_id(reg), val)
 

--- a/manticore/utils/fallback_emulator.py
+++ b/manticore/utils/fallback_emulator.py
@@ -233,6 +233,10 @@ class UnicornEmulator:
             registers |= set(['XMM0', 'XMM1', 'XMM2', 'XMM3', 'XMM4', 'XMM5', 'XMM6', 'XMM7',
                               'XMM8', 'XMM9', 'XMM10', 'XMM11', 'XMM12', 'XMM13', 'XMM14', 'XMM15'])
 
+            # TODO(eric_k): unicorn@778171fc9546c1fc3d1341ff1151eab379848ea0 doesn't like writing to
+            # the FS register, and it will segfault or hang.
+            registers -= {'FS'}
+
         # XXX(yan): This concretizes the entire register state. This is overly
         # aggressive. Once capstone adds consistent support for accessing
         # referred registers, make this only concretize those registers being

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -16,7 +16,10 @@ function install_mcore {
         EXTRAS="dev"
     fi
 
-    pip install --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
+    # Unicorn needs python2
+    export UNICORN_QEMU_FLAGS="--python=/usr/bin/python"
+
+    pip install -I --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
 }
 
 function install_cc_env {
@@ -33,5 +36,3 @@ if [ "$1" != "env" ]; then
     install_solc
     install_mcore $1
 fi
-
-

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def rtd_dependent_deps():
 native_deps = [
     'capstone==4.0.1',
     'pyelftools',
-    'unicorn',
+    'unicorn @ git+https://github.com/unicorn-engine/unicorn.git@778171fc9546c1fc3d1341ff1151eab379848ea0#subdirectory=bindings/python&egg=unicorn-1.0.1.post0',
 ]
 
 extra_require = {


### PR DESCRIPTION
This PR updates the Unicorn dependency.

Unfortunately, since Unicorn has not had an official release, I have pinned it to the latest commit in master at this time of PR. The method of pinning to the git commit is done in `setup.py`, but if there is a better way, I'm open to changing this. 

The git version pinning is only available in the latest `pip` versions, so I had to update Travis's pip version in the install script. Furthermore, in order to make `pip` use the git-pinned version, I had to add the `-I` option:
```
  -I, --ignore-installed      Ignore the installed packages (reinstalling instead).
```
but it still seems to use the cache for already-existing dependencies that aren't updated remotely.

There is at least one issue when switching to the newest Unicorn, and that issue involves Unicorn hanging when trying to write a value to the `FS` register in X86.

Closes #1434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1440)
<!-- Reviewable:end -->
