### PR TITLE
Install Native Dependencies when building on RTD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ on_rtd = os.environ.get("READTHEDOCS") == "True"
 def rtd_dependent_deps():
     # RTD tries to build z3, ooms, and fails to build.
     if on_rtd:
-        return []
+        return native_deps
     else:
         return ["z3-solver"]
 


### PR DESCRIPTION
Our docs were partially broken because the lack of the native dependencies on RTD would result in import errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1457)
<!-- Reviewable:end -->
