### PR TITLE
try refactoring to use pytest parametrization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - scripts/travis_install.sh $TEST_TYPE
 
 script:
-  - travis_wait 70 scripts/travis_test.sh $TEST_TYPE
+  - scripts/travis_test.sh $TEST_TYPE
 
 after_success:
   - ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$TEST_TYPE.json"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -6,6 +6,7 @@ function install_solc {
 }
 
 function install_mcore {
+    pip install pytest # this is for demo purposes only do not merge
     pip install -U pip
     pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -6,7 +6,7 @@ function install_solc {
 }
 
 function install_mcore {
-    pip install pytest # this is for demo purposes only do not merge
+    pip install -U pytest # this is for demo purposes only do not merge
     pip install -U pip
     pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,14 +118,8 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    coverage run -m pytest "tests/$DIR" 2>&1 >/dev/null | tee travis_tests.log
-    DID_OK=$(tail -n1 travis_tests.log)
-    if [[ "${DID_OK}" != OK* ]]; then
-        echo "Some tests failed :("
-        return 1
-    else
-        coverage xml
-    fi
+    coverage run -m pytest "tests/$DIR"
+    coverage xml
 }
 
 run_examples() {

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    coverage run -m pytest "tests/$DIR"
+    coverage run -m pytest -s "tests/$DIR"
     coverage xml
 }
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    coverage run -m unittest discover "tests/$DIR" 2>&1 >/dev/null | tee travis_tests.log
+    coverage run -m pytest "tests/$DIR" 2>&1 >/dev/null | tee travis_tests.log
     DID_OK=$(tail -n1 travis_tests.log)
     if [[ "${DID_OK}" != OK* ]]; then
         echo "Some tests failed :("

--- a/tests/ethereum/EVM/test_EVMADD.py
+++ b/tests/ethereum/EVM/test_EVMADD.py
@@ -1,16 +1,17 @@
-import struct
-import unittest
-import json
 from manticore.platforms import evm
-from manticore.core import state
-from manticore.core.smtlib import Operators, ConstraintSet
-import os
+from manticore.core.smtlib import ConstraintSet
+import pytest
 
 
-class EVMTest_ADD(unittest.TestCase):
-    _multiprocess_can_split_ = True
-    maxDiff = None
+def make_evm_world():
+    # Make the constraint store
+    constraints = ConstraintSet()
+    # make the ethereum world state
+    world = evm.EVMWorld(constraints)
+    return constraints, world
 
+
+class TestEVM_ADD:
     def _execute(self, new_vm):
         last_returned = None
         last_exception = None
@@ -34,1974 +35,344 @@ class EVMTest_ADD(unittest.TestCase):
 
         return last_exception, last_returned
 
-    def test_ADD_1(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [115792089237316195423570985008687907853269984665640564039457584007913129639934],
-        )
-
-    def test_ADD_2(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
-        )
-
-    def test_ADD_3(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [0])
-
-    def test_ADD_4(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819951],
-        )
-
-    def test_ADD_5(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301262],
-        )
-
-    def test_ADD_6(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [15])
-
-    def test_ADD_7(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [31])
-
-    def test_ADD_8(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [47])
-
-    def test_ADD_9(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718911])
-
-    def test_ADD_10(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [115792089237316195423570985008687907853269984665640564039457584007913129639935],
-        )
-
-    def test_ADD_11(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [0])
-
-    def test_ADD_12(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [1])
-
-    def test_ADD_13(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819952],
-        )
-
-    def test_ADD_14(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301263],
-        )
-
-    def test_ADD_15(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [16])
-
-    def test_ADD_16(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [32])
-
-    def test_ADD_17(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [48])
-
-    def test_ADD_18(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(0)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718912])
-
-    def test_ADD_19(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [0])
-
-    def test_ADD_20(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [1])
-
-    def test_ADD_21(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [2])
-
-    def test_ADD_22(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819953],
-        )
-
-    def test_ADD_23(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301264],
-        )
-
-    def test_ADD_24(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [17])
-
-    def test_ADD_25(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [33])
-
-    def test_ADD_26(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [49])
-
-    def test_ADD_27(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(1)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718913])
-
-    def test_ADD_28(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819951],
-        )
-
-    def test_ADD_29(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819952],
-        )
-
-    def test_ADD_30(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819953],
-        )
-
-    def test_ADD_31(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [115792089237316195423570985008687907853269984665640564039457584007913129639904],
-        )
-
-    def test_ADD_32(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [61514547407324228818772085785865451047049679353621549645961841504203850121215],
-        )
-
-    def test_ADD_33(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819968],
-        )
-
-    def test_ADD_34(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819984],
-        )
-
-    def test_ADD_35(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564820000],
-        )
-
-    def test_ADD_36(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504350043516790537761646130706531776516538464538864],
-        )
-
-    def test_ADD_37(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301262],
-        )
-
-    def test_ADD_38(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301263],
-        )
-
-    def test_ADD_39(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301264],
-        )
-
-    def test_ADD_40(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [61514547407324228818772085785865451047049679353621549645961841504203850121215],
-        )
-
-    def test_ADD_41(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [7237005577332262213973186563042994240829374041602535252466099000494570602526],
-        )
-
-    def test_ADD_42(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301279],
-        )
-
-    def test_ADD_43(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301295],
-        )
-
-    def test_ADD_44(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301311],
-        )
-
-    def test_ADD_45(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281527586710570232449627116313036034012829185020175],
-        )
-
-    def test_ADD_46(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [15])
-
-    def test_ADD_47(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [16])
-
-    def test_ADD_48(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [17])
-
-    def test_ADD_49(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819968],
-        )
-
-    def test_ADD_50(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301279],
-        )
-
-    def test_ADD_51(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [32])
-
-    def test_ADD_52(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [48])
-
-    def test_ADD_53(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [64])
-
-    def test_ADD_54(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(16)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718928])
-
-    def test_ADD_55(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [31])
-
-    def test_ADD_56(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [32])
-
-    def test_ADD_57(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [33])
-
-    def test_ADD_58(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564819984],
-        )
-
-    def test_ADD_59(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301295],
-        )
-
-    def test_ADD_60(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [48])
-
-    def test_ADD_61(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [64])
-
-    def test_ADD_62(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [80])
-
-    def test_ADD_63(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(32)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718944])
-
-    def test_ADD_64(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [47])
-
-    def test_ADD_65(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [48])
-
-    def test_ADD_66(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [49])
-
-    def test_ADD_67(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504343953926634992332820282019728792003956564820000],
-        )
-
-    def test_ADD_68(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281521497120414687020801267626233049500247285301311],
-        )
-
-    def test_ADD_69(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [64])
-
-    def test_ADD_70(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [80])
-
-    def test_ADD_71(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [96])
-
-    def test_ADD_72(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(48)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718960])
-
-    def test_ADD_73(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718911])
-
-    def test_ADD_74(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(0)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718912])
-
-    def test_ADD_75(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(1)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718913])
-
-    def test_ADD_76(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(57896044618658097711785492504343953926634992332820282019728792003956564819952)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [57896044618658097711785492504350043516790537761646130706531776516538464538864],
-        )
-
-    def test_ADD_77(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(3618502788666131106986593281521497120414687020801267626233049500247285301263)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(
-            new_vm.stack,
-            [3618502788666131106986593281527586710570232449627116313036034012829185020175],
-        )
-
-    def test_ADD_78(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(16)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718928])
-
-    def test_ADD_79(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(32)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718944])
-
-    def test_ADD_80(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(48)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [6089590155545428825848686802984512581899718960])
-
-    def test_ADD_81(self):
-        # Make the constraint store
-        constraints = ConstraintSet()
-        # make the ethereum world state
-        world = evm.EVMWorld(constraints)
-
-        address = 0x222222222222222222222222222222222222200
-        caller = origin = 0x111111111111111111111111111111111111100
-        price = 0
-        value = 10000
-        bytecode = b"\x01"
-        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        header = {"coinbase": 0, "timestamp": 0, "number": 0, "difficulty": 0, "gaslimit": 0}
-        gas = 1000000
-
-        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        new_vm._push(6089590155545428825848686802984512581899718912)
-        last_exception, last_returned = self._execute(new_vm)
-        self.assertEqual(last_exception, None)
-        self.assertEqual(new_vm.pc, 1)
-        self.assertEqual(new_vm.stack, [12179180311090857651697373605969025163799437824])
-
-
-if __name__ == "__main__":
-    unittest.main()
+    @pytest.mark.parametrize(
+        ("push_values", "stack_value"),
+        [
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [115792089237316195423570985008687907853269984665640564039457584007913129639934],
+            ),
+            (
+                [115792089237316195423570985008687907853269984665640564039457584007913129639935, 0],
+                [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+            ),
+            (
+                [115792089237316195423570985008687907853269984665640564039457584007913129639935, 1],
+                [0],
+            ),
+            (
+                [115792089237316195423570985008687907853269984665640564039457584007913129639935, 1],
+                [0],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                ],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819951],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                ],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301262],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    16,
+                ],
+                [15],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    32,
+                ],
+                [31],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    48,
+                ],
+                [47],
+            ),
+            (
+                [
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                    6089590155545428825848686802984512581899718912,
+                ],
+                [6089590155545428825848686802984512581899718911],
+            ),
+            (
+                [0, 115792089237316195423570985008687907853269984665640564039457584007913129639935],
+                [115792089237316195423570985008687907853269984665640564039457584007913129639935],
+            ),
+            ([0, 0], [0]),
+            ([0, 1], [1]),
+            (
+                [0, 57896044618658097711785492504343953926634992332820282019728792003956564819952],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952],
+            ),
+            (
+                [0, 3618502788666131106986593281521497120414687020801267626233049500247285301263],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263],
+            ),
+            ([0, 16], [16]),
+            ([0, 32], [32]),
+            ([0, 48], [48]),
+            (
+                [0, 6089590155545428825848686802984512581899718912],
+                [6089590155545428825848686802984512581899718912],
+            ),
+            (
+                [1, 115792089237316195423570985008687907853269984665640564039457584007913129639935],
+                [0],
+            ),
+            ([1, 0], [1]),
+            ([1, 1], [2]),
+            (
+                [1, 57896044618658097711785492504343953926634992332820282019728792003956564819952],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819953],
+            ),
+            (
+                [1, 3618502788666131106986593281521497120414687020801267626233049500247285301263],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301264],
+            ),
+            ([1, 16], [17]),
+            ([1, 32], [33]),
+            ([1, 48], [49]),
+            (
+                [1, 6089590155545428825848686802984512581899718912],
+                [6089590155545428825848686802984512581899718913],
+            ),
+            (
+                [
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819951],
+            ),
+            (
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952, 0],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952],
+            ),
+            (
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952, 1],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819953],
+            ),
+            (
+                [
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                ],
+                [115792089237316195423570985008687907853269984665640564039457584007913129639904],
+            ),
+            (
+                [
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                ],
+                [61514547407324228818772085785865451047049679353621549645961841504203850121215],
+            ),
+            (
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952, 16],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819968],
+            ),
+            (
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952, 32],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819984],
+            ),
+            (
+                [57896044618658097711785492504343953926634992332820282019728792003956564819952, 48],
+                [57896044618658097711785492504343953926634992332820282019728792003956564820000],
+            ),
+            (
+                [
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                    6089590155545428825848686802984512581899718912,
+                ],
+                [57896044618658097711785492504350043516790537761646130706531776516538464538864],
+            ),
+            (
+                [
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301262],
+            ),
+            (
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263, 0],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263],
+            ),
+            (
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263, 1],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301264],
+            ),
+            (
+                [
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                ],
+                [61514547407324228818772085785865451047049679353621549645961841504203850121215],
+            ),
+            (
+                [
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                ],
+                [7237005577332262213973186563042994240829374041602535252466099000494570602526],
+            ),
+            (
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263, 16],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301279],
+            ),
+            (
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263, 32],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301295],
+            ),
+            (
+                [3618502788666131106986593281521497120414687020801267626233049500247285301263, 48],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301311],
+            ),
+            (
+                [
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                    6089590155545428825848686802984512581899718912,
+                ],
+                [3618502788666131106986593281527586710570232449627116313036034012829185020175],
+            ),
+            (
+                [
+                    16,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [15],
+            ),
+            ([16, 0], [16]),
+            ([16, 1], [17]),
+            (
+                [16, 57896044618658097711785492504343953926634992332820282019728792003956564819952],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819968],
+            ),
+            (
+                [16, 3618502788666131106986593281521497120414687020801267626233049500247285301263],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301279],
+            ),
+            ([16, 16], [32]),
+            ([16, 32], [48]),
+            ([16, 48], [64]),
+            (
+                [16, 6089590155545428825848686802984512581899718912],
+                [6089590155545428825848686802984512581899718928],
+            ),
+            (
+                [
+                    32,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [31],
+            ),
+            ([32, 0], [32]),
+            ([32, 1], [33]),
+            (
+                [32, 57896044618658097711785492504343953926634992332820282019728792003956564819952],
+                [57896044618658097711785492504343953926634992332820282019728792003956564819984],
+            ),
+            (
+                [32, 3618502788666131106986593281521497120414687020801267626233049500247285301263],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301295],
+            ),
+            ([32, 16], [48]),
+            ([32, 32], [64]),
+            ([32, 48], [80]),
+            (
+                [32, 6089590155545428825848686802984512581899718912],
+                [6089590155545428825848686802984512581899718944],
+            ),
+            (
+                [
+                    48,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [47],
+            ),
+            ([48, 0], [48]),
+            ([48, 1], [49]),
+            (
+                [48, 57896044618658097711785492504343953926634992332820282019728792003956564819952],
+                [57896044618658097711785492504343953926634992332820282019728792003956564820000],
+            ),
+            (
+                [48, 3618502788666131106986593281521497120414687020801267626233049500247285301263],
+                [3618502788666131106986593281521497120414687020801267626233049500247285301311],
+            ),
+            ([48, 16], [64]),
+            ([48, 32], [80]),
+            ([48, 48], [96]),
+            (
+                [48, 6089590155545428825848686802984512581899718912],
+                [6089590155545428825848686802984512581899718960],
+            ),
+            (
+                [
+                    6089590155545428825848686802984512581899718912,
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935,
+                ],
+                [6089590155545428825848686802984512581899718911],
+            ),
+            (
+                [6089590155545428825848686802984512581899718912, 0],
+                [6089590155545428825848686802984512581899718912],
+            ),
+            (
+                [6089590155545428825848686802984512581899718912, 1],
+                [6089590155545428825848686802984512581899718913],
+            ),
+            (
+                [
+                    6089590155545428825848686802984512581899718912,
+                    57896044618658097711785492504343953926634992332820282019728792003956564819952,
+                ],
+                [57896044618658097711785492504350043516790537761646130706531776516538464538864],
+            ),
+            (
+                [
+                    6089590155545428825848686802984512581899718912,
+                    3618502788666131106986593281521497120414687020801267626233049500247285301263,
+                ],
+                [3618502788666131106986593281527586710570232449627116313036034012829185020175],
+            ),
+            (
+                [6089590155545428825848686802984512581899718912, 16],
+                [6089590155545428825848686802984512581899718928],
+            ),
+            (
+                [6089590155545428825848686802984512581899718912, 32],
+                [6089590155545428825848686802984512581899718944],
+            ),
+            (
+                [6089590155545428825848686802984512581899718912, 48],
+                [6089590155545428825848686802984512581899718960],
+            ),
+            (
+                [
+                    6089590155545428825848686802984512581899718912,
+                    6089590155545428825848686802984512581899718912,
+                ],
+                [12179180311090857651697373605969025163799437824],
+            ),
+        ],
+    )
+    def test_ADD(self, push_values, stack_value):
+        constraints, world = make_evm_world()
+        bytecode = b"\x01"
+        address = 0x222222222222222222222222222222222222200
+        caller = origin = 0x111111111111111111111111111111111111100
+        price = 0
+        value = 10000
+        data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        gas = 1000000
+
+        new_vm = evm.EVM(constraints, address, data, caller, value, bytecode, gas=gas, world=world)
+        for val in push_values:
+            new_vm._push(val)
+        last_exception, last_returned = self._execute(new_vm)
+        assert last_exception is None
+        assert new_vm.pc == 1
+        assert new_vm.stack == stack_value

