### PR TITLE
Revert Unicorn Dependency Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL dockerfile_maintenance=trailofbits
 
 ENV LANG C.UTF-8
 
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip git wget python
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip git wget
 
 # Install solc 0.4.25 and validate it
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -16,10 +16,7 @@ function install_mcore {
         EXTRAS="dev"
     fi
 
-    # Unicorn needs python2
-    export UNICORN_QEMU_FLAGS="--python=/usr/bin/python"
-
-    pip install -I --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
+    pip install --no-binary keystone-engine -e .[$EXTRAS]  # ks can have pip install issues
 }
 
 function install_cc_env {
@@ -46,3 +43,4 @@ if [ "$1" != "env" ]; then
         install_mcore $1
     fi
 fi
+

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,7 @@ def rtd_dependent_deps():
 
 # If you update native_deps please update the `REQUIREMENTS_TO_IMPORTS` dict in `utils/install_helper.py`
 # (we need to know how to import a given native dependency so we can check if native dependencies are installed)
-native_deps = [
-    'capstone==4.0.1',
-    'pyelftools',
-    'unicorn',
-]
+native_deps = ["capstone==4.0.1", "pyelftools", "unicorn"]
 
 extra_require = {
     "native": native_deps,

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ def rtd_dependent_deps():
 # If you update native_deps please update the `REQUIREMENTS_TO_IMPORTS` dict in `utils/install_helper.py`
 # (we need to know how to import a given native dependency so we can check if native dependencies are installed)
 native_deps = [
-    "capstone==4.0.1",
-    "pyelftools",
-    "unicorn @ git+https://github.com/unicorn-engine/unicorn.git@778171fc9546c1fc3d1341ff1151eab379848ea0#subdirectory=bindings/python&egg=unicorn-1.0.1.post0",
+    'capstone==4.0.1',
+    'pyelftools',
+    'unicorn',
 ]
 
 extra_require = {


### PR DESCRIPTION
PyPi doesn't allow direct links to packages in the dependency specification, so we need to roll back #1440 and wait for Unicorn to push a new release in order to be able to deploy Manticore. See: https://github.com/pypa/pip/issues/5898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1459)
<!-- Reviewable:end -->
