### PR TITLE
Fix FileNotFoundError when loading existing state

### DIFF
--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -290,7 +290,8 @@ class FilesystemStore(Store):
         :param str key: The file to delete
         """
         path = os.path.join(self.uri, key)
-        os.remove(path)
+        if os.path.exists(path):
+            os.remove(path)
 
     def ls(self, glob_str):
         """


### PR DESCRIPTION
Fixes https://github.com/trailofbits/manticore/issues/1479.

Simple check to ensure state's workspace URL does exist, and can still continue execution if it does not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1480)
<!-- Reviewable:end -->
