### PR TITLE
Clean-up log

### DIFF
--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -89,31 +89,26 @@ def get_levels():
         [(x, DEFAULT_LOG_LEVEL) for x in all_loggers],
         # 1
         [
-            ("manticore.manticore", logging.INFO),
-            ("manticore.main", logging.INFO),
             ("manticore.ethereum.*", logging.INFO),
             ("manticore.native.*", logging.INFO),
             ("manticore.core.manticore", logging.INFO),
         ],
         # 2 (-v)
         [
-            ("manticore.core.executor", logging.INFO),
+            ("manticore.core.worker", logging.INFO),
             ("manticore.platforms.*", logging.DEBUG),
             ("manticore.ethereum", logging.DEBUG),
             ("manticore.core.plugin", logging.DEBUG),
-            ("manticore.util.emulate", logging.INFO),
+            ("manticore.utils.emulate", logging.INFO),
+            ("manticore.utils.helpers", logging.INFO),
         ],
         # 3 (-vv)
         [("manticore.native.cpu.*", logging.DEBUG)],
         # 4 (-vvv)
-        [
-            ("manticore.native.memory", logging.DEBUG),
-            ("manticore.native.cpu.*", logging.DEBUG),
-            ("manticore.native.cpu.*.registers", logging.DEBUG),
-        ],
+        [("manticore.native.memory", logging.DEBUG)],
         # 5 (-vvvv)
         [
-            ("manticore.manticore", logging.DEBUG),
+            ("manticore.core.manticore", logging.DEBUG),
             ("manticore.ethereum.*", logging.DEBUG),
             ("manticore.native.*", logging.DEBUG),
             ("manticore.core.smtlib", logging.DEBUG),

--- a/tests/ethereum/test_regressions.py
+++ b/tests/ethereum/test_regressions.py
@@ -97,8 +97,8 @@ class IntegrationTest(unittest.TestCase):
         # but this seems as a good default
         self.assertGreaterEqual(len(output), 3)
         # self.assertIn(b'm.c.manticore:INFO: Verbosity set to 1.', output[0])
-        self.assertIn(b"m.main:INFO: Registered plugins: ", output[0])
-        self.assertIn(b"m.main:INFO: Beginning analysis", output[1])
+        self.assertIn(b"m.ethereum:INFO: Registered plugins: ", output[0])
+        self.assertIn(b"m.ethereum:INFO: Beginning analysis", output[1])
         self.assertTrue(
             any(b"m.e.manticore:INFO: Starting symbolic create contract" in o for o in output)
         )


### PR DESCRIPTION
This commit does two things: (1) repair log "paths" that appear to be
non-existent/out-of-date, and (2) add the "manticore.utils.helper",
logging.INFO "path".

I added the new "helper" path to level 2, but I am open to changing
this.