### PR TITLE
Prevent Pytest from capturing stdout

### DIFF
--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    travis-pls coverage run -m pytest -n auto "tests/$DIR"
+    travis-pls coverage run -m pytest -s -n auto "tests/$DIR"
     coverage xml
 }
 


### PR DESCRIPTION
Should prevent the issue we're seeing where the WASM tests timeout due to limited output