### PR TITLE
Fix check for symbolic syscall argument

### DIFF
--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -439,7 +439,11 @@ class SyscallAbi(Abi):
 
             args = []
             for arg in self._last_arguments:
-                arg_s = unsigned_hexlify(arg) if abs(arg) > min_hex_expansion else f"{arg}"
+                arg_s = (
+                    unsigned_hexlify(arg)
+                    if not issymbolic(arg) and abs(arg) > min_hex_expansion
+                    else f"{arg}"
+                )
                 if self._cpu.memory.access_ok(arg, "r") and model.__func__.__name__ not in {
                     "sys_mprotect",
                     "sys_mmap",


### PR DESCRIPTION
If there is no check, an error will occur when trying to take `abs(arg)`.

Not sure if you want to do anything else with the symbolic argument or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1452)
<!-- Reviewable:end -->
