### PR TITLE
Relegate coverage file to plugin

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -55,7 +55,7 @@ def parse_arguments():
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--context', type=str, default=None,
                         help=argparse.SUPPRESS)
-    parser.add_argument('--coverage', type=str, default=None,
+    parser.add_argument('--coverage', type=str, default='visited.txt',
                         help='Where to write the coverage data')
     parser.add_argument('--names', type=str, default=None,
                         help=argparse.SUPPRESS)

--- a/manticore/native/cli.py
+++ b/manticore/native/cli.py
@@ -11,12 +11,9 @@ def native_main(args, _logger):
 
     # Default plugins for now.. FIXME REMOVE!
     m.register_plugin(InstructionCounter())
-    m.register_plugin(Visited())
+    m.register_plugin(Visited(args.coverage))
     m.register_plugin(Tracer())
     m.register_plugin(RecordSymbolicBranches())
-
-    # Fixme(felipe) remove this, move to plugin
-    m.coverage_file = args.coverage
 
     if args.names is not None:
         m.apply_model_hooks(args.names)

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -44,7 +44,6 @@ class Manticore(ManticoreBase):
 
         # Move the following into a linux plugin
         self._assertions = {}
-        self._coverage_file = None
         self.trace = None
         # sugar for 'will_execute_instruction"
         self._hooks = {}
@@ -85,15 +84,6 @@ class Manticore(ManticoreBase):
 
         for cb in self._model_hooks[pc]:
             cb(state)
-
-    @property
-    def coverage_file(self):
-        return self._coverage_file
-
-    @coverage_file.setter
-    @ManticoreBase.at_not_running
-    def coverage_file(self, path):
-        self._coverage_file = path
 
     def _generate_testcase_callback(self, state, testcase, message):
         self._output.save_testcase(state, testcase, message)


### PR DESCRIPTION
Refactored out the `coverage_file` param to get exclusively passed to the `Visited` plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1442)
<!-- Reviewable:end -->
