### PR TITLE
performance: faster program load with faster memory write

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1047,7 +1047,7 @@ class Linux(Platform):
             logger.debug(
                 f"Zeroing main elf fractional pages. From bss({elf_bss:x}) to brk({elf_brk:x}), {bytes_to_clear} bytes."
             )
-            cpu.write_bytes(elf_bss, "\x00" * bytes_to_clear, force=True)
+            cpu.memory.write(elf_bss, "\x00" * bytes_to_clear, force=True)
 
         stack_size = 0x21000
 
@@ -1128,7 +1128,7 @@ class Linux(Platform):
                 logger.debug(
                     f"Zeroing interpreter elf fractional pages. From bss({elf_bss:x}) to brk({elf_brk:x}), {bytes_to_clear} bytes."
                 )
-                cpu.write_bytes(elf_bss, "\x00" * bytes_to_clear, force=True)
+                cpu.memory.write(elf_bss, "\x00" * bytes_to_clear, force=True)
 
         # free reserved brk space
         cpu.memory.munmap(reserved, 0x1000000)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1048,6 +1048,7 @@ class Linux(Platform):
                 f"Zeroing main elf fractional pages. From bss({elf_bss:x}) to brk({elf_brk:x}), {bytes_to_clear} bytes."
             )
             cpu.memory.write(elf_bss, "\x00" * bytes_to_clear, force=True)
+            cpu._publish("did_write_memory", elf_bss, "\x00" * bytes_to_clear, 8 * bytes_to_clear)
 
         stack_size = 0x21000
 
@@ -1129,6 +1130,7 @@ class Linux(Platform):
                     f"Zeroing interpreter elf fractional pages. From bss({elf_bss:x}) to brk({elf_brk:x}), {bytes_to_clear} bytes."
                 )
                 cpu.memory.write(elf_bss, "\x00" * bytes_to_clear, force=True)
+                cpu._publish("did_write_memory", elf_bss, "\x00" * bytes_to_clear, 8 * bytes_to_clear)
 
         # free reserved brk space
         cpu.memory.munmap(reserved, 0x1000000)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1130,7 +1130,9 @@ class Linux(Platform):
                     f"Zeroing interpreter elf fractional pages. From bss({elf_bss:x}) to brk({elf_brk:x}), {bytes_to_clear} bytes."
                 )
                 cpu.memory.write(elf_bss, "\x00" * bytes_to_clear, force=True)
-                cpu._publish("did_write_memory", elf_bss, "\x00" * bytes_to_clear, 8 * bytes_to_clear)
+                cpu._publish(
+                    "did_write_memory", elf_bss, "\x00" * bytes_to_clear, 8 * bytes_to_clear
+                )
 
         # free reserved brk space
         cpu.memory.munmap(reserved, 0x1000000)


### PR DESCRIPTION
I experienced it while loading a big program (200Mb)
After more than 10 minutes waiting, I saw that I was slowly looping in `write_bytes` in abstractcpu.py as the memory type is `FileMap` and not `AnonMap`

With this simple patch, it takes less than a minute.