### PR TITLE
Use dill instead of pickle

### DIFF
--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -1,5 +1,5 @@
 import logging
-import pickle
+import dill as pickle
 import sys
 from collections import OrderedDict
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,4 +1,5 @@
-import sys, os, pickle, argparse
+import sys, os, argparse
+import dill as pickle
 
 
 # Process the data of a workspace and prints out some global information

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6",
     install_requires=[
+        "dill",
         "pyyaml",
         "wrapt",
         # evm dependencies

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1926,7 +1926,7 @@ class Armv7CpuInstructions(unittest.TestCase):
 
     # Make sure a cpu will survive a round trip through pickling/unpickling
     def test_arm_save_restore_cpu(self):
-        import pickle
+        import dill as pickle
 
         dumped_s = pickle_dumps(self.cpu)
         self.cpu = pickle.loads(dumped_s)

--- a/tests/native/test_lazy_memory.py
+++ b/tests/native/test_lazy_memory.py
@@ -3,7 +3,7 @@ import unittest
 import tempfile
 import os
 import gc
-import pickle
+import dill as pickle
 import fcntl
 import resource
 from itertools import *

--- a/tests/native/test_memory.py
+++ b/tests/native/test_memory.py
@@ -1,6 +1,6 @@
 import fcntl
 import gc
-import pickle
+import dill as pickle
 import resource
 import sys
 import unittest

--- a/tests/native/test_state.py
+++ b/tests/native/test_state.py
@@ -158,7 +158,7 @@ class StateTest(unittest.TestCase):
         self.assertEqual(expr.taint, frozenset(taint))
 
     def testContextSerialization(self):
-        import pickle as pickle
+        import dill as pickle
 
         initial_file = ""
         new_file = ""
@@ -211,7 +211,7 @@ class StateTest(unittest.TestCase):
         self.assertEqual(new_new_state.context["step"], 30)
 
     def testContextSerialization(self):
-        import pickle as pickle
+        import dill as pickle
 
         initial_file = ""
         new_file = ""

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -376,7 +376,7 @@ class ExpressionTest(unittest.TestCase):
         )  # no default so it can be anything
 
     def testBasicPickle(self):
-        import pickle
+        import dill as pickle
 
         cs = ConstraintSet()
 
@@ -626,7 +626,7 @@ class ExpressionTest(unittest.TestCase):
 
     def test_ConstraintsForking(self):
         solver = Z3Solver.instance()
-        import pickle
+        import dill as pickle
 
         cs = ConstraintSet()
         # make free 32bit bitvectors


### PR DESCRIPTION
> [`dill`](https://pypi.org/project/dill/) extends python’s `pickle` module for serializing and de-serializing python objects to the majority of the built-in python types.

> dill can also pickle more ‘exotic’ standard types:
> * functions with yields, nested functions, lambdas,
> * cell, method, unboundmethod, module, code, methodwrapper,
> * dictproxy, methoddescriptor, getsetdescriptor, memberdescriptor,
> * wrapperdescriptor, xrange, slice,
> * notimplemented, ellipsis, quit