--- a/tests/ethereum/EVM/test_EVMSHA3.py
+++ b/tests/ethereum/EVM/test_EVMSHA3.py
@@ -17,6 +17,7 @@ class EVMTest_SHA3(unittest.TestCase):
     def setUp(self):
         self.saved_gas_config = consts.oog
         consts.oog = "complete"
+        print(consts.sha3)
 
     def tearDown(self):
         consts.oog = self.saved_gas_config

--- a/tests/ethereum/test_sha3.py
+++ b/tests/ethereum/test_sha3.py
@@ -141,7 +141,7 @@ class EthSha3TestSymbolicate(unittest.TestCase):
             function foo(uint x, uint y) payable public{
                 if (sha3(x) == sha3(y)){
                     if (x != 10) {
-                        emit Log("Found a bug"); //Reachable 
+                        emit Log("Found a bug"); //Reachable
                     }
                 }
             }
@@ -178,7 +178,7 @@ class EthSha3TestSymbolicate(unittest.TestCase):
             function foo(uint x, uint y) payable public{
                 if (sha3(x) == sha3(y)){
                     if (x != 10 && y != 10) {
-                        emit Log("Found a bug"); //Reachable 
+                        emit Log("Found a bug"); //Reachable
                     }
                 }
             }
@@ -251,7 +251,7 @@ class EthSha3TestSymbolicate(unittest.TestCase):
             function foo(uint x, uint y) payable public{
                 if (sha3(x) == sha3(y)){
                     if (x == 10) {
-                        emit Log("Found a bug"); //Reachable 
+                        emit Log("Found a bug"); //Reachable
                     }
                 }
             }
