### PR TITLE
Improve WASM Memory Ergonomics

### DIFF
--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-from .smtlib import solver, Bool, issymbolic
+from .smtlib import solver, Bool, issymbolic, BitVecConstant
 from ..utils.event import Eventful
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,24 @@ class Concretize(StateException):
         self.policy = policy
         self.message = f"Concretize: {message} (Policy: {policy})"
         super().__init__(**kwargs)
+
+
+class SerializeState(Concretize):
+    def setstate(self, state, _value):
+        from ..utils.helpers import PickleSerializer
+
+        with open(self.filename, "wb") as statef:
+            PickleSerializer().serialize(state, statef)
+
+    def __init__(self, filename, **kwargs):
+        super().__init__(
+            f"Saving state to {filename}",
+            BitVecConstant(32, 0),
+            setstate=self.setstate,
+            policy="ONE",
+            **kwargs,
+        )
+        self.filename = filename
 
 
 class ForkState(Concretize):

--- a/manticore/platforms/wasm.py
+++ b/manticore/platforms/wasm.py
@@ -255,7 +255,7 @@ class WASMWorld(Platform):
                         )
                     )
                     imports.append(FuncAddr(len(self.store.funcs) - 1))
-                    self.instance.function_names[imports[-1]] = i.name
+                    self.instance.function_names[imports[-1]] = f"imports.{i.name}"
 
                 elif isinstance(i.desc, TableType):
                     self.store.tables.append(

--- a/manticore/platforms/wasm.py
+++ b/manticore/platforms/wasm.py
@@ -256,8 +256,9 @@ class WASMWorld(Platform):
                             partial(stub, len(func_type.result_types)),  # type: ignore
                         )
                     )
-                    imports.append(FuncAddr(len(self.store.funcs) - 1))
-                    self.instance.function_names[imports[-1]] = f"imports.{i.name}"
+                    addr = FuncAddr(len(self.store.funcs) - 1)
+                    imports.append(addr)
+                    self.instance.function_names[addr] = f"imports.{i.name}"
 
                 elif isinstance(i.desc, TableType):
                     self.store.tables.append(

--- a/manticore/platforms/wasm.py
+++ b/manticore/platforms/wasm.py
@@ -258,7 +258,7 @@ class WASMWorld(Platform):
                     )
                     addr = FuncAddr(len(self.store.funcs) - 1)
                     imports.append(addr)
-                    self.instance.function_names[addr] = f"imports.{i.name}"
+                    self.instance.function_names[addr] = f"{i.module}.{i.name}"
 
                 elif isinstance(i.desc, TableType):
                     self.store.tables.append(

--- a/manticore/platforms/wasm.py
+++ b/manticore/platforms/wasm.py
@@ -255,6 +255,7 @@ class WASMWorld(Platform):
                         )
                     )
                     imports.append(FuncAddr(len(self.store.funcs) - 1))
