### PR TITLE
fixes issue #1463 - adds signed division logic

### DIFF
--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -448,6 +448,12 @@ class BitVec(Expression):
     def rudiv(self, other):
         return BitVecUnsignedDiv(self.cast(other), self)
 
+    def sdiv(self, other):
+        return BitVecDiv(self, self.cast(other))
+
+    def rsdiv(self, other):
+        return BitVecDiv(self.cast(other), self)
+
     def srem(self, other):
         return BitVecRem(self, self.cast(other))
 

--- a/manticore/core/smtlib/operators.py
+++ b/manticore/core/smtlib/operators.py
@@ -233,9 +233,9 @@ def UDIV(dividend, divisor):
 
 def SDIV(a, b):
     if isinstance(a, BitVec):
-        return a // b
+        return a.sdiv(b)
     elif isinstance(b, BitVec):
-        return b.__rsdiv__(a)
+        return b.rsdiv(a)
     return int(math.trunc(float(a) / float(b)))
 
 


### PR DESCRIPTION
fix #1463 

**Changes:**
* Adds `sdiv, rsdiv` methods
* Changes the calls to the respective functions

**Test:**
* Manual tested with corresponding logic_bomb

**Thoughts:**
* Reused similar implementation with respect to `srem, rsrem`
* There are a number of ways we could reuse already existing functions but reimplemented these functions to match existing flow.
