### PR TITLE
x86: movhps support

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -5508,6 +5508,27 @@ class X86Cpu(Cpu):
             dest.write(Operators.CONCAT(128, src.read(), value))
 
     @instruction
+    def MOVHPS(cpu, dest, src):
+        """
+        Moves high packed single-precision floating-point value.
+
+        Moves two packaed single-precision floating-point values from the source operand
+        (second operand) to the destination operand (first operand). The source and destination
+        operands can be an XMM register or a 64-bit memory location. The instruction allows
+        single-precision floating-point values to be moved to and from the high quadword of
+        an XMM register and memory. It cannot be used for register to register or memory to
+        memory moves. When the destination operand is an XMM register, the low quadword
+        of the register remains unchanged.
+        """
+        if src.size == 128:
+            assert dest.size == 64
+            dest.write(Operators.EXTRACT(src.read(), 64, 64))
+        else:
+            assert src.size == 64 and dest.size == 128
+            value = Operators.EXTRACT(dest.read(), 0, 64)  # low part
+            dest.write(Operators.CONCAT(128, src.read(), value))
+
+    @instruction
     def PSUBB(cpu, dest, src):
         """
         Packed subtract.

--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -5512,7 +5512,7 @@ class X86Cpu(Cpu):
         """
         Moves high packed single-precision floating-point value.
 
-        Moves two packaed single-precision floating-point values from the source operand
+        Moves two packed single-precision floating-point values from the source operand
         (second operand) to the destination operand (first operand). The source and destination
         operands can be an XMM register or a 64-bit memory location. The instruction allows
         single-precision floating-point values to be moved to and from the high quadword of

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -1172,8 +1172,8 @@ Using the SAR instruction to perform a division operation does not produce the s
         cpu.XMM1 = 0x4048f5c340c8f5c3ffffffffffffffff
         cpu.execute()
 
-        self.assertItemsEqual(mem[0x41e000:0x41e004], to_bytelist(b'\x40\x48\xf5\xc3'))
-        self.assertItemsEqual(mem[0x41e004:0x41e008], to_bytelist(b'\x40\xc8\xf5\xc3'))
+        self.assertItemsEqual(mem[0x41e000:0x41e004], to_bytelist(b'\x40\xc8\xf5\xc3'))
+        self.assertItemsEqual(mem[0x41e004:0x41e008], to_bytelist(b'\x40\x48\xf5\xc3'))
 
     def test_symbolic_instruction(self):
         cs = ConstraintSet()

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -1165,8 +1165,7 @@ Using the SAR instruction to perform a division operation does not produce the s
         # movhps qword ptr [eax], xmm1
         mem[0x0041e10a] = '\x0f'
         mem[0x0041e10b] = '\x17'
-        mem[0x0041e10c] = '\x48'
-        mem[0x0041e10d] = '\x08'
+        mem[0x0041e10c] = '\x08'
 
         cpu.RIP = 0x41e10a
         cpu.EAX = 0x41e000

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -9,7 +9,7 @@ from manticore.native.cpu.x86 import AMD64Cpu
 from manticore.native.memory import *
 from manticore.core.smtlib import BitVecOr, operator, Bool
 from manticore.core.smtlib.solver import Z3Solver
-import mockmem
+from . import mockmem
 from functools import reduce
 solver = Z3Solver.instance()
 class ROOperand:
@@ -1155,7 +1155,7 @@ Using the SAR instruction to perform a division operation does not produce the s
         cpu.XMM0 = 0x0000000000000000ffffffffffffffff
         cpu.execute()
 
-        self.assertEqual(cpu.XMM0, 0x4048f5c340c8f5c3ffffffffffffffff)
+        self.assertEqual(cpu.XMM0, 0xc3f5c840c3f54840ffffffffffffffff)
 
     def test_MOVHPS_2(self):
         mem = Memory32()
@@ -1170,7 +1170,7 @@ Using the SAR instruction to perform a division operation does not produce the s
 
         cpu.RIP = 0x41e10a
         cpu.EAX = 0x41e000
-        cpu.XMM0 = 0x4048f5c340c8f5c3ffffffffffffffff
+        cpu.XMM1 = 0x4048f5c340c8f5c3ffffffffffffffff
         cpu.execute()
 
         self.assertItemsEqual(mem[0x41e000:0x41e004], to_bytelist(b'\x40\x48\xf5\xc3'))

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -9,7 +9,7 @@ from manticore.native.cpu.x86 import AMD64Cpu
 from manticore.native.memory import *
 from manticore.core.smtlib import BitVecOr, operator, Bool
 from manticore.core.smtlib.solver import Z3Solver
-from . import mockmem
+import mockmem
 from functools import reduce
 solver = Z3Solver.instance()
 class ROOperand:

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -1128,6 +1128,54 @@ Using the SAR instruction to perform a division operation does not produce the s
             temp_cs.add(condition == False)
             self.assertFalse(solver.check(temp_cs))
 
+    def test_MOVHPS_1(self):
+        mem = Memory32()
+        cpu = I386Cpu(mem)
+        mem.mmap(0x0041e000, 0x1000, 'rwx')
+
+        # 3.14
+        mem[0x0041e000] = '\x40'
+        mem[0x0041e001] = '\x48'
+        mem[0x0041e002] = '\xf5'
+        mem[0x0041e003] = '\xc3'
+
+        # 6.28
+        mem[0x0041e004] = '\x40'
+        mem[0x0041e005] = '\xc8'
+        mem[0x0041e006] = '\xf5'
+        mem[0x0041e007] = '\xc3'
+
+        # movhps xmm0, qword ptr [eax]
+        mem[0x0041e10a] = '\x0f'
+        mem[0x0041e10b] = '\x16'
+        mem[0x0041e10c] = '\x00'
+
+        cpu.RIP = 0x41e10a
+        cpu.EAX = 0x41e000
+        cpu.XMM0 = 0x0000000000000000ffffffffffffffff
+        cpu.execute()
+
+        self.assertEqual(cpu.XMM0, 0x4048f5c340c8f5c3ffffffffffffffff)
+
+    def test_MOVHPS_2(self):
+        mem = Memory32()
+        cpu = I386Cpu(mem)
+        mem.mmap(0x0041e000, 0x1000, 'rwx')
+
+        # movhps qword ptr [eax], xmm1
+        mem[0x0041e10a] = '\x0f'
+        mem[0x0041e10b] = '\x17'
+        mem[0x0041e10c] = '\x48'
+        mem[0x0041e10d] = '\x08'
+
+        cpu.RIP = 0x41e10a
+        cpu.EAX = 0x41e000
+        cpu.XMM0 = 0x4048f5c340c8f5c3ffffffffffffffff
+        cpu.execute()
+
+        self.assertItemsEqual(mem[0x41e000:0x41e004], to_bytelist(b'\x40\x48\xf5\xc3'))
+        self.assertItemsEqual(mem[0x41e004:0x41e008], to_bytelist(b'\x40\xc8\xf5\xc3'))
+
     def test_symbolic_instruction(self):
         cs = ConstraintSet()
         mem = SMemory32(cs)


### PR DESCRIPTION
Adds support for `movhps`.

The implementation of `movhps` isidentical to `movhpd` since it moves two single-precision floats at the same time. As a result, we _could_ deduplicate the two into a single `movhp` or whatever method if desired.

Closes #1432.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1444)
<!-- Reviewable:end -->
