### PR TITLE
Update crackme example to match the description

### DIFF
--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -6,7 +6,7 @@ PYTHON=python3
 EXAMPLES=basic sindex  strncmp  arguments ibranch sendmail crackme indexhell  helloworld simple_copy simpleassert
 OTHER_EXAMPLES=nostdlib
 
-all: $(EXAMPLES) $(OTHER_EXAMPLES) 
+all: $(EXAMPLES) $(OTHER_EXAMPLES)
 
 arm: CC=arm-linux-gnueabi-gcc
 arm: $(EXAMPLES)
@@ -21,7 +21,7 @@ clean:
 % : %.c
 	$(CC) $(CFLAGS) $< -o $@
 
-nostdlib: nostdlib.c 
+nostdlib: nostdlib.c
 	$(CC) -m32 $(NOSTDLIBFLAGS) $< -o $@
 
 # simpleassert needs -O0
@@ -32,3 +32,5 @@ simpleassert: simpleassert.c
 crackme.c: crackme.py
 	$(PYTHON) crackme.py > $@
 
+crackme: crackme.c
+	$(CC) $(CFLAGS) -O0 $< -o $@

--- a/examples/linux/crackme.py
+++ b/examples/linux/crackme.py
@@ -13,7 +13,7 @@ PROGRAM = """
 /* This program parses a command line argument.
  *
  * Compile with :
- *   $ gcc -static -Os crackme.c -o crackme
+ *   $ gcc -static -O0 crackme.c -o crackme
  *
  * Analyze it with:
  *   $ manticore crackme
@@ -39,25 +39,25 @@ PROGRAM = """
  *  Look at ./mcore_IJ2sPb for results, you will find something like this:
  *
  *  $ head -c 4 *.stdin
- *  ==> test_00000001.stdin <==
+ *  ==> test_00000000.stdin <==
  *  �CMM
- *  ==> test_00000002.stdin <==
+ *  ==> test_00000001.stdin <==
  *  �C��
- *  ==> test_00000003.stdin <==
+ *  ==> test_00000002.stdin <==
  *  ��SS
- *  ==> test_00000004.stdin <==
+ *  ==> test_00000003.stdin <==
  *  ����
- *  ==> test_00000005.stdin <==
+ *  ==> test_00000004.stdin <==
  *  SCR
- *  ==> test_00000006.stdin <==
+ *  ==> test_00000005.stdin <==
  *  S�TT
- *  ==> test_00000007.stdin <==
+ *  ==> test_00000006.stdin <==
  *  SCRT
- *  ==> test_00000008.stdin <==
+ *  ==> test_00000007.stdin <==
  *  S���
- *  ==> test_00000009.stdin <==
+ *  ==> test_00000008.stdin <==
  *  SC�@
- *  ==> test_0000000a.stdin <==
+ *  ==> test_00000009.stdin <==
  *  SC�8
  *
 */


### PR DESCRIPTION
I've found that the `crackme` example is compiled with optimizations which cut out certain branches and renders the description in `crackme.py` inaccurate. The result below is latest manticore from pip with gcc 8.3 (gcc version 8.3.0 (Ubuntu 8.3.0-6ubuntu1)) and `-Os` from the Makefile:
```
$ manticore crackme
2019-07-30 20:13:14,793: [10674] m.n.manticore:INFO: Loading program crackme
2019-07-30 20:13:15,393: [10702] m.n.c.x86:WARNING: CPUID with EAX=80000000 not implemented @ 402605
2019-07-30 20:13:21,917: [10674] m.c.manticore:INFO: Generated testcase No. 0 - test
2019-07-30 20:13:25,306: [10674] m.c.manticore:INFO: Generated testcase No. 1 - test
2019-07-30 20:13:28,907: [10674] m.c.manticore:INFO: Generated testcase No. 2 - test
2019-07-30 20:13:32,720: [10674] m.c.manticore:INFO: Generated testcase No. 3 - test
2019-07-30 20:13:36,818: [10674] m.c.manticore:INFO: Generated testcase No. 4 - test
2019-07-30 20:13:40,953: [10674] m.c.manticore:INFO: Results in /home/vagrant/manticore/examples/linux/mcore_nvmerqeo
2019-07-30 20:13:40,954: [10674] m.n.manticore:INFO: Total time: 25.949420928955078
```
I've changed the optimization to `-O0` and now all the branches are explored:
```
$ manticore crackme
2019-07-30 20:08:51,194: [2554] m.n.manticore:INFO: Loading program crackme
2019-07-30 20:08:51,806: [2582] m.n.c.x86:WARNING: CPUID with EAX=80000000 not implemented @ 402815
2019-07-30 20:09:00,623: [2554] m.c.manticore:INFO: Generated testcase No. 0 - test
2019-07-30 20:09:04,689: [2554] m.c.manticore:INFO: Generated testcase No. 1 - test
2019-07-30 20:09:09,071: [2554] m.c.manticore:INFO: Generated testcase No. 2 - test
2019-07-30 20:09:13,428: [2554] m.c.manticore:INFO: Generated testcase No. 3 - test
2019-07-30 20:09:17,592: [2554] m.c.manticore:INFO: Generated testcase No. 4 - test
2019-07-30 20:09:21,804: [2554] m.c.manticore:INFO: Generated testcase No. 5 - test
2019-07-30 20:09:26,358: [2554] m.c.manticore:INFO: Generated testcase No. 6 - test
2019-07-30 20:09:30,967: [2554] m.c.manticore:INFO: Generated testcase No. 7 - test
2019-07-30 20:09:35,456: [2554] m.c.manticore:INFO: Generated testcase No. 8 - test
2019-07-30 20:09:40,305: [2554] m.c.manticore:INFO: Generated testcase No. 9 - test
2019-07-30 20:09:45,140: [2554] m.c.manticore:INFO: Results in /home/vagrant/manticore/examples/linux/mcore_4k0lh2ur
2019-07-30 20:09:45,141: [2554] m.n.manticore:INFO: Total time: 53.7365300655365
```

Additionally, the generated input files start from 0 and I've edited `crackme.py` to match that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1502)
<!-- Reviewable:end -->
