### PR TITLE
perf: avoid multiple calls to read same self.PC

### DIFF
--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -950,19 +950,21 @@ class Cpu(Eventful):
         """
         Decode, and execute one instruction pointed by register PC
         """
-        if issymbolic(self.PC):
+        curpc = self.PC
+        if issymbolic(curpc):
             raise ConcretizeRegister(self, "PC", policy="ALL")
-        if not self.memory.access_ok(self.PC, "x"):
-            raise InvalidMemoryAccess(self.PC, "x")
+        if not self.memory.access_ok(curpc, "x"):
+            raise InvalidMemoryAccess(curpc, "x")
 
-        self._publish("will_decode_instruction", self.PC)
+        self._publish("will_decode_instruction", curpc)
 
-        insn = self.decode_instruction(self.PC)
-        self._last_pc = self.PC
+        insn = self.decode_instruction(curpc)
+        self._last_pc = curpc
 
-        self._publish("will_execute_instruction", self.PC, insn)
+        self._publish("will_execute_instruction", curpc, insn)
 
         # FIXME (theo) why just return here?
+        # hook changed PC, so we trust that there is nothing more to do
         if insn.address != self.PC:
             return
 

--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -959,9 +959,9 @@ class Cpu(Eventful):
         self._publish("will_decode_instruction", curpc)
 
         insn = self.decode_instruction(curpc)
-        self._last_pc = curpc
+        self._last_pc = self.PC
 
-        self._publish("will_execute_instruction", curpc, insn)
+        self._publish("will_execute_instruction", self._last_pc, insn)
 
         # FIXME (theo) why just return here?
         # hook changed PC, so we trust that there is nothing more to do


### PR DESCRIPTION
Tested on example hxp2018_angrme

x86.py:696(read) drops from 900 000 calls to 500 000 calls
This results in a cumulative gain of about one second in abstractcpu.py:602(__getattr__)

For the last one, we must read again `self.PC` as `self._publish("will_execute_instruction", curpc, insn)` calls the hooks which may change the value of `self.PC`