### PR TITLE
fix some deprecation warnings

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -63,7 +63,7 @@ consts.add("procs", default=10, description="Number of parallel processes to spa
 consts.add(
     "mprocessing",
     default=MProcessingType.multiprocessing,
-    description="single: No multiprocessing at all. Single process.\n threading: use threads\m multiprocessing: use forked processes",
+    description="single: No multiprocessing at all. Single process.\n threading: use threads\n multiprocessing: use forked processes",
 )
 consts.add(
     "seed",

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -42,11 +42,11 @@ consts.add("defaultunsat", default=True, description="Consider solver timeouts a
 
 
 # Regular expressions used by the solver
-RE_GET_EXPR_VALUE_FMT = re.compile("\(\((?P<expr>(.*))\ #x(?P<value>([0-9a-fA-F]*))\)\)")
+RE_GET_EXPR_VALUE_FMT = re.compile(r"\(\((?P<expr>(.*))\ #x(?P<value>([0-9a-fA-F]*))\)\)")
 RE_OBJECTIVES_EXPR_VALUE = re.compile(
-    "\(objectives.*\((?P<expr>.*) (?P<value>\d*)\).*\).*", re.MULTILINE | re.DOTALL
+    r"\(objectives.*\((?P<expr>.*) (?P<value>\d*)\).*\).*", re.MULTILINE | re.DOTALL
 )
-RE_MIN_MAX_OBJECTIVE_EXPR_VALUE = re.compile("(?P<expr>.*?)\s+\|->\s+(?P<value>.*)", re.DOTALL)
+RE_MIN_MAX_OBJECTIVE_EXPR_VALUE = re.compile(r"(?P<expr>.*?)\s+\|->\s+(?P<value>.*)", re.DOTALL)
 
 
 class SingletonMixin(object):

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1131,7 +1131,7 @@ class ManticoreEVM(ManticoreBase):
 
     # Callbacks for generic SYMB TABLE
     def on_unsound_symbolication(self, state, func, data, result):
-        """Apply the function func to data
+        r"""Apply the function func to data
         state: a manticore state
         func: a concrete normal python function like `sha3()`
         data: a concrete or symbolic value of the domain of func

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -516,7 +516,7 @@ class TXError(EndTx):
 
 
 def concretized_args(**policies):
-    """
+    r"""
     Make sure an EVM instruction has all of its arguments concretized according to
     provided policies.
 


### PR DESCRIPTION
This fixes some issues that would arise if you ran it under Python 3.8 (which no longer supports invalid escape chars in non-raw strings). For manticore to run cleanly under Python 3.8 we'll need to get https://github.com/ethereum/pyrlp to run a release as their last release has this same issue. They fixed it with https://github.com/ethereum/pyrlp/commit/bb898f8056da3973204c699621350bf9565e43df but haven't tagged a release since.