### PR TITLE
Restore old init hook behavior

### DIFF
--- a/examples/script/aarch64/basic.py
+++ b/examples/script/aarch64/basic.py
@@ -22,9 +22,8 @@ m = Manticore(FILE, concrete_start="", stdin_size=0)
 
 
 @m.init
-def init(m, ready_states):
-    for state in ready_states:
-        state.platform.input.write(state.symbolicate_buffer(STDIN, label="STDIN"))
+def init(state):
+    state.platform.input.write(state.symbolicate_buffer(STDIN, label="STDIN"))
 
 
 # Hook the 'if' case.

--- a/manticore/native/cli.py
+++ b/manticore/native/cli.py
@@ -29,10 +29,9 @@ def native_main(args, _logger):
         m.load_assertions(args.assertions)
 
     @m.init
-    def init(m, ready_states):
+    def init(state):
         for file in args.files:
-            for state in ready_states:
-                state.platform.add_symbolic_file(file)
+            state.platform.add_symbolic_file(file)
 
     with m.kill_timeout():
         m.run()

--- a/scripts/sandshrew/sandshrew.py
+++ b/scripts/sandshrew/sandshrew.py
@@ -149,12 +149,12 @@ def main():
 
     # initialize state by checking and storing symbolic argv
     @m.init
-    def init(m, ready_states):
+    def init(state):
 
         logging.debug(f"Checking for symbolic ARGV")
 
         # determine argv[1] from state.input_symbols by label name
-        argv1 = next(sym for sym in next(ready_states).input_symbols if sym.name == "ARGV1")
+        argv1 = next(sym for sym in state.input_symbols if sym.name == "ARGV1")
         if argv1 is None:
             raise RuntimeException("ARGV was not provided and/or made symbolic")
 

--- a/tests/native/test_linux.py
+++ b/tests/native/test_linux.py
@@ -323,11 +323,10 @@ class LinuxTest(unittest.TestCase):
         m.context["success"] = False
 
         @m.init
-        def init(m, ready_states):
-            for state in ready_states:
-                state.platform.current.regfile.write("R0", 0)
-                state.platform.current.regfile.write("R1", 0x1234)
-                state.platform.current.regfile.write("R2", 0x5678)
+        def init(state):
+            state.platform.current.regfile.write("R0", 0)
+            state.platform.current.regfile.write("R1", 0x1234)
+            state.platform.current.regfile.write("R2", 0x5678)
 
         @m.hook(0x1001)
         def pre(state):

--- a/tests/native/test_manticore.py
+++ b/tests/native/test_manticore.py
@@ -61,9 +61,9 @@ class ManticoreTest(unittest.TestCase):
         self.m.context["x"] = 0
 
         @self.m.init
-        def tmp(m, _ready_states):
-            m.context["x"] = 1
-            m.kill()
+        def tmp(_state):
+            self.m.context["x"] = 1
+            self.m.kill()
 
         self.m.run()
 


### PR DESCRIPTION
Modifies `native/Manticore` so that `m.init` hooks have the same API as they did before the executor refactor:
```
@m.init
def foo(state):
    pass
```
as opposed to the current API of 
```
@m.init
def foo(m, ready_states):
    for state in ready_states:
        pass
```

Whereas the old `init` decorator simply subscribed the decorated function to `will_run`, this adds it to a set of init callbacks, and registers a separate `will_run` callback that loops over all decorated functions, then loops over all `ready_states`, and calls each callback with each state. This should be okay because `native/Manticore` should only ever have one starting state.

Note that this _doesn't_ change the API for the `will_run_callback`, which still takes `ready_states` as an argument. This is because the `m.init` function only exists on `native/Manticore`, so we don't risk calling the `init` callback multiple times. `will_run_callback`, however, is on `core/Manticore`, so it's also used by EVM, which can have multiple entries in `ready_states` at the beginning of a run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1447)
<!-- Reviewable:end -->