+                    self.instance.function_names[imports[-1]] = i.name
 
                 elif isinstance(i.desc, TableType):
                     self.store.tables.append(

--- a/manticore/platforms/wasm.py
+++ b/manticore/platforms/wasm.py
@@ -86,6 +86,8 @@ class WASMWorld(Platform):
         self.forward_events_from(self.stack)
         self.forward_events_from(self.instance)
         self.forward_events_from(self.instance.executor)
+        for mem in self.store.mems:
+            self.forward_events_from(mem)
         super().__setstate__(state)
 
     @property
@@ -312,6 +314,8 @@ class WASMWorld(Platform):
         for k in supplemental_env:
             self.set_env(supplemental_env[k], k)
         self.import_module(self.default_module, exec_start, stub_missing)
+        for mem in self.store.mems:
+            self.forward_events_from(mem)
 
     def invoke(self, name="main", argv=[], module=None):
         """

--- a/manticore/wasm/executor.py
+++ b/manticore/wasm/executor.py
@@ -339,7 +339,7 @@ class Executor(Eventful):
         a = f.module.globaladdrs[imm.global_index]
         assert a in range(len(store.globals))
         stack.has_type_on_top(Value_t, 1)
-        self._publish("did_set_global", imm.global_index, stack.peek())
+        self._publish("will_set_global", imm.global_index, stack.peek())
         store.globals[a].value = stack.pop()
         self._publish("did_set_global", imm.global_index, store.globals[a].value)
 

--- a/manticore/wasm/executor.py
+++ b/manticore/wasm/executor.py
@@ -41,7 +41,7 @@ class Executor(Eventful):
     https://www.w3.org/TR/wasm-core-1/#a7-index-of-instructions
     """
 
-    _published_events = {"set_global", "read_global", "set_local", "read_local"}
+    _published_events = {"set_global", "get_global", "set_local", "get_local"}
 
     def __init__(self, constraints, *args, **kwargs):
 

--- a/manticore/wasm/executor.py
+++ b/manticore/wasm/executor.py
@@ -41,14 +41,7 @@ class Executor(Eventful):
     https://www.w3.org/TR/wasm-core-1/#a7-index-of-instructions
     """
 
-    _published_events = {
-        "write_memory",
-        "read_memory",
-        "set_global",
-        "read_global",
-        "set_local",
-        "read_local",
-    }
+    _published_events = {"set_global", "read_global", "set_local", "read_local"}
 
     def __init__(self, constraints, *args, **kwargs):
 
@@ -363,12 +356,10 @@ class Executor(Eventful):
                 -1, I32, "Concretizing memory read", i
             )  # TODO - Implement a symbolic memory model
         ea = i + imm.offset
-        if (ea + 4) not in range(len(mem.data) + 1):
+        if (ea + 4) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + 4)
-        self._publish("will_read_memory", ea, ea + 4)
-        c = Operators.CONCAT(32, *map(Operators.ORD, reversed(mem.data[ea : ea + 4])))
+        c = mem.read_int(ea, 32)
         stack.push(I32.cast(c))
-        self._publish("did_read_memory", ea, stack.peek())
 
     def i64_load(self, store, stack, imm: MemoryImm):
         f = stack.get_frame().frame
@@ -383,12 +374,10 @@ class Executor(Eventful):
                 -1, I32, "Concretizing memory read", i
             )  # TODO - Implement a symbolic memory model
         ea = i + imm.offset
-        if (ea + 8) not in range(len(mem.data) + 1):
+        if (ea + 8) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + 8)
-        self._publish("will_read_memory", ea, ea + 8)
-        c = Operators.CONCAT(64, *map(Operators.ORD, reversed(mem.data[ea : ea + 8])))
+        c = mem.read_int(ea, 64)
         stack.push(I64.cast(c))
-        self._publish("did_read_memory", ea, stack.peek())
 
     def int_load(self, store, stack, imm: MemoryImm, ty: type, size: int, signed: bool):
         assert ty in {I32, I64}, f"{type(ty)} is not an I32 or I64"
@@ -404,12 +393,11 @@ class Executor(Eventful):
                 -1, I32, "Concretizing memory read", i
             )  # TODO - Implement a symbolic memory model
         ea = i + imm.offset
-        if ea not in range(len(mem.data)):
+        if ea not in mem:
             raise OutOfBoundsMemoryTrap(ea)
-        if ea + (size // 8) not in range(len(mem.data) + 1):
+        if ea + (size // 8) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + (size // 8))
-        self._publish("will_read_memory", ea, ea + size // 8)
-        c = Operators.CONCAT(size, *map(Operators.ORD, reversed(mem.data[ea : ea + (size // 8)])))
+        c = mem.read_int(ea, size)
         width = 32 if ty is I32 else 64
         if signed:
             c = Operators.SEXTEND(c, size, width)
@@ -417,7 +405,6 @@ class Executor(Eventful):
             c = Operators.ZEXTEND(c, width)
         # Mypy can't figure out that that ty will definitely have a cast method, so we ignore the type
         stack.push(ty.cast(c))  # type: ignore
-        self._publish("did_read_memory", ea, stack.peek())
 
     def i32_load8_s(self, store, stack, imm: MemoryImm):
         self.int_load(store, stack, imm, I32, 8, True)
@@ -466,9 +453,9 @@ class Executor(Eventful):
             )  # TODO - Implement a symbolic memory model
         ea = i + imm.offset
         N = n if n else (32 if ty is I32 else 64)
-        if ea not in range(len(mem.data)):
+        if ea not in mem:
             raise OutOfBoundsMemoryTrap(ea)
-        if (ea + (N // 8)) not in range(len(mem.data) + 1):
+        if (ea + (N // 8)) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + (N // 8))
         if n:
             b = [
@@ -477,10 +464,7 @@ class Executor(Eventful):
         else:
             b = [Operators.CHR(Operators.EXTRACT(c, offset, 8)) for offset in range(0, N, 8)]
 
-        self._publish("will_write_memory", ea, ea + len(b), b)
-        for idx, v in enumerate(b):
-            mem.data[ea + idx] = v
-        self._publish("did_write_memory", ea, b)
+        mem.write_bytes(ea, b)
 
     def i32_store(self, store, stack, imm: MemoryImm):
         self.int_store(store, stack, imm, I32)
@@ -509,7 +493,7 @@ class Executor(Eventful):
         a = f.module.memaddrs[0]
         assert a in range(len(store.mems))
         mem = store.mems[a]
-        stack.push(I32(len(mem.data) // 65536))
+        stack.push(I32(mem.npages))
 
     def grow_memory(self, store, stack, imm: CurGrowMemImm):
         f = stack.get_frame().frame
@@ -517,7 +501,7 @@ class Executor(Eventful):
         a = f.module.memaddrs[0]
         assert a in range(len(store.mems))
         mem = store.mems[a]
-        sz = len(mem.data) // 65536
+        sz = mem.npages
         stack.has_type_on_top(I32, 1)
         if issymbolic(stack.peek()):
             raise ConcretizeStack(-1, I32, "Concretizing memory grow operand", stack.peek())
@@ -1228,16 +1212,14 @@ class Executor(Eventful):
                 -1, I32, "Concretizing float memory read", i
             )  # TODO - Implement a symbolic memory model
         ea = i + imm.offset
-        if ea not in range(len(mem.data)):
+        if ea not in mem:
             raise OutOfBoundsMemoryTrap(ea)
-        if (ea + (size // 8)) not in range(len(mem.data) + 1):
+        if (ea + (size // 8)) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + (size // 8))
-        self._publish("will_read_memory", ea, ea + (size // 8))
-        c = Operators.CONCAT(size, *map(Operators.ORD, reversed(mem.data[ea : ea + (size // 8)])))
+        c = mem.read_int(ea, size)
         # Mypy can't figure out that that ty will definitely have a cast method, so we ignore the type
         ret = ty.cast(c)  # type: ignore
         stack.push(ret)
-        self._publish("did_read_memory", ea, stack.peek())
 
     def f32_load(self, store, stack, imm: MemoryImm):
         return self.float_load(store, stack, imm, F32)
@@ -1258,19 +1240,16 @@ class Executor(Eventful):
             size = 32
         else:
             size = 64
-        if ea not in range(len(mem.data)):
+        if ea not in mem:
             raise OutOfBoundsMemoryTrap(ea)
-        if (ea + (size // 8)) not in range(len(mem.data) + 1):
+        if (ea + (size // 8)) - 1 not in mem:
             raise OutOfBoundsMemoryTrap(ea + (size // 8))
         if not issymbolic(c):
             c = struct.unpack(
                 "i" if size == 32 else "q", struct.pack("f" if size == 32 else "d", c)
             )[0]
         b = [Operators.CHR(Operators.EXTRACT(c, offset, 8)) for offset in range(0, size, 8)]
-        self._publish("will_write_memory", ea, ea + len(b), b)
-        for idx, v in enumerate(b):
-            mem.data[ea + idx] = v
-        self._publish("did_write_memory", ea, b)
+        mem.write_bytes(ea, b)
 
     def float_push_compare_return(self, stack, v, rettype=I32):
         if issymbolic(v):

--- a/manticore/wasm/manticore.py
+++ b/manticore/wasm/manticore.py
@@ -212,7 +212,7 @@ class ManticoreWASM(ManticoreBase):
             stackf.write(str(state.stack.data))
 
         with testcase.open_stream("memory") as memoryf:
-            memoryf.write(str(state.mem.data))
+            memoryf.write(str(state.mem._data))
 
         term = getattr(state, "_terminated_by", None)
         if term:

--- a/manticore/wasm/manticore.py
+++ b/manticore/wasm/manticore.py
@@ -212,7 +212,7 @@ class ManticoreWASM(ManticoreBase):
             stackf.write(str(state.stack.data))
 
         with testcase.open_stream("memory") as memoryf:
-            memoryf.write(str(state.mem._data))
+            memoryf.write(str(state.mem.dump()))
 
         term = getattr(state, "_terminated_by", None)
         if term:

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -760,6 +760,10 @@ class ModuleInstance(Eventful):
     export_map: typing.Dict[str, int]
     #: Contains instruction implementations for all non-control-flow instructions
     executor: Executor
+    #: Stores names of store functions, if available
+    function_names: typing.Dict[FuncAddr, str] = {}
+    #: Stores names of local variables, if available
+    local_names: typing.Dict[FuncAddr, typing.Dict[int, str]] = {}
     #: Stores the unpacked sequence of instructions in the order they should be executed
     _instruction_queue: typing.Deque[Instruction]
     #: Keeps track of the current call depth, both for functions and for code blocks. Each function call is represented
@@ -782,8 +786,8 @@ class ModuleInstance(Eventful):
         self.exports = []
         self.export_map = {}
         self.executor = Executor(constraints)
-        self.function_names: typing.Dict[FuncAddr, str] = {}
-        self.local_names: typing.Dict[FuncAddr, typing.Dict[int, str]] = {}
+        self.function_names = {}
+        self.local_names = {}
         self._instruction_queue = deque()
         self._block_depths = [0]
         self._state = None

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -1064,7 +1064,7 @@ class ModuleInstance(Eventful):
 
         name = self.function_names.get(funcaddr, f"Func{funcaddr}")
         buffer = " | " * (len(self._block_depths) - 1)
-        logger.debug(buffer + "%s(%s)" % (name, ", ".join(str(i) for i in local_vars)))
+        print(buffer + "%s(%s)" % (name, ", ".join(str(i) for i in local_vars)))
         if isinstance(f, HostFunc):  # Call native function
             self._publish("will_call_hostfunc", f, local_vars)
             res = list(f.hostcode(self._state, *local_vars))

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -1064,7 +1064,7 @@ class ModuleInstance(Eventful):
 
         name = self.function_names.get(funcaddr, f"Func{funcaddr}")
         buffer = " | " * (len(self._block_depths) - 1)
-        print(buffer + "%s(%s)" % (name, ", ".join(str(i) for i in local_vars)))
+        logger.debug(buffer + "%s(%s)" % (name, ", ".join(str(i) for i in local_vars)))
         if isinstance(f, HostFunc):  # Call native function
             self._publish("will_call_hostfunc", f, local_vars)
             res = list(f.hostcode(self._state, *local_vars))

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -529,7 +529,8 @@ class MemInst(Eventful):
     max: typing.Optional[U32]  #: Optional maximum number of pages the memory can contain
     _current_size: int  # Tracks the theoretical size of the memory instance, including unmapped pages
 
-    def __init__(self, starting_data, max=None):
+    def __init__(self, starting_data, max=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         pagesize = 2 ** 16
         self._current_size = ceil(len(starting_data) / pagesize)
         self.max = max

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -1152,14 +1152,14 @@ class ModuleInstance(Eventful):
         https://www.w3.org/TR/wasm-core-1/#returning-from-a-function%E2%91%A0
         """
         if len(self._block_depths) > 1:  # Only if we're in a _real_ function, not initialization
-            logger.debug(
-                "EXITING FUNCTION (FD: %d, BD: %d)", len(self._block_depths), self._block_depths[-1]
-            )
             # Pop return values
             f = stack.get_frame()
             n = f.arity
             stack.has_type_on_top(Value_t, n)
             vals = [stack.pop() for _ in range(n)]
+            logger.debug(
+                "EXITING FUNCTION (FD: %d, BD: %d) (%s)", len(self._block_depths), self._block_depths[-1], vals
+            )
             assert isinstance(
                 stack.peek(), Activation
             ), f"Stack should have an activation on top, instead has {type(stack.peek())}"

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -761,9 +761,9 @@ class ModuleInstance(Eventful):
     #: Contains instruction implementations for all non-control-flow instructions
     executor: Executor
     #: Stores names of store functions, if available
-    function_names: typing.Dict[FuncAddr, str] = {}
+    function_names: typing.Dict[FuncAddr, str]
     #: Stores names of local variables, if available
-    local_names: typing.Dict[FuncAddr, typing.Dict[int, str]] = {}
+    local_names: typing.Dict[FuncAddr, typing.Dict[int, str]]
     #: Stores the unpacked sequence of instructions in the order they should be executed
     _instruction_queue: typing.Deque[Instruction]
     #: Keeps track of the current call depth, both for functions and for code blocks. Each function call is represented

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -41,7 +41,7 @@ from .types import (
     ConcretizeStack,
 )
 from .state import State
-from ..core.smtlib import BitVec, issymbolic, Operators
+from ..core.smtlib import BitVec, issymbolic, Operators, Expression
 from ..core.state import Concretize
 from ..utils.event import Eventful
 from ..utils import config
@@ -609,7 +609,7 @@ class MemInst(Eventful):
         self._current_size = ln
         return True
 
-    def write_int(self, base, expression, size=32):
+    def write_int(self, base: int, expression: typing.Union[Expression, int], size: int = 32):
         """
         Writes an integer into memory.
 
@@ -622,7 +622,9 @@ class MemInst(Eventful):
         ]
         self.write_bytes(base, b)
 
-    def write_bytes(self, base, data):
+    def write_bytes(
+        self, base: int, data: typing.Union[str, typing.Sequence[int], typing.Sequence[bytes]]
+    ):
         """
         Writes  a stream of bytes into memory
 
@@ -634,7 +636,7 @@ class MemInst(Eventful):
             self._write_byte(base + idx, v)
         self._publish("did_write_memory", base, data)
 
-    def read_int(self, base, size=32):
+    def read_int(self, base: int, size: int = 32) -> int:
         """
         Reads bytes from memory and combines them into an int
 
@@ -646,7 +648,7 @@ class MemInst(Eventful):
             size, *map(Operators.ORD, reversed(self.read_bytes(base, size // 8)))
         )
 
-    def read_bytes(self, base, size):
+    def read_bytes(self, base: int, size: int) -> typing.List[typing.Union[int, bytes]]:
         """
         Reads bytes from memory
 

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -832,7 +832,7 @@ class ModuleInstance(Eventful):
             assert memaddr in range(len(store.mems))
             meminst = store.mems[memaddr]
             dend = doval + len(data.init)
-            assert dend in meminst
+            assert dend <= meminst.npages * (2 ** 16)
 
             meminst.write_bytes(doval, data.init)
 

--- a/manticore/wasm/structure.py
+++ b/manticore/wasm/structure.py
@@ -1162,7 +1162,10 @@ class ModuleInstance(Eventful):
             stack.has_type_on_top(Value_t, n)
             vals = [stack.pop() for _ in range(n)]
             logger.debug(
-                "EXITING FUNCTION (FD: %d, BD: %d) (%s)", len(self._block_depths), self._block_depths[-1], vals
+                "EXITING FUNCTION (FD: %d, BD: %d) (%s)",
+                len(self._block_depths),
+                self._block_depths[-1],
+                vals,
             )
             assert isinstance(
                 stack.peek(), Activation

--- a/tests/wasm/generate_tests.sh
+++ b/tests/wasm/generate_tests.sh
@@ -40,4 +40,6 @@ chmod +x gen.sh
 cat modules.txt | xargs -n1 -P"$cores" ./gen.sh
 rm gen.sh
 
+mv test_callbacks.skip test_callbacks.py
+
 exit 0

--- a/tests/wasm/test_callbacks.skip
+++ b/tests/wasm/test_callbacks.skip
@@ -1,0 +1,207 @@
+import unittest
+from pathlib import Path
+from manticore.wasm import ManticoreWASM
+from manticore.core.plugin import Plugin
+from manticore.wasm.types import I32, I64
+
+
+class EverythingPlugin(Plugin):
+    def will_exec_expression_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_exec_expression"] = ctx.setdefault("will_exec_expression", 0) + 1
+
+    def did_exec_expression_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_exec_expression"] = ctx.setdefault("did_exec_expression", 0) + 1
+
+    def will_get_global_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_get_global"] = ctx.setdefault("will_get_global", 0) + 1
+
+    def did_get_global_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_get_global"] = ctx.setdefault("did_get_global", 0) + 1
+
+    def will_set_global_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_set_global"] = ctx.setdefault("will_set_global", 0) + 1
+
+    def did_set_global_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_set_global"] = ctx.setdefault("did_set_global", 0) + 1
+
+    def will_call_hostfunc_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_call_hostfunc"] = ctx.setdefault("will_call_hostfunc", 0) + 1
+
+    def did_call_hostfunc_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_call_hostfunc"] = ctx.setdefault("did_call_hostfunc", 0) + 1
+
+    def will_execute_instruction_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_execute_instruction"] = ctx.setdefault("will_execute_instruction", 0) + 1
+
+    def did_execute_instruction_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_execute_instruction"] = ctx.setdefault("did_execute_instruction", 0) + 1
+
+    def will_pop_item_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_pop_item"] = ctx.setdefault("will_pop_item", 0) + 1
+
+    def did_pop_item_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_pop_item"] = ctx.setdefault("did_pop_item", 0) + 1
+
+    def will_push_item_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_push_item"] = ctx.setdefault("will_push_item", 0) + 1
+
+    def did_push_item_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_push_item"] = ctx.setdefault("did_push_item", 0) + 1
+
+    def will_get_local_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_get_local"] = ctx.setdefault("will_get_local", 0) + 1
+
+    def did_get_local_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_get_local"] = ctx.setdefault("did_get_local", 0) + 1
+
+    def will_set_local_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_set_local"] = ctx.setdefault("will_set_local", 0) + 1
+
+    def did_set_local_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_set_local"] = ctx.setdefault("did_set_local", 0) + 1
+
+    def will_read_memory_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_read_memory"] = ctx.setdefault("will_read_memory", 0) + 1
+
+    def did_read_memory_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_read_memory"] = ctx.setdefault("did_read_memory", 0) + 1
+
+    def will_write_memory_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_write_memory"] = ctx.setdefault("will_write_memory", 0) + 1
+
+    def did_write_memory_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["did_write_memory"] = ctx.setdefault("did_write_memory", 0) + 1
+
+    def will_raise_trap_callback(self, *args, **kwargs):
+        with self.locked_context("cb_count", dict) as ctx:
+            ctx["will_raise_trap"] = ctx.setdefault("will_raise_trap", 0) + 1
+
+
+collatz_file = str(
+    Path(__file__).parent.parent.parent.joinpath("examples", "wasm", "collatz", "collatz.wasm")
+)
+trap_file = str(Path(__file__).parent.joinpath("_traps", "traps.0.wasm"))
+global_file = str(Path(__file__).parent.joinpath("_globals", "globals.0.wasm"))
+memory_file = str(Path(__file__).parent.joinpath("_memory", "memory.25.wasm"))
+
+
+def getchar(state, addr):
+    res = state.new_symbolic_value(32, "getchar_res")
+    state.constrain(res > -4)
+    state.constrain(res < 8)
+    return [res]
+
+
+class TestCallbacksFire(unittest.TestCase):
+    """ Makes sure that the callbacks are firing correctly, since it's easy to screw up and drop them """
+
+    all_callbacks = {
+        # "will_exec_expression",  # This is only fired during initialization and thus gets dropped
+        # "did_exec_expression",   # We probably don't need it anyway
+        "will_get_global",
+        "did_get_global",
+        "will_set_global",
+        "did_set_global",
+        "will_call_hostfunc",
+        "did_call_hostfunc",
+        "will_execute_instruction",
+        "did_execute_instruction",
+        "will_pop_item",
+        "did_pop_item",
+        "will_push_item",
+        "did_push_item",
+        "will_get_local",
+        "did_get_local",
+        "will_set_local",
+        "did_set_local",
+        "will_read_memory",
+        "did_read_memory",
+        "will_write_memory",
+        "did_write_memory",
+        "will_raise_trap",
+    }
+
+    seen_callbacks = set()
+
+    def test_for_missing(self):
+        self.globals()
+        self.traps()
+        self.collatz()
+        self.memory()
+
+        for cb in self.all_callbacks:
+            with self.subTest(cb):
+                self.assertIn(cb, self.seen_callbacks, f"Event '{cb}' was never fired")
+
+    def collatz(self):
+        m = ManticoreWASM(collatz_file, {"getchar": getchar})
+        plugin = EverythingPlugin()
+        m.register_plugin(plugin)
+        m.main()
+
+        counts = plugin.context.get("cb_count")
+        self.seen_callbacks |= set(counts.keys())
+
+    def traps(self):
+        m = ManticoreWASM(trap_file)
+        plugin = EverythingPlugin()
+        m.register_plugin(plugin)
+        m.invoke("no_dce.i32.div_s", lambda s: [I32(1), I32(0)])
+        m.run()
+
+        counts = plugin.context.get("cb_count")
+        self.seen_callbacks |= set(counts.keys())
+
+    def globals(self):
+        m = ManticoreWASM(global_file)
+        plugin = EverythingPlugin()
+        m.register_plugin(plugin)
+        m.invoke("get-a")
+        m.run()
+
+        m._reinit()
+        m.invoke("set-y", lambda s: [I64(7)])
+        m.run()
+
+        counts = plugin.context.get("cb_count")
+        self.seen_callbacks |= set(counts.keys())
+
+    def memory(self):
+        m = ManticoreWASM(memory_file)
+        plugin = EverythingPlugin()
+        m.register_plugin(plugin)
+        m.invoke("i64_load32_s", lambda s: [I64(18364758543954109763)])
+        m.run()
+
+        m._reinit()
+        m.invoke("i32_load8_s", lambda s: [I32(4294967295)])
+        m.run()
+
+        counts = plugin.context.get("cb_count")
+        self.seen_callbacks |= set(counts.keys())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds several helper methods to the WASM memory so as to conform to the standard laid out by native modules. Also lazily creates memory pages so that binaries can request large amounts of memory without Manticore needing to fill an appropriately large region with 0's. 