### PR TITLE
perf: optimize decode_instruction

### DIFF
--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -889,11 +889,10 @@ class Cpu(Eventful):
         text = b""
 
         # Read Instruction from memory
-        for address in range(pc, pc + self.max_instr_width):
+        maxexecsize = self.memory.max_exec_size(pc, self.max_instr_width)
+        for address in range(pc, pc + maxexecsize):
             # This reads a byte from memory ignoring permissions
             # and concretize it if symbolic
-            if not self.memory.access_ok(address, "x"):
-                break
 
             c = self.memory[address]
 

--- a/manticore/native/memory.py
+++ b/manticore/native/memory.py
@@ -892,6 +892,19 @@ class Memory(object, metaclass=ABCMeta):
         else:
             return self.map_containing(index).perms
 
+    def max_exec_size(self, index, size):
+        r = 0
+        addr = index
+        while addr < index + size:
+            if addr not in self:
+                return r
+            m = self.map_containing(addr)
+            if not m.access_ok("x"):
+                return r
+            r += m.end - addr
+            addr = m.end
+        return size
+
     def access_ok(self, index, access, force=False):
         if isinstance(index, slice):
             assert index.stop - index.start >= 0


### PR DESCRIPTION
By avoiding multiple calls to memory `access_ok`

Tested on multiple_styles :
There are 387008 calls to `access_ok` from `decode_instruction for 3.5 seconds

With the PR, there are
25268 calls to `access_ok` from `decode_instruction for 0.3 seconds
25268 calls to `max_exec_size` from `decode_instruction for 0.3 seconds