### PR TITLE
Simplify the pc whenever it is set.

### DIFF
--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -266,6 +266,7 @@ class ConstantFolderSimplifier(Visitor):
         BitVecSub: operator.__sub__,
         BitVecMul: operator.__mul__,
         BitVecDiv: operator.__truediv__,
+        BitVecUnsignedDiv: operator.__floordiv__,
         BitVecShiftLeft: operator.__lshift__,
         BitVecShiftRight: operator.__rshift__,
         BitVecAnd: operator.__and__,

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -379,12 +379,12 @@ class ArithmeticSimplifier(Visitor):
             return expression
 
     def visit_BitVecITE(self, expression, *operands):
-        # FIXME Enable some taint propagating optimization
-        if isinstance(expression.operands[0], Constant) and not expression.operands[0].taint:
+        if isinstance(expression.operands[0], Constant):
             if expression.operands[0].value:
                 result = expression.operands[1]
             else:
                 result = expression.operands[2]
+            result._taint |= expression.operands[0].taint
             return result
 
         if self._changed(expression, operands):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -1,6 +1,7 @@
 from ...utils.helpers import CacheDict
 from .expression import *
 from functools import lru_cache
+import copy
 import logging
 import operator
 
@@ -111,8 +112,6 @@ class Visitor:
     def _rebuild(expression, operands):
         if isinstance(expression, Operation):
             if any(x is not y for x, y in zip(expression.operands, operands)):
-                import copy
-
                 aux = copy.copy(expression)
                 aux._operands = operands
                 return aux
@@ -384,7 +383,10 @@ class ArithmeticSimplifier(Visitor):
                 result = expression.operands[1]
             else:
                 result = expression.operands[2]
-            result._taint |= expression.operands[0].taint
+            new_taint = result._taint | expression.operands[0].taint
+            if result._taint != new_taint:
+                result = copy.copy(result)
+                result._taint = new_taint
             return result
 
         if self._changed(expression, operands):

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -720,7 +720,7 @@ class EVM(Eventful):
         # self.invalid = set()
 
         # Machine state
-        self.pc = 0
+        self._pc = 0
         self.stack = []
         # We maintain gas as a 512 bits internally to avoid overflows
         # it is shortened to 256 bits when it is used by the GAS instruction

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -739,6 +739,14 @@ class EVM(Eventful):
         self._valid_jmpdests = set()
 
     @property
+    def pc(self):
+        return self._pc
+
+    @pc.setter
+    def pc(self, pc):
+        self._pc = simplify(pc)
+
+    @property
     def bytecode(self):
         return self._bytecode
 

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1131,7 +1131,7 @@ class EVM(Eventful):
         last_pc, last_gas, last_instruction, last_arguments, fee, allocated = self._checkpoint_data
         self._push_arguments(last_arguments)
         self._gas = last_gas
-        self._pc = last_pc
+        self.pc = last_pc
         self._allocated = allocated
         self._checkpoint_data = None
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -533,6 +533,17 @@ class ExpressionTest(unittest.TestCase):
         )
         self.assertEqual(translate_to_smtlib(simplify(c)), "((_ extract 23 8) VARA)")
 
+    def test_arithmetic_simplify_udiv(self):
+        cs = ConstraintSet()
+        a = cs.new_bitvec(32, name="VARA")
+        b = a + Operators.UDIV(BitVecConstant(32, 0), BitVecConstant(32, 2))
+        self.assertEqual(translate_to_smtlib(b), "(bvadd VARA (bvudiv #x00000000 #x00000002))")
+        self.assertEqual(translate_to_smtlib(simplify(b)), "VARA")
+
+        c = a + Operators.UDIV(BitVecConstant(32, 2), BitVecConstant(32, 2))
+        self.assertEqual(translate_to_smtlib(c), "(bvadd VARA (bvudiv #x00000002 #x00000002))")
+        self.assertEqual(translate_to_smtlib(simplify(c)), "(bvadd VARA #x00000001)")
+
     def testBasicReplace(self):
         """ Add """
         a = BitVecConstant(32, 100)


### PR DESCRIPTION
This pull request simplifies `pc` using `simplify` in `visitor.py` whenever `pc` is set. This gives a significant speed-up whenever `DetectIntegerOverflow` is enabled. I think this is because that detector's use of taint cause `pc` to become symbolic, but in a way that can be simplified.

To demonstrate the speed-up, I performed the following experiment. I introduced `DetectIntegerOverflow` to eight examples in `examples/evm` and timed them using both the `master` and `simplify-pc` branches. I performed ten runs of each, interleaved to even out load spikes, and summed the timings of the corresponding runs. Results appear below.

