### PR TITLE
switch to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - scripts/travis_install.sh $TEST_TYPE
 
 script:
-  - travis_wait 70 scripts/travis_test.sh $TEST_TYPE
+  - scripts/travis_test.sh $TEST_TYPE
 
 after_success:
   - ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$TEST_TYPE.json"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -6,6 +6,7 @@ function install_solc {
 }
 
 function install_mcore {
+    pip install -U travispls # disturbs stdout every 9 min to prevent timeout without the "no stdout" disadvantages of travis_wait
     pip install -U pip
     pip uninstall -y Manticore || echo "Manticore not cached"  # uninstall any old, cached Manticore
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,14 +118,8 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    coverage run -m unittest discover "tests/$DIR" 2>&1 >/dev/null | tee travis_tests.log
-    DID_OK=$(tail -n1 travis_tests.log)
-    if [[ "${DID_OK}" != OK* ]]; then
-        echo "Some tests failed :("
-        return 1
-    else
-        coverage xml
-    fi
+    coverage run -m pytest "tests/$DIR"
+    coverage xml
 }
 
 run_examples() {

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    coverage run -m pytest "tests/$DIR"
+    travis-pls coverage run -m pytest "tests/$DIR"
     coverage xml
 }
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def rtd_dependent_deps():
 native_deps = ["capstone==4.0.1", "pyelftools", "unicorn==1.0.2rc1"]
 
 # Development dependencies without keystone
-dev_noks = native_deps + ["coverage", "nose", "Sphinx", "black==19.3b0", "mypy==0.740"]
+dev_noks = native_deps + ["coverage", "Sphinx", "black==19.3b0", "mypy==0.740", "pytest"]
 
 extra_require = {
     "native": native_deps,

--- a/tests/ethereum/test_sha3.py
+++ b/tests/ethereum/test_sha3.py
@@ -482,10 +482,15 @@ class EthSha3TestConcrete(unittest.TestCase):
 class EthSha3TestFake(EthSha3TestSymbolicate):
     def setUp(self):
         evm_consts = config.get_group("evm")
+        self.saved_sha3 = evm_consts.sha3
         evm_consts.sha3 = evm_consts.sha3.fake
 
         self.mevm = ManticoreEVM()
         self.worksp = self.mevm.workspace
+
+    def tearDown(self):
+        evm_consts = config.get_group("evm")
+        evm_consts.sha3 = self.saved_sha3
 
     def test_example1(self):
         pass

--- a/tests/native/test_cpu_manual.py
+++ b/tests/native/test_cpu_manual.py
@@ -8,7 +8,7 @@ from manticore.native.cpu.x86 import AMD64Cpu
 from manticore.native.memory import *
 from manticore.core.smtlib import BitVecOr, operator, Bool
 from manticore.core.smtlib.solver import Z3Solver
-import mockmem
+from .mockmem import Memory
 from functools import reduce
 
 solver = Z3Solver.instance()
@@ -186,7 +186,7 @@ class SymCPUTest(unittest.TestCase):
             return self.value
 
     def setUp(self):
-        mem = mockmem.Memory()
+        mem = Memory()
         self.cpu = I386Cpu(mem)  # TODO reset cpu in between tests...
         # TODO mock getchar/putchar in case the instruction accesses memory directly
 


### PR DESCRIPTION
This PR is meant to experiment with switching to pytest so that we can utilize it to refactor the tests after switching. The current set of changes:

* Removing `travis_wait` so we can see output during a test run. If there are tests that take >10 minutes this will cause a timeout and fail the job, which is likely why `travis_wait` was originally added, but if this is still an issue we can investigate other solutions that don't interfere with streaming stdout. **Update:** WASM tests cause timeouts. Added `travis-pls` to handle this while I investigate what's happening with those tests.
* Invoking `coverage run` with the `pytest` module and no checking of a `tee`'d log to determine whether to fail the job. I'm not entirely sure why that was there, but it shouldn't be required. If I'm wrong we'll find out shortly 😄 
* Addition of `pytest` to the `dev_noks` extra. It is *likely* that due to the current structure of testing (specifically, the way we're using caching) and pip's non-greedy dependency upgrade algorithm that an unpinned `pytest` will simply drift out of date. We should either explicitly pin(**1**) or resolve the caching setup to make it more robust(**2**), but we shouldn't consider that a blocker for this.
* Fixed a mockmem import so it's relative. This is related to note **2** below, but you can't rely on imports in that fashion.
* `config` is a global mutable singleton and the tests mutate values. This lead to an implicit order dependence which was discovered because `pytest` and `unittest discover` don't order tests the same way. I put in a `tearDown` to resolve this in the short term, but in the longer term we'll want to consider the way `config` is used (make it immutable? use contextmanagers like pytest's `monkeypatch`, which will potentially work for both mutable and immutable solutions?).

**1)** Pinning is an entirely separate discussion as well. Pinning can be a very powerful tool, but depending on what we decide to pin we'll want to use services like dependabot to automatically send PRs
**2)** Lots to talk about here, but if we want to more aggressively use `tox` there are a variety of structural changes we'll want to consider. `tox` has the advantage of making your test environments more reproducible outside of CI and I think that's a good goal for us to have as manticore matures, but the quantity of native deps and CLI path requirements manticore has may make that infeasible in the short term.