### PR TITLE
fix 1427 - limit sanity check in SMTlib

### DIFF
--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -248,7 +248,7 @@ class BoolAnd(BoolOperation):
 
 
 class BoolOr(BoolOperation):
-    def __init__(self, a: Type["Bool"], b: Type["Bool"], **kwargs: Any) -> None:
+    def __init__(self, a: "Bool", b: "Bool", **kwargs: Any) -> None:
         super().__init__(a, b, **kwargs)
 
 
@@ -258,9 +258,7 @@ class BoolXor(BoolOperation):
 
 
 class BoolITE(BoolOperation):
-    def __init__(
-        self, cond: Type["Bool"], true: Type["Bool"], false: Type["Bool"], **kwargs: Any
-    ) -> None:
+    def __init__(self, cond: "Bool", true: "Bool", false: "Bool", **kwargs: Any) -> None:
         super().__init__(cond, true, false, **kwargs)
 
 
@@ -280,7 +278,7 @@ class BitVec(Expression):
         return 1 << (self.size - 1)
 
     def cast(
-        self, value: Union[Type["BitVec"], str, int, bytes], **kwargs: Any
+        self, value: Union["BitVec", str, int, bytes], **kwargs: Any
     ) -> Union["BitVecConstant", "BitVec"]:
         if isinstance(value, BitVec):
             assert value.size == self.size
@@ -563,7 +561,7 @@ class BitVecAnd(BitVecOperation):
 
 
 class BitVecOr(BitVecOperation):
-    def __init__(self, a: Type["BitVec"], b: Type["BitVec"], *args: Any, **kwargs: Any) -> None:
+    def __init__(self, a: "BitVec", b: "BitVec", *args: Any, **kwargs: Any) -> None:
         assert a.size == b.size
         super().__init__(a.size, a, b, *args, **kwargs)
 
@@ -696,7 +694,7 @@ class Array(Expression):
         assert index.size == self.index_bits
         return index
 
-    def cast_value(self, value: Type["BitVec"]) -> Union["BitVecConstant", "BitVec"]:
+    def cast_value(self, value: "BitVec") -> Union["BitVecConstant", "BitVec"]:
         if isinstance(value, (str, bytes)) and len(value) == 1:
             value = ord(value)
         if isinstance(value, int):
@@ -873,7 +871,7 @@ class ArrayVariable(Array, Variable):
 
 
 class ArrayOperation(Array, Operation):
-    def __init__(self, array: Type["Array"], *operands: Any, **kwargs: Any) -> None:
+    def __init__(self, array: "Array", *operands: Any, **kwargs: Any) -> None:
         super().__init__(
             array.index_bits, array.index_max, array.value_bits, array, *operands, **kwargs
         )
@@ -881,12 +879,7 @@ class ArrayOperation(Array, Operation):
 
 class ArrayStore(ArrayOperation):
     def __init__(
-        self,
-        array: Type["Array"],
-        index: Type["BitVec"],
-        value: Type["BitVec"],
-        *args: Any,
-        **kwargs: Any,
+        self, array: "Array", index: "BitVec", value: "BitVec", *args: Any, **kwargs: Any
     ) -> None:
         assert index.size == array.index_bits
         assert value.size == array.value_bits
@@ -911,12 +904,7 @@ class ArrayStore(ArrayOperation):
 
 class ArraySlice(Array):
     def __init__(
-        self,
-        array: Type[Union["Array", "ArrayProxy"]],
-        offset: int,
-        size: int,
-        *args: Any,
-        **kwargs: Any,
+        self, array: Union["Array", "ArrayProxy"], offset: int, size: int, *args: Any, **kwargs: Any
     ) -> None:
         if not isinstance(array, Array):
             raise ValueError("Array expected")
@@ -964,7 +952,7 @@ class ArraySlice(Array):
 
 
 class ArrayProxy(Array):
-    def __init__(self, array: Type["Array"], default: Any = None) -> None:
+    def __init__(self, array: "Array", default: Any = None) -> None:
         self._default = default
         self._concrete_cache = {}
         self._written = None
