### PR TITLE
Fix assertion failure in mappingchallenge.py

### DIFF
--- a/examples/evm/mappingchallenge.py
+++ b/examples/evm/mappingchallenge.py
@@ -64,4 +64,4 @@ for st in m.all_states:
     if st.can_be_true(flag_value != 0):
         print("Flag Found! Check ", m.workspace)
         st.constraints.add(flag_value != 0)
-        m.generate_testcase(st, "Flag Found", "")
+        m.generate_testcase(st, "Flag Found")


### PR DESCRIPTION
https://github.com/trailofbits/manticore/blob/085c1d4d4558a8267a4873b6e157acc9ef361a6a/examples/evm/mappingchallenge.py#L67
The above line causes an assertion failure because the last argument should be an expression, not a string.  This pull request eliminates the last argument to that call, allowing it to default to `None`.