### PR TITLE
Fixes ConstraintSet.new_bitvec size check

### DIFF
--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -357,7 +357,7 @@ class ConstraintSet:
             :return: a fresh BitVecVariable
         """
         if size <= 0:
-            raise Exception(f"Bitvec size ({size}) can't be negative")
+            raise ValueError(f"Bitvec size ({size}) can't be equal to or less than 0")
         if name is None:
             name = "BV"
             avoid_collisions = True

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -356,8 +356,8 @@ class ConstraintSet:
             :param avoid_collisions: potentially avoid_collisions the variable to avoid name collisions if True
             :return: a fresh BitVecVariable
         """
-        if not (size == 1 or size % 8 == 0):
-            raise Exception(f"Invalid bitvec size {size}")
+        if size <= 0:
+            raise Exception(f"Bitvec size ({size}) can't be negative")
         if name is None:
             name = "BV"
             avoid_collisions = True

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -81,6 +81,18 @@ class ExpressionTest(unittest.TestCase):
         self.assertTrue("SOURCE3" in x.taint)
         self.assertTrue("SOURCE4" in x.taint)
 
+    def test_cs_new_bitvec_invalid_size(self):
+        cs = ConstraintSet()
+        with self.assertRaises(ValueError) as e:
+            cs.new_bitvec(size=0)
+
+        self.assertEqual(str(e.exception), "Bitvec size (0) can't be equal to or less than 0")
+
+        with self.assertRaises(ValueError) as e:
+            cs.new_bitvec(size=-23)
+
+        self.assertEqual(str(e.exception), "Bitvec size (-23) can't be equal to or less than 0")
+
     def testBasicConstraints(self):
         cs = ConstraintSet()
         a = cs.new_bitvec(32)


### PR DESCRIPTION
Previously the `new_bitvec` checked for `size == 1 or size % 8 == 0`.

This check allowed to create a bitvec with negative size, as in `cs.new_bitvec(-8)`.

It was also too constrained, as we might have cases where we want to constraint ourselves to e.g. 5 bits out of 8 bits of a byte). Sure, this can be done via setting a constrain over an 8-bit (1 Byte) bitvector, but it might be not the most efficient solution(?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trailofbits/manticore/1511)
<!-- Reviewable:end -->
