### PR TITLE
Improve performance of bulk read/writes to memory

### DIFF
--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -1194,7 +1194,7 @@ class SMemory(Memory):
                 if issymbolic(value[offset]):
                     # Commit (offload) concrete write
                     if concrete_start is not None:
-                        super().write(address+concrete_start, value[concrete_start:offset], force)
+                        super().write(address + concrete_start, value[concrete_start:offset], force)
                         concrete_start = None
 
                     # Commit symbolic write if access is okay

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -1181,15 +1181,17 @@ class SMemory(Memory):
         else:
 
             for offset in range(size):
+                ea = address + offset
+
                 if issymbolic(value[offset]):
-                    if not self.access_ok(address + offset, "w", force):
-                        raise InvalidMemoryAccess(address + offset, "w")
-                    self._symbols[address + offset] = [(True, value[offset])]
+                    if not self.access_ok(ea, "w", force):
+                        raise InvalidMemoryAccess(ea, "w")
+                    self._symbols[ea] = [(True, value[offset])]
                 else:
                     # overwrite all previous items
-                    if address + offset in self._symbols:
-                        del self._symbols[address + offset]
-                    super().write(address + offset, [value[offset]], force)
+                    if ea in self._symbols:
+                        del self._symbols[ea]
+                    super().write(ea, [value[offset]], force)
 
     def _try_get_solutions(self, address, size, access, max_solutions=0x1000, force=False):
         """

--- a/tests/native/test_memory.py
+++ b/tests/native/test_memory.py
@@ -1138,12 +1138,10 @@ class MemoryTest(unittest.TestCase):
 
         # Check if they are concretes/symbolics
         for addr in concretes:
-            byte = mem[addr]
-            self.assertFalse(issymbolic(byte))
+            self.assertFalse(issymbolic(mem[addr]))
 
         for addr in symbolics:
-            byte = mem[addr]
-            self.assertTrue(issymbolic(byte))
+            self.assertTrue(issymbolic(mem[addr]))
 
         # And assert the internal symbolic chunks dict representation
         self.assertDictEqual(
@@ -1167,12 +1165,10 @@ class MemoryTest(unittest.TestCase):
 
         # Assert again
         for addr in concretes:
-            byte = mem[addr]
-            self.assertFalse(issymbolic(byte))
+            self.assertFalse(issymbolic(mem[addr]))
 
         for addr in symbolics:
-            byte = mem[addr]
-            self.assertTrue(issymbolic(byte))
+            self.assertTrue(issymbolic(mem[addr]))
 
         # And reassert the internal symbolic chunks dict representation
         expected_symbolic_chunks = {
@@ -1182,28 +1178,31 @@ class MemoryTest(unittest.TestCase):
         self.assertDictEqual(mem._symbols, expected_symbolic_chunks)
 
         # Do a write to memory that combines concrete and symbolic value and see if it succeeds
-        symbolic_bytes = [cs.new_bitvec(8) for _ in range(3)]
-        mem[buf + 0x10 : buf + 0x15] = (
+        symbolic_bytes = [cs.new_bitvec(8) for _ in range(4)]
+        mem[buf + 0x10 : buf + 0x17] = (
             symbolic_bytes[0],
-            "A",
+            'A',  # will be converted to b'A'
             symbolic_bytes[1],
-            "B",
             symbolic_bytes[2],
+            b'B',
+            b'C',
+            symbolic_bytes[3],
         )
 
         # And assert it!
-        expected_symbolic_chunks[buf + 0x10] = [(True, symbolic_bytes[0])]
-        expected_symbolic_chunks[buf + 0x12] = [(True, symbolic_bytes[1])]
-        expected_symbolic_chunks[buf + 0x14] = [(True, symbolic_bytes[2])]
+        for idx, symbolic_val in zip((0x10, 0x12, 0x13, 0x16), symbolic_bytes):
+            addr = buf + idx
+            self.assertIs(mem[addr], symbolic_val)  # We can't do assertEqual as `==` operator leads to an expression
+            self.assertTrue(issymbolic(mem[addr]))
+            expected_symbolic_chunks[addr] = [(True, symbolic_val)]
 
-        for idx in (0x10, 0x12, 0x14):
-            self.assertTrue(issymbolic(mem[buf + idx]))
-
-        for idx in (0x11, 0x13):
-            self.assertFalse(issymbolic(mem[buf + idx]))
+        for idx, val in ((0x11, b'A'), (0x14, b'B'), (0x15, b'C')):
+            byte = mem[buf + idx]
+            self.assertEqual(byte, val)
+            self.assertFalse(issymbolic(byte))
 
         self.assertDictEqual(mem._symbols, expected_symbolic_chunks)
-        self.assertEqual(len(mem._symbols), 7)  # Sanity check if keys didn't overlap
+        self.assertEqual(len(mem._symbols), 8)  # Sanity check if keys didn't overlap
 
     def test_one_concrete_one_symbolic(self):
         # global mainsolver

--- a/tests/native/test_memory.py
+++ b/tests/native/test_memory.py
@@ -1699,8 +1699,8 @@ class MemoryTest(unittest.TestCase):
         mem.write(addr + 1, "b")
         writes = mem.pop_record_writes()
 
-        self.assertIn((addr, ["a"]), writes)
-        self.assertIn((addr + 1, ["b"]), writes)
+        self.assertIn((addr, "a"), writes)
+        self.assertIn((addr + 1, "b"), writes)
 
     def test_mem_trace_no_overwrites(self):
         cs = ConstraintSet()
@@ -1713,8 +1713,8 @@ class MemoryTest(unittest.TestCase):
         mem.write(addr, "b")
         writes = mem.pop_record_writes()
 
-        self.assertIn((addr, ["a"]), writes)
-        self.assertIn((addr, ["b"]), writes)
+        self.assertIn((addr, "a"), writes)
+        self.assertIn((addr, "b"), writes)
 
     def test_mem_trace_nested(self):
         cs = ConstraintSet()
@@ -1732,17 +1732,17 @@ class MemoryTest(unittest.TestCase):
         outer_writes = mem.pop_record_writes()
 
         # Make sure writes do not appear in a trace started after them
-        self.assertNotIn((addr, ["a"]), inner_writes)
-        self.assertNotIn((addr + 1, ["b"]), inner_writes)
+        self.assertNotIn((addr, "a"), inner_writes)
+        self.assertNotIn((addr + 1, "b"), inner_writes)
         # Make sure the first two are in the outer write
-        self.assertIn((addr, ["a"]), outer_writes)
-        self.assertIn((addr + 1, ["b"]), outer_writes)
+        self.assertIn((addr, "a"), outer_writes)
+        self.assertIn((addr + 1, "b"), outer_writes)
         # Make sure the last two are in the inner write
-        self.assertIn((addr + 2, ["c"]), inner_writes)
-        self.assertIn((addr + 3, ["d"]), inner_writes)
+        self.assertIn((addr + 2, "c"), inner_writes)
+        self.assertIn((addr + 3, "d"), inner_writes)
         # Make sure the last two are also in the outer write
-        self.assertIn((addr + 2, ["c"]), outer_writes)
-        self.assertIn((addr + 3, ["d"]), outer_writes)
+        self.assertIn((addr + 2, "c"), outer_writes)
+        self.assertIn((addr + 3, "d"), outer_writes)
 
     def test_mem_trace_ignores_failing(self):
         cs = ConstraintSet()

--- a/tests/native/test_memory.py
+++ b/tests/native/test_memory.py
@@ -1181,22 +1181,24 @@ class MemoryTest(unittest.TestCase):
         symbolic_bytes = [cs.new_bitvec(8) for _ in range(4)]
         mem[buf + 0x10 : buf + 0x17] = (
             symbolic_bytes[0],
-            'A',  # will be converted to b'A'
+            "A",  # will be converted to b'A'
             symbolic_bytes[1],
             symbolic_bytes[2],
-            b'B',
-            b'C',
+            b"B",
+            b"C",
             symbolic_bytes[3],
         )
 
         # And assert it!
         for idx, symbolic_val in zip((0x10, 0x12, 0x13, 0x16), symbolic_bytes):
             addr = buf + idx
-            self.assertIs(mem[addr], symbolic_val)  # We can't do assertEqual as `==` operator leads to an expression
+            self.assertIs(
+                mem[addr], symbolic_val
+            )  # We can't do assertEqual as `==` operator leads to an expression
             self.assertTrue(issymbolic(mem[addr]))
             expected_symbolic_chunks[addr] = [(True, symbolic_val)]
 
-        for idx, val in ((0x11, b'A'), (0x14, b'B'), (0x15, b'C')):
+        for idx, val in ((0x11, b"A"), (0x14, b"B"), (0x15, b"C")):
             byte = mem[buf + idx]
             self.assertEqual(byte, val)
             self.assertFalse(issymbolic(byte))


### PR DESCRIPTION
This is a better version of https://github.com/trailofbits/manticore/pull/1465.

This PR improves performance of `SMemory` concrete writes so we write concrete bytes in chunks instead of one by one.

Unlike #1465, this PR does not introduce `write1` which was a specialized `write` for single concrete bytes write.

I benchmarked master vs this PR vs #1465 via this code:
```python
import time
def test_write_concrete():
    from manticore.core.smtlib import ConstraintSet
    from manticore.native.memory import SMemory32

    string = 'a' * 0x1000

    mem = SMemory32(ConstraintSet())
    buf = mem.mmap(None, 0x1000, "rw")

    t1 = time.time()
    for i in range(1000):
        mem[buf:buf+0x1000] = string
    t2 = time.time()

    print(f"test_write_concrete: {t2-t1} seconds")

    assert mem[buf:buf+0x1000] == [b'a'] * 0x1000

test_write_concrete()
```

Results TLDR - master 54s, this PR 3.1s, #1465 2.8s.

![image](https://user-images.githubusercontent.com/10009354/63469257-14706b00-c46a-11e9-983c-19d2ab5b8b64.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1509)
<!-- Reviewable:end -->
