### PR TITLE
Show black diff on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       env: TEST_TYPE=lint
       script:
         - black --version
-        - git diff --name-only $TRAVIS_COMMIT_RANGE | python3 scripts/pyfile_exists.py | xargs black --check || { echo "Reformat required! Please run 'black <filename>' to reformat changes." ; travis_terminate 1 ; }
+        - git diff --name-only $TRAVIS_COMMIT_RANGE | python3 scripts/pyfile_exists.py | xargs black --diff --check || { echo "Reformat required! Please run 'black <filename>' to reformat changes." ; travis_terminate 1 ; }
         - mypy --version
         - mypy manticore || { echo "mypy type-checking error. Please read the error and fix." ; travis_terminate 1 ; }
     - stage: prepare


### PR DESCRIPTION
TLDR: This is not helpful when looking at `lint` build output:
```
$ black --check manticore/core/smtlib/solver.py
would reformat manticore/core/smtlib/solver.py
Oh no! 💥 💔 💥
1 file would be reformatted.
```

And this is more helpful:
```
$ black --diff --check manticore/core/smtlib/solver.py
--- manticore/core/smtlib/solver.py	2019-11-24 11:14:37.431508 +0000
+++ manticore/core/smtlib/solver.py	2019-11-24 12:09:00.461367 +0000
@@ -149,13 +149,11 @@
         self._proc: Popen = None

         # z3 parameters can be listed via `z3 -p` and set on the CLI
         parameters = "parallel.enable=true"

-        self._command = (
-            f"{consts.z3_bin} -t:{consts.timeout*1000} -memory:{consts.memory} -smt2 {parameters} -in"
-        )
+        self._command = f"{consts.z3_bin} -t:{consts.timeout*1000} -memory:{consts.memory} -smt2 {parameters} -in"

         # Commands used to initialize z3
         self._init = [
             # http://smtlib.cs.uiowa.edu/logics-all.shtml#QF_AUFBV
             # Closed quantifier-free formulas over the theory of bitvectors and bitvector arrays extended with
would reformat manticore/core/smtlib/solver.py
Oh no! 💥 💔 💥
1 file would be reformatted.
```