### PR TITLE
Perf optimization for writing one byte in memory

### DIFF
--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -970,7 +970,7 @@ class Memory(object, metaclass=ABCMeta):
         if self._recording_stack:
             self._recording_stack[-1].append((addr, [val]))
 
-        m[addr] = val
+        m[addr : addr + 1] = [val]
 
     def write(self, addr, buf, force=False):
         size = len(buf)

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -301,7 +301,7 @@ class AnonMap(Map):
                 self._data = [
                     Operators.ORD(b) for b in self._data
                 ]  # completely convert everything to a list if we need to store some symbolic data, just copying fpse
-            else if not isinstance(value[0], int):
+            elif not isinstance(value[0], int):
                 value = [Operators.ORD(n) for n in value]
             self._data[index] = value
         else:

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -1193,16 +1193,16 @@ class SMemory(Memory):
                         raise InvalidMemoryAccess(address + offset, "w")
                     self._symbols[address + offset] = [(True, value[offset])]
                 else:
-                    sizeArea+=1
+                    sizeArea += 1
             if sizeArea > 0:
                 areas.append((startArea, sizeArea))
             for (startArea, sizeArea) in areas:
                 if sizeArea == 1:
-                    super().write1(address+startArea, value[startArea], force)
+                    super().write1(address + startArea, value[startArea], force)
                 else:
-                    super().write(address+startArea, value[startArea:startArea+sizeArea], force)
-
-
+                    super().write(
+                        address + startArea, value[startArea : startArea + sizeArea], force
+                    )
 
     def _try_get_solutions(self, address, size, access, max_solutions=0x1000, force=False):
         """

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -296,13 +296,12 @@ class AnonMap(Map):
         assert not isinstance(index, slice) or len(value) == index.stop - index.start
         index = self._get_offset(index)
 
-        if issymbolic(value[0]) and isinstance(self._data, bytearray):
-            self._data = [
-                Operators.ORD(b) for b in self._data
-            ]  # completely convert everything to a list if we need to store some symbolic data, just copying fpse
-
         if isinstance(index, slice):
-            if not isinstance(value[0], int):
+            if issymbolic(value[0]) and isinstance(self._data, bytearray):
+                self._data = [
+                    Operators.ORD(b) for b in self._data
+                ]  # completely convert everything to a list if we need to store some symbolic data, just copying fpse
+            else if not isinstance(value[0], int):
                 value = [Operators.ORD(n) for n in value]
             self._data[index] = value
         else:
@@ -970,7 +969,7 @@ class Memory(object, metaclass=ABCMeta):
         if self._recording_stack:
             self._recording_stack[-1].append((addr, [val]))
 
-        m[addr : addr + 1] = [val]
+        m[addr] = val
 
     def write(self, addr, buf, force=False):
         size = len(buf)

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -957,6 +957,21 @@ class Memory(object, metaclass=ABCMeta):
             self._recording_stack[-1].extend(lst)
         return lst
 
+    # this is an optimized version of write with only one byte
+    # and thus only one map
+    def write1(self, addr, val, force=False):
+        # optimizing together map_containing and access_ok
+        m = self._page2map.get(addr >> self.page_bit_size, None)
+        if m is None:
+            raise InvalidMemoryAccess(addr, "w")
+        if not force and not m.access_ok("w"):
+            raise InvalidMemoryAccess(addr, "w")
+
+        if self._recording_stack:
+            self._recording_stack[-1].append((addr, [val]))
+
+        m[addr] = val
+
     def write(self, addr, buf, force=False):
         size = len(buf)
         if not self.access_ok(slice(addr, addr + size), "w", force):
@@ -1174,7 +1189,7 @@ class SMemory(Memory):
                     # overwrite all previous items
                     if address + offset in self._symbols:
                         del self._symbols[address + offset]
-                    super().write(address + offset, [value[offset]], force)
+                    super().write1(address + offset, value[offset], force)
 
     def _try_get_solutions(self, address, size, access, max_solutions=0x1000, force=False):
         """


### PR DESCRIPTION
Tested on ais3_crackme example

Function `write` called 19164 times goes down from 2.076 seconds cumulated to 0.914 seconds by using this new `write1` function (on 42 seconds total time)

This code may be less readable though...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1465)
<!-- Reviewable:end -->
