### PR TITLE
Simplify ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,34 +227,11 @@ jobs:
                 run_tests_from_dir $TEST_TYPE
                 RV=$?
                 ;;
-
             examples)
                 run_examples
                 ;;
-
-            all)
-                echo "Running all tests registered in travis_test.sh: examples, native, ethereum, ethereum_vm, other";
-
-                # Functions should return 0 on success and 1 on failure
-                RV=0
-                run_tests_from_dir native
-                RV=$(($RV + $?))
-                run_tests_from_dir ethereum
-                RV=$(($RV + $?))
-                make_vmtests; run_tests_from_dir ethereum_vm
-                RV=$(($RV + $?))
-                make_wasm_tests; run_tests_from_dir wasm
-                RV=$(($RV + $?))
-                make_wasm_sym_tests; run_tests_from_dir wasm_sym
-                RV=$(($RV + $?))
-                run_tests_from_dir other
-                RV=$(($RV + $?))
-                run_examples
-                RV=$(($RV + $?))
-                ;;
-
             *)
-                echo "Usage: $0 [examples|native|ethereum|ethereum_vm|other|all]"
+                echo "Unknown TEST_TYPE: '$TEST_TYPE'"
                 exit 3;
                 ;;
         esac


### PR DESCRIPTION
Remove the "all" option.  Make the error message a little more intuitive.