@@ -1147,9 +1135,7 @@ class ArrayProxy(Array):
 
 
 class ArraySelect(BitVec, Operation):
-    def __init__(
-        self, array: Type["Array"], index: Type["BitVec"], *args: Any, **kwargs: Any
-    ) -> None:
+    def __init__(self, array: "Array", index: "BitVec", *args: Any, **kwargs: Any) -> None:
         assert index.size == array.index_bits
         super().__init__(array.value_bits, array, index, *args, **kwargs)
 
@@ -1166,21 +1152,23 @@ class ArraySelect(BitVec, Operation):
 
 
 class BitVecSignExtend(BitVecOperation):
-    def __init__(self, operand: Type["BitVec"], size_dest: int, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, operand: "BitVec", size_dest: int, *args: Any, **kwargs: Any) -> None:
         assert size_dest >= operand.size
         super().__init__(size_dest, operand, *args, **kwargs)
         self.extend = size_dest - operand.size
 
 
 class BitVecZeroExtend(BitVecOperation):
-    def __init__(self, size_dest: int, operand: Type["BitVec"], *args: Any, **kwargs: Any) -> None:
+    def __init__(self, size_dest: int, operand: "BitVec", *args: Any, **kwargs: Any) -> None:
         assert size_dest >= operand.size
         super().__init__(size_dest, operand, *args, **kwargs)
         self.extend = size_dest - operand.size
 
 
 class BitVecExtract(BitVecOperation):
-    def __init__(self, operand: int, offset: int, size: int, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, operand: "BitVec", offset: int, size: int, *args: Any, **kwargs: Any
+    ) -> None:
         assert offset >= 0 and offset + size <= operand.size
         super().__init__(size, operand, *args, **kwargs)
         self._begining = offset
@@ -1211,8 +1199,8 @@ class BitVecITE(BitVecOperation):
         self,
         size: int,
         condition: Any,
-        true_value: Type["BitVec"],
-        false_value: Type["BitVec"],
+        true_value: "BitVec",
+        false_value: "BitVec",
         *args: Any,
         **kwargs: Any,
     ) -> None:

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -111,7 +111,7 @@ def taint_with(arg, *taints, value_bits=256, index_bits=256):
 
 
 class Variable(Expression):
-    def __init__(self, name: str, *args: Any, **kwargs: Any):
+    def __init__(self, name: str, *args, **kwargs):
         if self.__class__ is Variable:
             raise TypeError
         assert " " not in name
@@ -137,7 +137,7 @@ class Variable(Expression):
 
 
 class Constant(Expression):
-    def __init__(self, value: Union[bool, int], *args: Any, **kwargs: Any):
+    def __init__(self, value: Union[bool, int], *args, **kwargs):
         if self.__class__ is Constant:
             raise TypeError
         super().__init__(*args, **kwargs)
@@ -149,7 +149,7 @@ class Constant(Expression):
 
 
 class Operation(Expression):
-    def __init__(self, *operands: Any, **kwargs: Any):
+    def __init__(self, *operands, **kwargs):
         if self.__class__ is Operation:
             raise TypeError
         # assert len(operands) > 0
@@ -173,7 +173,7 @@ class Bool(Expression):
     def __init__(self, *operands, **kwargs):
         super().__init__(*operands, **kwargs)
 
-    def cast(self, value: Union[int, bool], **kwargs: Any) -> Union["BoolConstant", "Bool"]:
+    def cast(self, value: Union[int, bool], **kwargs) -> Union["BoolConstant", "Bool"]:
         if isinstance(value, Bool):
             return value
         return BoolConstant(bool(value), **kwargs)
@@ -225,7 +225,7 @@ class BoolVariable(Bool, Variable):
 
 
 class BoolConstant(Bool, Constant):
-    def __init__(self, value: bool, *args: Any, **kwargs: Any):
+    def __init__(self, value: bool, *args, **kwargs):
         super().__init__(value, *args, **kwargs)
 
     def __bool__(self):
@@ -248,7 +248,7 @@ class BoolAnd(BoolOperation):
 
 
 class BoolOr(BoolOperation):
