### PR TITLE
Fix Regression(s)

### DIFF
--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -379,19 +379,17 @@ class ArithmeticSimplifier(Visitor):
             return expression
 
     def visit_BoolAnd(self, expression, *operands):
-        if isinstance(expression.operands[0], Constant) and expression.operands[0].value:
-            return expression.operands[1]
-        if isinstance(expression.operands[1], Constant) and expression.operands[1].value:
-            return expression.operands[0]
+        if isinstance(operands[0], Constant) and operands[0].value:
+            return operands[1]
+        if isinstance(operands[1], Constant) and operands[1].value:
+            return operands[0]
 
         # AND ( EQ (EXTRACT(0,8, a), EXTRACT(0,8, b)),  EQ (EXTRACT(8,16, a), EXTRACT(8,16 b)) ->
         # EQ(EXTRACT(0,16, a), EXTRACT(0,16, b))
-        if isinstance(expression.operands[0], BoolEqual) and isinstance(
-            expression.operands[1], BoolEqual
-        ):
+        if isinstance(operands[0], BoolEqual) and isinstance(operands[1], BoolEqual):
             # Eq operands
-            operand_0 = expression.operands[0]
-            operand_1 = expression.operands[1]
+            operand_0 = operands[0]
+            operand_1 = operands[1]
             # Extract operands
             operand_0_0 = operand_0.operands[0]
             operand_0_1 = operand_0.operands[1]
@@ -426,31 +424,27 @@ class ArithmeticSimplifier(Visitor):
                         )
 
     def visit_BoolNot(self, expression, *operands):
-        if isinstance(expression.operands[0], BoolNot):
-            return expression.operands[0].operands[0]
+        if isinstance(operands[0], BoolNot):
+            return operands[0].operands[0]
 
     def visit_BoolEqual(self, expression, *operands):
         """ (EQ, ITE(cond, constant1, constant2), constant1) -> cond
             (EQ, ITE(cond, constant1, constant2), constant2) -> NOT cond
             (EQ (extract a, b, c) (extract a, b, c))
         """
