### PR TITLE
Improvements in event publishing 

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -725,6 +725,7 @@ class ManticoreBase(Eventful):
                         )
 
         plugin.on_register()
+        return plugin
 
     @at_not_running
     def unregister_plugin(self, plugin):

--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -27,10 +27,12 @@ class Plugin:
         """
         plugin_context_name = str(type(self))
         with self.manticore.locked_context(plugin_context_name, dict) as context:
-            assert value_type in (list, dict, set)
-            ctx = context.get(key, value_type())
-            yield ctx
-            context[key] = ctx
+            if key is None:
+                yield context
+            else:
+                ctx = context.get(key, value_type())
+                yield ctx
+                context[key] = ctx
 
     @property
     def context(self):

--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -953,10 +953,14 @@ class Cpu(Eventful):
         """
         Decode, and execute one instruction pointed by register PC
         """
-        if self._delayed_event :
+        if self._delayed_event:
             self._icount += 1
-            self._publish("did_execute_instruction", self._last_pc, self.PC,
-                          self.decode_instruction(self._last_pc))
+            self._publish(
+                "did_execute_instruction",
+                self._last_pc,
+                self.PC,
+                self.decode_instruction(self._last_pc),
+            )
             self._delayed_event = False
 
         if issymbolic(self.PC):

--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -507,6 +507,7 @@ class Cpu(Eventful):
         self._concrete = kwargs.pop("concrete", False)
         self.emu = None
         self._break_unicorn_at = None
+        self._delayed_event = False
         if not hasattr(self, "disasm"):
             self.disasm = init_disassembler(self._disasm, self.arch, self.mode)
         # Ensure that regfile created STACK/PC aliases
@@ -522,6 +523,7 @@ class Cpu(Eventful):
         state["disassembler"] = self._disasm
         state["concrete"] = self._concrete
         state["break_unicorn_at"] = self._break_unicorn_at
+        state["delayed_event"] = self._delayed_event
         return state
 
     def __setstate__(self, state):
@@ -537,6 +539,7 @@ class Cpu(Eventful):
         self._disasm = state["disassembler"]
         self._concrete = state["concrete"]
         self._break_unicorn_at = state["break_unicorn_at"]
+        self._delayed_event = state["delayed_event"]
         super().__setstate__(state)
 
     @property
@@ -950,6 +953,12 @@ class Cpu(Eventful):
         """
         Decode, and execute one instruction pointed by register PC
         """
+        if self._delayed_event :
+            self._icount += 1
+            self._publish("did_execute_instruction", self._last_pc, self.PC,
+                          self.decode_instruction(self._last_pc))
+            self._delayed_event = False
+
         if issymbolic(self.PC):
             raise ConcretizeRegister(self, "PC", policy="ALL")
         if not self.memory.access_ok(self.PC, "x"):
@@ -999,7 +1008,7 @@ class Cpu(Eventful):
                     )
                     self.backup_emulate(insn)
         except (Interruption, Syscall) as e:
-            e.on_handled = lambda: self._publish_instruction_as_executed(insn)
+            self._delayed_event = True
             raise e
         else:
             self._publish_instruction_as_executed(insn)


### PR DESCRIPTION
Sometimes the "did_execute_instruction" failed to be fired after an int80 (native/x86)