-    def __init__(self, a: "Bool", b: "Bool", **kwargs: Any):
+    def __init__(self, a: "Bool", b: "Bool", **kwargs):
         super().__init__(a, b, **kwargs)
 
 
@@ -258,7 +258,7 @@ class BoolXor(BoolOperation):
 
 
 class BoolITE(BoolOperation):
-    def __init__(self, cond: "Bool", true: "Bool", false: "Bool", **kwargs: Any):
+    def __init__(self, cond: "Bool", true: "Bool", false: "Bool", **kwargs):
         super().__init__(cond, true, false, **kwargs)
 
 
@@ -278,7 +278,7 @@ class BitVec(Expression):
         return 1 << (self.size - 1)
 
     def cast(
-        self, value: Union["BitVec", str, int, bytes], **kwargs: Any
+        self, value: Union["BitVec", str, int, bytes], **kwargs
     ) -> Union["BitVecConstant", "BitVec"]:
         if isinstance(value, BitVec):
             assert value.size == self.size
@@ -475,7 +475,7 @@ class BitVecVariable(BitVec, Variable):
 
 
 class BitVecConstant(BitVec, Constant):
-    def __init__(self, size: int, value: int, *args: Any, **kwargs: Any):
+    def __init__(self, size: int, value: int, *args, **kwargs):
         super().__init__(size, value, *args, **kwargs)
 
     def __bool__(self):
@@ -561,7 +561,7 @@ class BitVecAnd(BitVecOperation):
 
 
 class BitVecOr(BitVecOperation):
-    def __init__(self, a: BitVec, b: BitVec, *args: Any, **kwargs: Any):
+    def __init__(self, a: BitVec, b: BitVec, *args, **kwargs):
         assert a.size == b.size
         super().__init__(a.size, a, b, *args, **kwargs)
 
@@ -639,12 +639,7 @@ class UnsignedGreaterOrEqual(BoolOperation):
 # Array  BV32 -> BV8  or BV64 -> BV8
 class Array(Expression):
     def __init__(
-        self,
-        index_bits: int,
-        index_max: Optional[int],
-        value_bits: int,
-        *operands: Any,
-        **kwargs: Any,
+        self, index_bits: int, index_max: Optional[int], value_bits: int, *operands, **kwargs
     ):
         assert index_bits in (32, 64, 256)
         assert value_bits in (8, 16, 32, 64, 256)
@@ -871,14 +866,14 @@ class ArrayVariable(Array, Variable):
 
 
 class ArrayOperation(Array, Operation):
-    def __init__(self, array: Array, *operands: Any, **kwargs: Any):
+    def __init__(self, array: Array, *operands, **kwargs):
         super().__init__(
             array.index_bits, array.index_max, array.value_bits, array, *operands, **kwargs
         )
 
 
 class ArrayStore(ArrayOperation):
-    def __init__(self, array: "Array", index: "BitVec", value: "BitVec", *args: Any, **kwargs: Any):
+    def __init__(self, array: "Array", index: "BitVec", value: "BitVec", *args, **kwargs):
         assert index.size == array.index_bits
         assert value.size == array.value_bits
         super().__init__(array, index, value, *args, **kwargs)
@@ -902,7 +897,7 @@ class ArrayStore(ArrayOperation):
 
 class ArraySlice(Array):
     def __init__(
-        self, array: Union["Array", "ArrayProxy"], offset: int, size: int, *args: Any, **kwargs: Any
+        self, array: Union["Array", "ArrayProxy"], offset: int, size: int, *args, **kwargs
     ):
         if not isinstance(array, Array):
             raise ValueError("Array expected")
@@ -1133,7 +1128,7 @@ class ArrayProxy(Array):
 
 
 class ArraySelect(BitVec, Operation):
-    def __init__(self, array: "Array", index: "BitVec", *args: Any, **kwargs: Any):
+    def __init__(self, array: "Array", index: "BitVec", *args, **kwargs):
         assert index.size == array.index_bits
         super().__init__(array.value_bits, array, index, *args, **kwargs)
 
