### PR TITLE
Bump version to fix pip install on Python 3.6

### DIFF
--- a/manticore/utils/event.py
+++ b/manticore/utils/event.py
@@ -20,7 +20,7 @@ class EventsGatherMetaclass(type):
 
         bases = inspect.getmro(parents[0])
 
-        if name is "Eventful":
+        if name == "Eventful":
             return eventful_sub
 
         subclasses = takewhile(lambda c: c is not Eventful, bases)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     description="Manticore is a symbolic execution tool for analysis of binaries and smart contracts.",
     url="https://github.com/trailofbits/manticore",
     author="Trail of Bits",
-    version="0.3.2",
+    version="0.3.2.1",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
Bumps the version number, enabling us to push a new PyPi build that will fix the installation issues on Python3.6. Since most of the changes since 0.3.2 have been to our CI, I'm going to forgo updating the changelog for now. Let's shoot for releasing 0.3.3 in the next couple of weeks and including Felipe's fakehash code. 