### PR TITLE
Add SHL/SHR/SAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ brew install unicorn
 UNICORN_QEMU_FLAGS="--python=`whereis python`" pip install unicorn
 ```
 
+### Solidity Versions
+Note that we're still in the process of implementing full support for the EVM Constantinople instruction semantics, so certain opcodes may not be supported.
+You may want to consider using a version of `solc` that's less likely to generate these opcodes (eg pre-0.5.0).
+
 ## Getting Help
 
 Feel free to stop by our #manticore slack channel in [Empire Hacking](https://empireslacking.herokuapp.com/) for help using or extending Manticore.

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -6,7 +6,6 @@ from multiprocessing import Queue, Process
 from queue import Empty as EmptyQueue
 from subprocess import check_output, Popen, PIPE
 from typing import Dict, Optional, Union
-from pkg_resources import parse_version
 
 import io
 import os
@@ -17,7 +16,6 @@ import sha3
 import tempfile
 
 from crytic_compile import CryticCompile, InvalidCompilation, is_supported
-from crytic_compile.platform.solc import get_version
 
 from ..core.manticore import ManticoreBase
 from ..core.smtlib import (
@@ -734,14 +732,6 @@ class ManticoreEVM(ManticoreBase):
         while contract_names:
             contract_name_i = contract_names.pop()
             try:
-                # version check
-                binary = crytic_compile_args.get("solc", "solc")
-                version = get_version(binary)
-                if not parse_version(version) < parse_version("0.5.0"):
-                    raise EthereumError(
-                        f"Manticore requires a solc version < 0.5.0 and {version} was found"
-                    )
-
                 compile_results = self._compile(
                     source_code,
                     contract_name_i,

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1511,15 +1511,15 @@ class EVM(Eventful):
 
     def SHL(self, a, b):
         """Shift Left operation"""
-        raise NotImplementedError("SHL")
+        return b << a
 
     def SHR(self, a, b):
         """Logical Shift Right operation"""
-        raise NotImplementedError("SHR")
+        return b >> a
 
     def SAR(self, a, b):
         """Arithmetic Shift Right operation"""
-        raise NotImplementedError("SAR")
+        return Operators.SAR(256, b, a)
 
     def try_simplify_to_constant(self, data):
         concrete_data = bytearray()

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -73,7 +73,7 @@ TT256M1 = 2 ** 256 - 1
 MASK160 = 2 ** 160 - 1
 TT255 = 2 ** 255
 TOOHIGHMEM = 0x1000
-DEFAULT_FORK = "byzantium"
+DEFAULT_FORK = "constantinople"
 
 # FIXME. We should just use a Transaction() for this
 PendingTransaction = namedtuple(
@@ -1508,6 +1508,18 @@ class EVM(Eventful):
         """Retrieve single byte from word"""
         offset = Operators.ITEBV(256, offset < 32, (31 - offset) * 8, 256)
         return Operators.ZEXTEND(Operators.EXTRACT(value, offset, 8), 256)
+
+    def SHL(self, a, b):
+        """Shift Left operation"""
+        raise NotImplementedError("SHL")
+
+    def SHR(self, a, b):
+        """Logical Shift Right operation"""
+        raise NotImplementedError("SHR")
+
+    def SAR(self, a, b):
+        """Arithmetic Shift Right operation"""
+        raise NotImplementedError("SAR")
 
     def try_simplify_to_constant(self, data):
         concrete_data = bytearray()

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -88,11 +88,14 @@ run_truffle_tests(){
     cd truffle_tests
     truffle unbox metacoin
     manticore . --contract MetaCoin --workspace output
+    ### The original comment says we should get 41 states, but after implementing the shift
+    ### insructions, we get 31. Was the original comment a typo?
+
     # The correct answer should be 41
     # but Manticore fails to explore the paths due to the lack of the 0x1f opcode support
     # see https://github.com/trailofbits/manticore/issues/1166
     # if [ "$(ls output/*tx -l | wc -l)" != "41" ]; then
-    if [ "$(ls output/*tx -l | wc -l)" != "3" ]; then
+    if [ "$(ls output/*tx -l | wc -l)" != "31" ]; then
         echo "Truffle test failed"
         return 1
     fi

--- a/tests/auto_generators/make_VMTests.py
+++ b/tests/auto_generators/make_VMTests.py
@@ -375,7 +375,9 @@ class EVMTest_{os.path.splitext(os.path.basename(filename_or_folder))[0]}(unitte
                 continue
 
             filename = os.path.join(folder, filename)
-            testcase = dict(json.loads(open(filename).read()))
+            fp = open(filename)
+            testcase = dict(json.loads(fp.read()))
+            fp.close()
             for name, testcase in testcase.items():
                 output += (
                     gen_test(testcase, filename, symbolic=symbolic, skip="Performance" in filename)
@@ -387,7 +389,9 @@ class EVMTest_{os.path.splitext(os.path.basename(filename_or_folder))[0]}(unitte
     else:
         folder = None
         filename = os.path.abspath(filename_or_folder)
-        testcase = dict(json.loads(open(filename).read()))
+        fp = open(filename)
+        testcase = dict(json.loads(fp.read()))
+        fp.close()
         for name, testcase in testcase.items():
             output += (
                 gen_test(testcase, filename, symbolic=symbolic, skip="Performance" in filename)

--- a/tests/ethereum/EVM/test_EVMSHIFT.py
+++ b/tests/ethereum/EVM/test_EVMSHIFT.py
@@ -1,0 +1,885 @@
+import struct
+import unittest
+import json
+from manticore.platforms import evm
+from manticore.core import state
+from manticore.core.smtlib import Operators, ConstraintSet
+import os
+
+
+class EVMTest_SHIFT(unittest.TestCase):
+    _multiprocess_can_split_ = True
+    maxDiff = None
+
+    def _execute(self, new_vm):
+        last_returned = None
+        last_exception = None
+        try:
+            new_vm.execute()
+        except evm.Stop as e:
+            last_exception = "STOP"
+        except evm.NotEnoughGas:
+            last_exception = "OOG"
+        except evm.StackUnderflow:
+            last_exception = "INSUFFICIENT STACK"
+        except evm.InvalidOpcode:
+            last_exception = "INVALID"
+        except evm.SelfDestruct:
+            last_exception = "SUICIDED"
+        except evm.Return as e:
+            last_exception = "RETURN"
+            last_returned = e.data
+        except evm.Revert:
+            last_exception = "REVERT"
+
+        return last_exception, last_returned
+
+    def test_SHL_0(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SHL_1(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [2])
+
+    def test_SHL_2(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [57896044618658097711785492504343953926634992332820282019728792003956564819968],
+        )
+
+    def test_SHL_3(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHL_4(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(257)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHL_5(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SHL_6(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639934],
+        )
+
+    def test_SHL_7(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [57896044618658097711785492504343953926634992332820282019728792003956564819968],
+        )
+
+    def test_SHL_8(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHL_9(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(0)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHL_10(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1b"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819967)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639934],
+        )
+
+    def test_SHR_0(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SHR_1(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHR_2(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [28948022309329048855892746252171976963317496166410141009864396001978282409984],
+        )
+
+    def test_SHR_3(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SHR_4(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHR_5(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(257)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHR_6(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SHR_7(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [57896044618658097711785492504343953926634992332820282019728792003956564819967],
+        )
+
+    def test_SHR_8(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SHR_9(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SHR_10(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1c"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(0)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SAR_0(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SAR_1(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(1)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SAR_2(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [86844066927987146567678238756515930889952488499230423029593188005934847229952],
+        )
+
+    def test_SAR_3(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_4(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_5(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        new_vm._push(257)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_6(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(0)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_7(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_8(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_9(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(
+            new_vm.stack,
+            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+        )
+
+    def test_SAR_10(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(0)
+        new_vm._push(1)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SAR_11(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(28948022309329048855892746252171976963317496166410141009864396001978282409984)
+        new_vm._push(254)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SAR_12(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819967)
+        new_vm._push(248)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [127])
+
+    def test_SAR_13(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819967)
+        new_vm._push(254)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [1])
+
+    def test_SAR_14(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819967)
+        new_vm._push(255)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+    def test_SAR_15(self):
+        # Make the constraint store
+        constraints = ConstraintSet()
+        # make the ethereum world state
+        world = evm.EVMWorld(constraints)
+
+        address = 0x222222222222222222222222222222222222200
+        caller = 0x111111111111111111111111111111111111100
+        value = 10000
+        bytecode = b"\x1d"
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819967)
+        new_vm._push(256)
+        last_exception, last_returned = self._execute(new_vm)
+        self.assertEqual(last_exception, None)
+        self.assertEqual(new_vm.pc, 1)
+        self.assertEqual(new_vm.stack, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1166 
Adds instruction semantics and tests from [EIP-145](https://eips.ethereum.org/EIPS/eip-145).

Does not update for the Constantinople gas calculation semantics, or, for that matter, most of the other Constantinople changes. Further work will be handled in later PR's; the motivation behind this merge is to get the shift instructions into master sooner rather than later. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1498)
<!-- Reviewable:end -->