@@ -1150,21 +1145,21 @@ class ArraySelect(BitVec, Operation):
 
 
 class BitVecSignExtend(BitVecOperation):
-    def __init__(self, operand: "BitVec", size_dest: int, *args: Any, **kwargs: Any):
+    def __init__(self, operand: "BitVec", size_dest: int, *args, **kwargs):
         assert size_dest >= operand.size
         super().__init__(size_dest, operand, *args, **kwargs)
         self.extend = size_dest - operand.size
 
 
 class BitVecZeroExtend(BitVecOperation):
-    def __init__(self, size_dest: int, operand: "BitVec", *args: Any, **kwargs: Any):
+    def __init__(self, size_dest: int, operand: "BitVec", *args, **kwargs):
         assert size_dest >= operand.size
         super().__init__(size_dest, operand, *args, **kwargs)
         self.extend = size_dest - operand.size
 
 
 class BitVecExtract(BitVecOperation):
-    def __init__(self, operand: "BitVec", offset: int, size: int, *args: Any, **kwargs: Any):
+    def __init__(self, operand: "BitVec", offset: int, size: int, *args, **kwargs):
         assert offset >= 0 and offset + size <= operand.size
         super().__init__(size, operand, *args, **kwargs)
         self._begining = offset
@@ -1184,7 +1179,7 @@ class BitVecExtract(BitVecOperation):
 
 
 class BitVecConcat(BitVecOperation):
-    def __init__(self, size_dest: int, *operands: Any, **kwargs: Any):
+    def __init__(self, size_dest: int, *operands, **kwargs):
         assert all(isinstance(x, BitVec) for x in operands)
         assert size_dest == sum(x.size for x in operands)
         super().__init__(size_dest, *operands, **kwargs)
@@ -1197,8 +1192,8 @@ class BitVecITE(BitVecOperation):
         condition: Union["Bool", bool],
         true_value: "BitVec",
         false_value: "BitVec",
-        *args: Any,
-        **kwargs: Any,
+        *args,
+        **kwargs,
     ):
         assert true_value.size == size
         assert false_value.size == size

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -682,20 +682,24 @@ class Array(Expression):
             return arr
         raise ValueError  # cast not implemented
 
-    def cast_index(self, index: int) -> Union[int, "BitVecConstant"]:
+    def cast_index(self, index: Union[int, "BitVec"]) -> Union["BitVecConstant", "BitVec"]:
         if isinstance(index, int):
             # assert self.index_max is None or index >= 0 and index < self.index_max
             return BitVecConstant(self.index_bits, index)
         assert index.size == self.index_bits
         return index
 
-    def cast_value(self, value: "BitVec") -> Union["BitVecConstant", "BitVec"]:
+    def cast_value(
+        self, value: Union["BitVec", str, bytes, int]
+    ) -> Union["BitVecConstant", "BitVec"]:
+        if isinstance(value, BitVec):
+            assert value.size == self.value_bits
+            return value
         if isinstance(value, (str, bytes)) and len(value) == 1:
             value = ord(value)
-        if isinstance(value, int):
-            return BitVecConstant(self.value_bits, value)
-        assert value.size == self.value_bits
-        return value
+        if not isinstance(value, int):
+            value = int(value)
+        return BitVecConstant(self.value_bits, value)
 
     def __len__(self):
         if self.index_max is None:


### PR DESCRIPTION
Would like to give #1427 a try. This is my first shot at type hints in python.

**Changes**
* (Part 1) Removed `assert isinstances` for type checks with type hints in function arguments.

**Test**
* Manual test with `mypy`

**Thoughts**
* For positional arguments, we only need to match expected value for one such argument. [ Ref: https://github.com/python/typing/issues/270, https://github.com/python/mypy/issues/5876 ]. Currently, using `Any`, suggestions?

**References**
* https://www.python.org/dev/peps/pep-0484/
* https://docs.python.org/3/library/typing.html
* https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html
* https://www.pythonlikeyoumeanit.com/Module5_OddsAndEnds/Writing_Good_Code.html
* https://stackoverflow.com/questions/15853469/putting-current-class-as-return-type-annotation

Let me know if any specific changes are also required.