### PR TITLE
Optimize repeated division in CMPXCHG8B

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -1479,6 +1479,7 @@ class X86Cpu(Cpu):
         :param dest: destination operand.
         """
         size = dest.size
+        half_size = size // 2
         cmp_reg_name_l = {64: "EAX", 128: "RAX"}[size]
         cmp_reg_name_h = {64: "EDX", 128: "RDX"}[size]
         src_reg_name_l = {64: "EBX", 128: "RBX"}[size]
@@ -1499,12 +1500,12 @@ class X86Cpu(Cpu):
         dest.write(Operators.ITEBV(size, cpu.ZF, Operators.CONCAT(size, srch, srcl), arg_dest))
         cpu.write_register(
             cmp_reg_name_l,
-            Operators.ITEBV(size // 2, cpu.ZF, cmpl, Operators.EXTRACT(arg_dest, 0, size // 2)),
+            Operators.ITEBV(half_size, cpu.ZF, cmpl, Operators.EXTRACT(arg_dest, 0, half_size)),
         )
         cpu.write_register(
             cmp_reg_name_h,
             Operators.ITEBV(
-                size // 2, cpu.ZF, cmph, Operators.EXTRACT(arg_dest, size // 2, size // 2)
+                half_size, cpu.ZF, cmph, Operators.EXTRACT(arg_dest, half_size, half_size)
             ),
         )
 


### PR DESCRIPTION
Python doesn't optimize those and repeats the same calculation 5 times. I've checked this on the following example:
```python
In [1]: def g(x):
   ...:     a = x // 2
   ...:     b = x // 2
   ...:     c = x // 2
   ...:     d = x // 2
   ...:     e = x // 2
   ...:

In [2]: import dis

In [3]: dis.dis(g)
  2           0 LOAD_FAST                0 (x)
              2 LOAD_CONST               1 (2)
              4 BINARY_FLOOR_DIVIDE
              6 STORE_FAST               1 (a)

  3           8 LOAD_FAST                0 (x)
             10 LOAD_CONST               1 (2)
             12 BINARY_FLOOR_DIVIDE
             14 STORE_FAST               2 (b)

  4          16 LOAD_FAST                0 (x)
             18 LOAD_CONST               1 (2)
             20 BINARY_FLOOR_DIVIDE
             22 STORE_FAST               3 (c)

  5          24 LOAD_FAST                0 (x)
             26 LOAD_CONST               1 (2)
             28 BINARY_FLOOR_DIVIDE
             30 STORE_FAST               4 (d)

  6          32 LOAD_FAST                0 (x)
             34 LOAD_CONST               1 (2)
             36 BINARY_FLOOR_DIVIDE
             38 STORE_FAST               5 (e)
             40 LOAD_CONST               0 (None)
             42 RETURN_VALUE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1501)
<!-- Reviewable:end -->
