### PR TITLE
Add flag to only generate alive states when finalizing Manticore

### DIFF
--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -220,6 +220,12 @@ def parse_arguments():
         help="Do not generate testcases for discovered states when analysis finishes",
     )
 
+    eth_flags.add_argument(
+        "--only-alive-testcases",
+        action="store_true",
+        help="Do not generate testcases for invalid/throwing states when analysis finishes",
+    )
+
     config_flags = parser.add_argument_group("Constants")
     config.add_config_vars_to_argparse(config_flags)
 

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -112,7 +112,7 @@ def ethereum_main(args, logger):
             )
 
         if not args.no_testcases:
-            m.finalize()
+            m.finalize(only_alive_states=args.only_alive_testcases)
         else:
             m.kill()
 

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1608,6 +1608,7 @@ class ManticoreEVM(ManticoreBase):
         transaction).
 
         :param procs: force the number of local processes to use in the reporting
+        :param bool only_alive_states: if True, killed states (revert/throw/txerror) do not generate testscases
         generation. Uses global configuration constant by default
         """
         if procs is None:

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1601,7 +1601,7 @@ class ManticoreEVM(ManticoreBase):
             filestream.write(ln)
 
     @ManticoreBase.at_not_running
-    def finalize(self, procs=None):
+    def finalize(self, procs=None, only_alive_states=False):
         """
         Terminate and generate testcases for all currently alive states (contract
         states that cleanly executed to a STOP or RETURN in the last symbolic
@@ -1618,8 +1618,11 @@ class ManticoreEVM(ManticoreBase):
         def finalizer(state_id):
             st = self._load(state_id)
             if self.fix_unsound_symbolication(st):
-                logger.debug("Generating testcase for state_id %d", state_id)
                 last_tx = st.platform.last_transaction
+                # Do not generate killed state if only_alive_states is True
+                if only_alive_states and last_tx.result in {"REVERT", "THROW", "TXERROR"}:
+                    return
+                logger.debug("Generating testcase for state_id %d", state_id)
                 message = last_tx.result if last_tx else "NO STATE RESULT (?)"
                 self.generate_testcase(st, message=message)
 


### PR DESCRIPTION
It is common to only want to see the states alive when finalizing Manticore. This PR adds this feature at the cli and script level.

- Add `--only-alive-testscases` flag
- Add `only_alive_states` to `m.finliaze` (default False)