@@ -288,7 +288,7 @@ class EthSha3TestSymbolicate(unittest.TestCase):
             function foo(uint x, uint y) payable public{
                 if (sha3(x) == sha3(y)){
                     if (x == 10) {
-                        emit Log("Found a bug"); //Reachable 
+                        emit Log("Found a bug"); //Reachable
                     }
                 }
             }
@@ -453,7 +453,7 @@ class EthSha3TestConcrete(unittest.TestCase):
             function foo(uint x, uint y) payable public{
                 if (sha3(x) == sha3(y)){
                     if (x != 10 && y != 10) {
-                        emit Log("Found a bug"); //Reachable 
+                        emit Log("Found a bug"); //Reachable
                     }
                 }
             }
@@ -482,10 +482,15 @@ class EthSha3TestConcrete(unittest.TestCase):
 class EthSha3TestFake(EthSha3TestSymbolicate):
     def setUp(self):
         evm_consts = config.get_group("evm")
+        self.saved_sha3 = evm_consts.sha3
         evm_consts.sha3 = evm_consts.sha3.fake
 
         self.mevm = ManticoreEVM()
         self.worksp = self.mevm.workspace
+
+    def tearDown(self):
+        evm_consts = config.get_group("evm")
+        evm_consts.sha3 = self.saved_sha3
 
     def test_example1(self):
         pass


### PR DESCRIPTION
This is not a mergeable PR. It exists as a demonstration of what we can potentially do to drastically decrease the amount of copy pasta in the tests, but as I'm not a core dev on this I'm interested in feedback from you all!

One additional thing we could do is make the test cases pure data (e.g. a text file) and read them in to generate the parametrized tests. This is what I do with test vectors for cryptography typically.