To repeat my experiment, perform the following steps.
1. Drop the four scripts in [simplify-pc.zip](https://github.com/trailofbits/manticore/files/3581480/simplify-pc.zip) into `examples/evm`.
2. Run `./patch.sh *.py`.
3. Run `./loop.sh`.

Here is sample output. Note that toward the end, I added the `<==` to draw your attention to where there were significant differences. But everything else is untouched.
```
Switched to branch 'master'
complete.py	2.94
coverage.py	28.90
minimal_bytecode_only.py	5.52
minimal-json.py	9.04
minimal.py	6.92
reentrancy_concrete.py	40.36
simple_mapping.py	8.46
use_def.py	3.61
Switched to branch 'simplify-pc'
complete.py	3.03
coverage.py	28.94
minimal_bytecode_only.py	3.78
minimal-json.py	9.19
minimal.py	5.42
reentrancy_concrete.py	21.41
simple_mapping.py	8.64
use_def.py	3.70
Switched to branch 'master'
complete.py	2.95
coverage.py	29.31
minimal_bytecode_only.py	5.23
minimal-json.py	8.99
minimal.py	6.80
reentrancy_concrete.py	40.22
simple_mapping.py	8.39
use_def.py	3.62
Switched to branch 'simplify-pc'
complete.py	3.05
coverage.py	28.20
minimal_bytecode_only.py	3.83
minimal-json.py	8.87
minimal.py	5.31
reentrancy_concrete.py	21.88
simple_mapping.py	8.40
use_def.py	3.51
Switched to branch 'master'
complete.py	2.89
coverage.py	27.84
minimal_bytecode_only.py	5.06
minimal-json.py	9.56
minimal.py	7.13
reentrancy_concrete.py	39.58
simple_mapping.py	8.74
use_def.py	3.66
Switched to branch 'simplify-pc'
complete.py	2.91
coverage.py	29.12
minimal_bytecode_only.py	3.61
minimal-json.py	9.06
minimal.py	5.07
reentrancy_concrete.py	22.35
simple_mapping.py	8.54
use_def.py	3.66
Switched to branch 'master'
complete.py	3.07
coverage.py	29.23
minimal_bytecode_only.py	4.95
minimal-json.py	9.17
minimal.py	7.27
reentrancy_concrete.py	39.38
simple_mapping.py	8.70
use_def.py	3.44
Switched to branch 'simplify-pc'
complete.py	2.83
coverage.py	29.76
minimal_bytecode_only.py	3.91
minimal-json.py	8.94
minimal.py	5.39
reentrancy_concrete.py	21.88
simple_mapping.py	8.63
use_def.py	3.73
Switched to branch 'master'
complete.py	3.10
coverage.py	28.68
minimal_bytecode_only.py	4.91
minimal-json.py	8.83
minimal.py	7.11
reentrancy_concrete.py	40.42
simple_mapping.py	8.84
use_def.py	3.67
Switched to branch 'simplify-pc'
complete.py	2.95
coverage.py	28.50
minimal_bytecode_only.py	3.77
minimal-json.py	9.17
minimal.py	5.30
reentrancy_concrete.py	21.78
simple_mapping.py	8.13
use_def.py	3.61
Switched to branch 'master'
complete.py	2.96
coverage.py	30.77
minimal_bytecode_only.py	4.99
minimal-json.py	9.46
minimal.py	7.27
reentrancy_concrete.py	39.46
simple_mapping.py	8.04
use_def.py	3.45
Switched to branch 'simplify-pc'
complete.py	3.26
coverage.py	29.08
minimal_bytecode_only.py	3.64
minimal-json.py	8.88
minimal.py	5.25
reentrancy_concrete.py	21.44
simple_mapping.py	8.61
use_def.py	3.85
Switched to branch 'master'
complete.py	3.08
coverage.py	29.19
minimal_bytecode_only.py	4.92
minimal-json.py	8.88
minimal.py	6.84
reentrancy_concrete.py	39.61
simple_mapping.py	8.33
use_def.py	3.66
Switched to branch 'simplify-pc'
complete.py	3.05
coverage.py	28.98
minimal_bytecode_only.py	3.71
minimal-json.py	9.17
minimal.py	5.02
reentrancy_concrete.py	21.66
simple_mapping.py	8.63
use_def.py	3.60
Switched to branch 'master'
complete.py	2.91
coverage.py	29.14
minimal_bytecode_only.py	4.88
minimal-json.py	9.05
minimal.py	6.90
reentrancy_concrete.py	40.33
simple_mapping.py	8.68
use_def.py	3.49
Switched to branch 'simplify-pc'
complete.py	3.01
coverage.py	28.80
minimal_bytecode_only.py	3.76
minimal-json.py	9.22
minimal.py	5.21
reentrancy_concrete.py	21.42
simple_mapping.py	8.37
use_def.py	3.70
Switched to branch 'master'
complete.py	2.98
coverage.py	28.10
minimal_bytecode_only.py	5.00
minimal-json.py	9.18
minimal.py	6.88
reentrancy_concrete.py	39.61
simple_mapping.py	8.27
use_def.py	3.94
Switched to branch 'simplify-pc'
complete.py	2.98
coverage.py	28.01
minimal_bytecode_only.py	3.76
minimal-json.py	9.27
minimal.py	5.21
reentrancy_concrete.py	22.00
simple_mapping.py	8.69
use_def.py	3.92
Switched to branch 'master'
complete.py	3.02
coverage.py	27.63
minimal_bytecode_only.py	4.99
minimal-json.py	9.24
minimal.py	6.97
reentrancy_concrete.py	40.30
simple_mapping.py	8.42
use_def.py	3.58
Switched to branch 'simplify-pc'
complete.py	2.89
coverage.py	28.92
minimal_bytecode_only.py	3.57
minimal-json.py	9.17
minimal.py	5.50
reentrancy_concrete.py	21.37
simple_mapping.py	8.40
use_def.py	3.71

summary
29.90	29.96
288.79	288.31
50.45	37.34	<== minimal_bytecode_only.py
91.40	90.94
70.09	52.68	<== minimal.py
399.27	217.19	<== reentrancy_concrete.py
84.87	85.04
36.12	36.99
```
As you can see from the above, when `DetectIntegerOverflow` is enabled, `simplify-pc` significantly speeds up `minimal_bytecode_only.py`, `minimal.py`, and `reentrancy_concrete.py`, and has a negligible effect elsewhere.