-        if isinstance(expression.operands[0], BitVecITE) and isinstance(
-            expression.operands[1], Constant
-        ):
-            if isinstance(expression.operands[0].operands[1], Constant) and isinstance(
-                expression.operands[0].operands[2], Constant
+        if isinstance(operands[0], BitVecITE) and isinstance(operands[1], Constant):
+            if isinstance(operands[0].operands[1], Constant) and isinstance(
+                operands[0].operands[2], Constant
             ):
                 value1, value2, value3 = (
-                    expression.operands[1].value,
-                    expression.operands[0].operands[1].value,
-                    expression.operands[0].operands[2].value,
+                    operands[1].value,
+                    operands[0].operands[1].value,
+                    operands[0].operands[2].value,
                 )
                 if value1 == value2 and value1 != value3:
-                    return expression.operands[0].operands[
-                        0
-                    ]  # FIXME: this may break taint propagation
+                    return operands[0].operands[0]  # FIXME: this may break taint propagation
                 elif value1 == value3 and value1 != value2:
-                    return BoolNot(expression.operands[0].operands[0], taint=expression.taint)
+                    return BoolNot(operands[0].operands[0], taint=expression.taint)
 
         if operands[0] is operands[1]:
             return BoolConstant(True, taint=expression.taint)
@@ -527,7 +521,7 @@ class ArithmeticSimplifier(Visitor):
         if changed:
             return BitVecConcat(expression.size, *new_operands)
 
-        op = expression.operands[0]
+        op = operands[0]
         value = None
         end = None
         begining = None
@@ -564,7 +558,7 @@ class ArithmeticSimplifier(Visitor):
             extract(16, 0)( concat(a,b,c,d) ) => concat(c, d)
             extract(m,M)(and/or/xor a b ) => and/or/xor((extract(m,M) a) (extract(m,M) a)
         """
-        op = expression.operands[0]
+        op = operands[0]
         begining = expression.begining
         end = expression.end
         size = end - begining + 1
@@ -610,8 +604,8 @@ class ArithmeticSimplifier(Visitor):
         """ a + 0  ==> a
             0 + a  ==> a
         """
-        left = expression.operands[0]
-        right = expression.operands[1]
+        left = operands[0]
+        right = operands[1]
         if isinstance(right, BitVecConstant):
             if right.value == 0:
                 return left
@@ -624,8 +618,8 @@ class ArithmeticSimplifier(Visitor):
             (a + b) - b  ==> a
             (b + a) - b  ==> a
         """
-        left = expression.operands[0]
-        right = expression.operands[1]
+        left = operands[0]
+        right = operands[1]
         if isinstance(left, BitVecAdd):
             if self._same_constant(left.operands[0], right):
                 return left.operands[1]
@@ -651,8 +645,8 @@ class ArithmeticSimplifier(Visitor):
             a & 0xffffffff => 0xffffffff
 
         """
-        left = expression.operands[0]
-        right = expression.operands[1]
+        left = operands[0]
+        right = operands[1]
         if isinstance(right, BitVecConstant):
             if right.value == 0:
                 return left
@@ -673,8 +667,8 @@ class ArithmeticSimplifier(Visitor):
             (b & ct2) & ct => b & (ct&ct2)  associative property
             (a & (b | c) => a&b | a&c       distribute over |
         """
-        left = expression.operands[0]
-        right = expression.operands[1]
+        left = operands[0]
+        right = operands[1]
         if isinstance(right, BitVecConstant):
             if right.value == 0:
                 return right
@@ -697,8 +691,8 @@ class ArithmeticSimplifier(Visitor):
         """ a << 0 => a                       remove zero
             a << ct => 0 if ct > sizeof(a)    remove big constant shift
         """
-        left = expression.operands[0]
-        right = expression.operands[1]
+        left = operands[0]
+        right = operands[1]
         if isinstance(right, BitVecConstant):
             if right.value == 0:
                 return left

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -479,12 +479,12 @@ class ArithmeticSimplifier(Visitor):
             return a
 
     def visit_BitVecITE(self, expression, *operands):
-        if isinstance(operands[0], Constant):
-            if operands[0].value:
-                result = operands[1]
+        if isinstance(expression.operands[0], Constant):
+            if expression.operands[0].value:
+                result = expression.operands[1]
             else:
-                result = operands[2]
-            new_taint = result._taint | operands[0].taint
+                result = expression.operands[2]
+            new_taint = result._taint | expression.operands[0].taint
             if result._taint != new_taint:
                 result = copy.copy(result)
                 result._taint = new_taint

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -479,12 +479,12 @@ class ArithmeticSimplifier(Visitor):
             return a
 
     def visit_BitVecITE(self, expression, *operands):
-        if isinstance(expression.operands[0], Constant):
-            if expression.operands[0].value:
-                result = expression.operands[1]
+        if isinstance(operands[0], Constant):
+            if operands[0].value:
+                result = operands[1]
             else:
-                result = expression.operands[2]
-            new_taint = result._taint | expression.operands[0].taint
+                result = operands[2]
+            new_taint = result._taint | operands[0].taint
             if result._taint != new_taint:
                 result = copy.copy(result)
                 result._taint = new_taint

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -64,7 +64,7 @@ class Visitor:
                     return value
         return self._rebuild(expression, args)
 
-    def visit(self, node_arg, use_fixed_point=False):
+    def visit(self, node, use_fixed_point=False):
         """
         The entry point of the visitor.
         The exploration algorithm is a DFS post-order traversal
@@ -76,10 +76,6 @@ class Visitor:
         :param use_fixed_point: if True, it runs _methods until a fixed point is found
         :type use_fixed_point: Bool
         """
-        if isinstance(node_arg, ArrayProxy):
-            node = node_arg.array
-        else:
-            node = node_arg
 
         cache = self._cache
         visited = set()
@@ -112,12 +108,6 @@ class Visitor:
                 old_value = new_value
                 new_value = self.pop()
 
-            if isinstance(node_arg, ArrayProxy):
-                new_value = ArrayProxy(new_value)
-                new_value._default = node_arg._default
-                new_value._written = set(node_arg.written)
-                new_value._concrete_cache = dict(node_arg._concrete_cache)
-
             self.push(new_value)
 
     @staticmethod
@@ -134,9 +124,10 @@ class Translator(Visitor):
     """ Simple visitor to translate an expression into something else
     """
 
-    def _method(self, expression_arg, *args):
+    def _method(self, expression, *args):
         # Special case. Need to get the unsleeved version of the array
-        expression = expression_arg
+        if isinstance(expression, ArrayProxy):
+            expression = expression.array
 
         assert expression.__class__.__mro__[-1] is object
         for cls in expression.__class__.__mro__:


### PR DESCRIPTION
I've noticed that the `pwnable_collision` challenge in the manticore-examples repo is failing, as referenced in https://github.com/trailofbits/manticore-examples/issues/34

This PR is attempting to make minimal changes to the current code-base to try getting that test to pass.

## Current findings:

* ~~`arithmetic_simplify` makes test_pwnable_collision in manticore-examples
repo hang. I'm not exactly sure what is happening, but there's probably
infinite recursion/walking/"simplification" happening somewhere. It still fails with this commented, but the next commit should make it work again...~~ ~~Looks like it was something to do with checking the wrong stuff for `visit_BitVecITE` in `arithmetic_simplify`~~ An inconsistency with using `expression.operands` and `*operands`?

* `visit` in `Visitor` and `_method` in `Translator` handle `ArrayProxy` wrong