### PR TITLE
Add partial implementation of recvfrom syscall

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2117,21 +2117,21 @@ class Linux(Platform):
 
     def sys_recv(self, sockfd, buf, count, flags, trace_str="_recv"):
         data: bytes = bytes()
-        if count != 0:
-            if buf not in self.current.memory or (buf + count) not in self.current.memory:
-                logger.info("buf or (buf + count) points to invalid address. Returning EFAULT")
-                return -errno.EFAULT
+        if buf not in self.current.memory or (buf + count) not in self.current.memory:
+            logger.info("buf or (buf + count) points to invalid address. Returning EFAULT")
+            return -errno.EFAULT
 
-            try:
-                sock = self._get_fd(sockfd)
-            except FdError:
-                return -errno.EINVAL
+        try:
+            sock = self._get_fd(sockfd)
+        except FdError:
+            return -errno.EBADF
 
-            if not isinstance(sock, Socket):
-                return -errno.ENOTSOCK
-            data = sock.read(count)
-            self.syscall_trace.append((trace_str, sockfd, data))
-            self.current.write_bytes(buf, data)
+        if not isinstance(sock, Socket):
+            return -errno.ENOTSOCK
+
+        data = sock.read(count)
+        self.syscall_trace.append((trace_str, sockfd, data))
+        self.current.write_bytes(buf, data)
 
         return len(data)
 

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2118,8 +2118,8 @@ class Linux(Platform):
     def sys_recv(self, sockfd, buf, count, flags, trace_str="_recv"):
         data: bytes = bytes()
         if count != 0:
-            if buf not in self.current.memory:
-                logger.info("buf points to invalid address. Returning EFAULT")
+            if buf not in self.current.memory or (buf + count) not in self.current.memory:
+                logger.info("buf or (buf + count) points to invalid address. Returning EFAULT")
                 return -errno.EFAULT
 
             try:

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2955,7 +2955,7 @@ class SLinux(Linux):
 
         return super().sys_write(fd, buf, count)
 
-    def sys_recv(self, sockfd, buf, count, flags, trace_str='_recv'):
+    def sys_recv(self, sockfd, buf, count, flags, trace_str="_recv"):
         if issymbolic(sockfd):
             logger.debug("Ask to read from a symbolic file descriptor!!")
             raise ConcretizeArgument(self, 0)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2117,8 +2117,8 @@ class Linux(Platform):
 
     def sys_recv(self, sockfd, buf, count, flags, trace_str="_recv"):
         data: bytes = bytes()
-        if buf not in self.current.memory or (buf + count) not in self.current.memory:
-            logger.info("buf or (buf + count) points to invalid address. Returning EFAULT")
+        if not self.current.memory.access_ok(slice(buf, buf + count), "w"):
+            logger.info("RECV: buf within invalid memory. Returning EFAULT")
             return -errno.EFAULT
 
         try:

--- a/tests/native/test_syscalls.py
+++ b/tests/native/test_syscalls.py
@@ -177,6 +177,21 @@ class LinuxTest(unittest.TestCase):
         wrote = self.linux.sys_recvfrom(conn_fd, 0x1100, 10, 0x0, 0x0, 0x0)
         self.assertEqual(wrote, -errno.EINVAL)
 
+    @unittest.expectedFailure
+    def test_multiple_sockets(self):
+        sock_fd = self.linux.sys_socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        self.assertEqual(sock_fd, 3)
+        self.linux.sys_bind(sock_fd, None, None)
+        self.linux.sys_listen(sock_fd, None)
+        conn_fd = self.linux.sys_accept(sock_fd, None, 0)
+        self.assertEqual(conn_fd, 4)
+        self.linux.sys_close(conn_fd)
+
+        conn_fd = -1
+        # Fails with "Name socket4 already in use"
+        conn_fd = self.linux.sys_accept(sock_fd, None, 0)
+        self.assertEqual(conn_fd, 4)
+
     def test_unimplemented(self):
         stubs = linux_syscall_stubs.SyscallStubs(default_to_fail=False)
 

--- a/tests/native/test_syscalls.py
+++ b/tests/native/test_syscalls.py
@@ -175,7 +175,7 @@ class LinuxTest(unittest.TestCase):
 
         self.linux.sys_close(conn_fd)
         wrote = self.linux.sys_recvfrom(conn_fd, 0x1100, 10, 0x0, 0x0, 0x0)
-        self.assertEqual(wrote, -errno.EINVAL)
+        self.assertEqual(wrote, -errno.EBADF)
 
     @unittest.expectedFailure
     def test_multiple_sockets(self):


### PR DESCRIPTION
This partial implementation does not handle src_addr and addrlen
arguments, which means this recvfrom acts like a recv syscall