### PR TITLE
Clean-up log

### DIFF
--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -89,7 +89,6 @@ def get_levels():
         [(x, DEFAULT_LOG_LEVEL) for x in all_loggers],
         # 1
         [
-            ("manticore.manticore", logging.INFO),
             ("manticore.main", logging.INFO),
             ("manticore.ethereum.*", logging.INFO),
             ("manticore.native.*", logging.INFO),
@@ -97,11 +96,12 @@ def get_levels():
         ],
         # 2 (-v)
         [
-            ("manticore.core.executor", logging.INFO),
+            ("manticore.core.worker", logging.INFO),
             ("manticore.platforms.*", logging.DEBUG),
             ("manticore.ethereum", logging.DEBUG),
             ("manticore.core.plugin", logging.DEBUG),
-            ("manticore.util.emulate", logging.INFO),
+            ("manticore.utils.emulate", logging.INFO),
+            ("manticore.utils.helpers", logging.INFO),
         ],
         # 3 (-vv)
         [("manticore.native.cpu.*", logging.DEBUG)],
@@ -113,7 +113,7 @@ def get_levels():
         ],
         # 5 (-vvvv)
         [
-            ("manticore.manticore", logging.DEBUG),
+            ("manticore.core.manticore", logging.DEBUG),
             ("manticore.ethereum.*", logging.DEBUG),
             ("manticore.native.*", logging.DEBUG),
             ("manticore.core.smtlib", logging.DEBUG),


### PR DESCRIPTION
This commit does two things: (1) repair log "paths" that appear to be
non-existent/out-of-date, and (2) add the "manticore.utils.helper",
logging.INFO "path".

I added the new "helper" path to level 2, but I am open to changing
this.