### PR TITLE
Add serialization/deserialization log messages.

### DIFF
--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -79,6 +79,7 @@ class PickleSerializer(StateSerializer):
         sys.setrecursionlimit(PickleSerializer.DEFAULT_RECURSION)
 
     def serialize(self, state, f):
+        logger.info(f"Serializing %s", f.name)
         try:
             f.write(pickle.dumps(state, 2))
         except RuntimeError:
@@ -92,4 +93,5 @@ class PickleSerializer(StateSerializer):
             self.serialize(state, f)
 
     def deserialize(self, f):
+        logger.info(f"Deserializing %s", f.name)
         return pickle.load(f)

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -79,7 +79,7 @@ class PickleSerializer(StateSerializer):
         sys.setrecursionlimit(PickleSerializer.DEFAULT_RECURSION)
 
     def serialize(self, state, f):
-        logger.info("Serializing %s", f.name if hasattr(f, "name") else "<unkown>")
+        logger.info("Serializing %s", f.name if hasattr(f, "name") else "<unknown>")
         try:
             f.write(pickle.dumps(state, 2))
         except RuntimeError:
@@ -93,5 +93,5 @@ class PickleSerializer(StateSerializer):
             self.serialize(state, f)
 
     def deserialize(self, f):
-        logger.info("Deserializing %s", f.name if hasattr(f, "name") else "<unkown>")
+        logger.info("Deserializing %s", f.name if hasattr(f, "name") else "<unknown>")
         return pickle.load(f)

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -79,7 +79,7 @@ class PickleSerializer(StateSerializer):
         sys.setrecursionlimit(PickleSerializer.DEFAULT_RECURSION)
 
     def serialize(self, state, f):
-        logger.info(f"Serializing %s", f.name)
+        logger.info("Serializing %s", f.name if hasattr(f, "name") else "<unkown>")
         try:
             f.write(pickle.dumps(state, 2))
         except RuntimeError:
@@ -93,5 +93,5 @@ class PickleSerializer(StateSerializer):
             self.serialize(state, f)
 
     def deserialize(self, f):
-        logger.info(f"Deserializing %s", f.name)
+        logger.info("Deserializing %s", f.name if hasattr(f, "name") else "<unkown>")
         return pickle.load(f)


### PR DESCRIPTION
Note that these log messages are currently "invisible" as there is no
verbosity level that includes "manticore.util.helpers" in log.py.  These
log messages will be made visisble by a subsequent commit.