### PR TITLE
Fix documentation typo in ManticoreBase

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -223,7 +223,7 @@ class ManticoreBase(Eventful):
         *State list: TERMINATED*
 
         TERMINATED contains states that have reached a final condition and raised
-        TerminateState. Workers mainloop simpliy move the states that requested
+        TerminateState. Worker's mainloop simply moves the states that requested
         termination to the TERMINATED list. This is a final list.
 
         ```An inherited Manticore class like ManticoreEVM could internally revive


### PR DESCRIPTION
I've spotted the typo while reading the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1492)
<!-- Reviewable:end -->
