### PR TITLE
Use deque instead of list for FIFO queue in Linux Socket buffer

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -370,7 +370,9 @@ class Socket:
         return a, b
 
     def __init__(self):
-        self.buffer = []  # queue os bytes
+        from collections import deque
+
+        self.buffer = deque()  # queue os bytes
         self.peer = None
 
     def __repr__(self):
@@ -399,7 +401,7 @@ class Socket:
         rx_bytes = min(size, len(self.buffer))
         ret = []
         for i in range(rx_bytes):
-            ret.append(self.buffer.pop())
+            ret.append(self.buffer.popleft())
         return ret
 
     def write(self, buf):
@@ -408,7 +410,7 @@ class Socket:
 
     def _transmit(self, buf):
         for c in buf:
-            self.buffer.insert(0, c)
+            self.buffer.append(c)
         return len(buf)
 
     def sync(self):


### PR DESCRIPTION
More efficient to use deque for FIFO buffer of Socket data. O(1) for `popleft()` instead of O(n) for `insert(0, c)` https://docs.python.org/3/library/collections.html#collections.deque

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1453)
<!-- Reviewable:end -->
