### PR TITLE
Enforce black formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
     - stage: format
       env: TEST_TYPE=format
       script:
-        - git diff --name-only $TRAVIS_COMMIT_RANGE | python3 scripts/pyfile_exists.py | xargs black -t py36 -l 100 --check
+        - git diff --name-only $TRAVIS_COMMIT_RANGE | python3 scripts/pyfile_exists.py | xargs black --check
     - stage: prepare
       env: TEST_TYPE=env
       script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Some pull request guidelines:
 
 - We use the [`black`](https://black.readthedocs.io/en/stable/index.html) auto-formatter
   to enforce style conventions in Manticore. To ensure your code is properly 
-  formatted, run `black -t py36 -l 100 .` in the manticore directory before
+  formatted, run `black .` in the manticore directory before
   committing.
 - Minimize irrelevant changes (formatting, whitespace, etc) to code that would
   otherwise not be touched by this patch. Save formatting or style corrections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+target-version = ['py36']
+line-length = 100


### PR DESCRIPTION
create a pyproject.toml so users don't have to worry about command line flags for black

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1466)
<!-- Reviewable:end -->
