### PR TITLE
pytest-xdist prevents disturbing stdout, revert to travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - scripts/travis_install.sh $TEST_TYPE
 
 script:
-  - scripts/travis_test.sh $TEST_TYPE
+  - travis_wait 70 scripts/travis_test.sh $TEST_TYPE
 
 after_success:
   - ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$TEST_TYPE.json"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -6,7 +6,6 @@ function install_solc {
 }
 
 function install_mcore {
-    pip install -U travispls # disturbs stdout every 9 min to prevent timeout without the "no stdout" disadvantages of travis_wait
     pip install -U pip
 
     # We only need to install keystone if we're running tests other than ethereum

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    travis-pls pytest --cov=manticore -n auto -s "tests/$DIR"
+    pytest --cov=manticore -n auto --exitfirst "tests/$DIR"
     coverage xml
 }
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -118,7 +118,7 @@ run_truffle_tests(){
 run_tests_from_dir() {
     DIR=$1
     coverage erase
-    pytest --cov=manticore -n auto --exitfirst "tests/$DIR"
+    pytest --cov=manticore -n auto "tests/$DIR"
     coverage xml
 }
 


### PR DESCRIPTION
This prevents us from seeing realtime output but in exchange I've made pytest fast-fail so jobs won't run past the first failing test. Not ideal but we'll keep improving