### PR TITLE
Streamline State Serialization Interface

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -311,6 +311,24 @@ class ManticoreBase(Eventful):
     def __str__(self):
         return f"<{str(type(self))[8:-2]}| Alive States: {self.count_ready_states()}; Running States: {self.count_busy_states()} Terminated States: {self.count_terminated_states()} Killed States: {self.count_killed_states()} Started: {self._running.value} Killed: {self._killed.value}>"
 
+    @classmethod
+    def from_saved_state(cls, filename: str, *args, **kwargs):
+        """
+        Creates a Manticore object starting from a serialized state on the disk.
+
+        :param filename: File to load the state from
+        :param args: Arguments forwarded to the Manticore object
+        :param kwargs: Keyword args forwarded to the Manticore object
+        :return: An instance of a subclass of ManticoreBase with the given initial state
+        """
+        from ..utils.helpers import PickleSerializer
+
+        fd = open(filename, "rb")
+        deserialized = PickleSerializer().deserialize(fd)
+        fd.close()
+
+        return cls(deserialized, *args, **kwargs)
+
     def _fork(self, state, expression, policy="ALL", setstate=None):
         """
         Fork state on expression concretizations.

--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -323,9 +323,8 @@ class ManticoreBase(Eventful):
         """
         from ..utils.helpers import PickleSerializer
 
-        fd = open(filename, "rb")
-        deserialized = PickleSerializer().deserialize(fd)
-        fd.close()
+        with open(filename, "rb") as fd:
+            deserialized = PickleSerializer().deserialize(fd)
 
         return cls(deserialized, *args, **kwargs)
 

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-from .smtlib import solver, Bool, issymbolic
+from .smtlib import solver, Bool, issymbolic, BitVecConstant
 from ..utils.event import Eventful
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,27 @@ class Concretize(StateException):
         self.policy = policy
         self.message = f"Concretize: {message} (Policy: {policy})"
         super().__init__(**kwargs)
+
+
+class SerializeState(Concretize):
+    """ Allows the user to save a copy of the current state somewhere on the
+        disk so that analysis can later be resumed from this point.
+    """
+    def setstate(self, state, _value):
+        from ..utils.helpers import PickleSerializer
+
+        with open(self.filename, "wb") as statef:
+            PickleSerializer().serialize(state, statef)
+
+    def __init__(self, filename, **kwargs):
+        super().__init__(
+            f"Saving state to {filename}",
+            BitVecConstant(32, 0),
+            setstate=self.setstate,
+            policy="ONE",
+            **kwargs,
+        )
+        self.filename = filename
 
 
 class ForkState(Concretize):

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -58,6 +58,7 @@ class SerializeState(Concretize):
     """ Allows the user to save a copy of the current state somewhere on the
         disk so that analysis can later be resumed from this point.
     """
+
     def setstate(self, state, _value):
         from ..utils.helpers import PickleSerializer
 

--- a/tests/native/test_resume.py
+++ b/tests/native/test_resume.py
@@ -1,0 +1,62 @@
+import unittest
+from manticore.native import Manticore
+from manticore.core.plugin import Plugin
+from manticore.core.state import SerializeState, TerminateState
+from pathlib import Path
+
+
+class InsnCounterPlugin(Plugin):
+    def did_execute_instruction_callback(self, state, last_pc, pc, instruction):
+        with self.locked_context("counter", dict) as ctx:
+            val = ctx.setdefault(instruction.mnemonic, 0)
+            ctx[instruction.mnemonic] = val + 1
+
+
+ms_file = str(
+    Path(__file__).parent.parent.parent.joinpath("examples", "linux", "binaries", "multiple-styles")
+)
+
+
+class TestResume(unittest.TestCase):
+    def test_resume(self):
+        m = Manticore(ms_file, stdin_size=18)
+        plugin = InsnCounterPlugin()
+        m.register_plugin(plugin)
+        m.run()
+
+        counts_canonical = plugin.context.get("counter")
+
+        m = Manticore(ms_file, stdin_size=18)
+        plugin = InsnCounterPlugin()
+        m.register_plugin(plugin)
+
+        @m.hook(0x0400A55)
+        def serialize(state):
+            with m.locked_context() as context:
+                if context.get("kill", False):
+                    raise TerminateState("Abandoning...")
+                context["kill"] = True
+            raise SerializeState("/tmp/ms_checkpoint.pkl")
+
+        m.run()
+
+        counts_save = plugin.context.get("counter")
+
+        m = Manticore.from_saved_state("/tmp/ms_checkpoint.pkl")
+        plugin = InsnCounterPlugin()
+        m.register_plugin(plugin)
+        m.run()
+
+        counts_resume = plugin.context.get("counter")
+
+        for k in counts_canonical:
+            with self.subTest(k):
+                self.assertEqual(
+                    counts_save.get(k, 0) + counts_resume.get(k, 0),
+                    counts_canonical[k],
+                    f"Mismatched {k} count",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/native/test_resume.py
+++ b/tests/native/test_resume.py
@@ -3,14 +3,9 @@ from manticore.native import Manticore
 from manticore.core.plugin import Plugin
 from manticore.core.state import SerializeState, TerminateState
 from pathlib import Path
+import os
 
-
-class InsnCounterPlugin(Plugin):
-    def did_execute_instruction_callback(self, state, last_pc, pc, instruction):
-        with self.locked_context("counter", dict) as ctx:
-            val = ctx.setdefault(instruction.mnemonic, 0)
-            ctx[instruction.mnemonic] = val + 1
-
+from manticore.utils.log import set_verbosity
 
 ms_file = str(
     Path(__file__).parent.parent.parent.joinpath("examples", "linux", "binaries", "multiple-styles")
@@ -19,43 +14,34 @@ ms_file = str(
 
 class TestResume(unittest.TestCase):
     def test_resume(self):
-        m = Manticore(ms_file, stdin_size=18)
-        plugin = InsnCounterPlugin()
-        m.register_plugin(plugin)
-        m.run()
+        m = Manticore(ms_file, stdin_size=17)
 
-        counts_canonical = plugin.context.get("counter")
-
-        m = Manticore(ms_file, stdin_size=18)
-        plugin = InsnCounterPlugin()
-        m.register_plugin(plugin)
-
-        @m.hook(0x0400A55)
+        # First instruction of `main`
+        @m.hook(0x4009AE)
         def serialize(state):
-            with m.locked_context() as context:
-                if context.get("kill", False):
-                    raise TerminateState("Abandoning...")
-                context["kill"] = True
+            if os.path.exists("/tmp/ms_checkpoint.pkl"):
+                raise TerminateState("Abandoning...")
             raise SerializeState("/tmp/ms_checkpoint.pkl")
 
         m.run()
-
-        counts_save = plugin.context.get("counter")
+        self.assertEqual(m.count_terminated_states(), 1)
+        for state in m.terminated_states:
+            self.assertEqual(state.cpu.PC, 0x4009AE)
 
         m = Manticore.from_saved_state("/tmp/ms_checkpoint.pkl")
-        plugin = InsnCounterPlugin()
-        m.register_plugin(plugin)
+        self.assertEqual(m.count_ready_states(), 1)
+        for st in m.ready_states:
+            self.assertEqual(state.cpu.PC, 0x4009AE)
         m.run()
 
-        counts_resume = plugin.context.get("counter")
-
-        for k in counts_canonical:
-            with self.subTest(k):
-                self.assertEqual(
-                    counts_save.get(k, 0) + counts_resume.get(k, 0),
-                    counts_canonical[k],
-                    f"Mismatched {k} count",
-                )
+        self.assertEqual(m.count_terminated_states(), 18)
+        self.assertTrue(
+            any("exit status: 0" in str(st._terminated_by) for st in m.terminated_states)
+        )
+        m.finalize()
+        for st in m.terminated_states:
+            if "exit status: 0" in str(st._terminated_by):
+                self.assertEqual(st.solve_one(st.input_symbols[0]), b"coldlikeminisodas")
 
 
 if __name__ == "__main__":

--- a/tests/wasm/test_state_saving.py
+++ b/tests/wasm/test_state_saving.py
@@ -35,28 +35,27 @@ collatz_file = str(
 class TestResume(unittest.TestCase):
     def test_resume(self):
         m = ManticoreWASM(collatz_file)
-        m.register_plugin(CallCounterPlugin())
+        plugin = CallCounterPlugin()
+        m.register_plugin(plugin)
         m.collatz(lambda s: [I32(1337)])
         m.run()
 
-        counts_canonical = m.context.get("<class 'test_state_saving.CallCounterPlugin'>").get(
-            "counter"
-        )
+        counts_canonical = plugin.context.get("counter")
 
         m = ManticoreWASM(collatz_file)
-        m.register_plugin(SerializerPlugin())
+        plugin = SerializerPlugin()
+        m.register_plugin(plugin)
         m.collatz(lambda s: [I32(1337)])
         m.run()
 
-        counts_save = m.context.get("<class 'test_state_saving.SerializerPlugin'>").get("counter")
+        counts_save = plugin.context.get("counter")
 
         m = ManticoreWASM.from_saved_state("/tmp/collatz_checkpoint.pkl")
-        m.register_plugin(CallCounterPlugin())
+        plugin = CallCounterPlugin()
+        m.register_plugin(plugin)
         m.run()
 
-        counts_resume = m.context.get("<class 'test_state_saving.CallCounterPlugin'>").get(
-            "counter"
-        )
+        counts_resume = plugin.context.get("counter")
 
         for k in counts_canonical:
             with self.subTest(k):

--- a/tests/wasm/test_state_saving.py
+++ b/tests/wasm/test_state_saving.py
@@ -1,0 +1,77 @@
+import unittest
+from manticore.wasm import ManticoreWASM
+from manticore.wasm.types import I32
+from manticore.core.plugin import Plugin
+from manticore.core.state import SerializeState, TerminateState
+from pathlib import Path
+
+
+class CallCounterPlugin(Plugin):
+    def did_execute_instruction_callback(self, state, instruction):
+        with self.locked_context("counter", dict) as ctx:
+            val = ctx.setdefault(instruction.mnemonic, 0)
+            ctx[instruction.mnemonic] = val + 1
+
+
+class SerializerPlugin(Plugin):
+    killed = False
+
+    def did_execute_instruction_callback(self, state, instruction):
+        if self.killed:
+            raise TerminateState("Abandoning")
+        with self.locked_context("counter", dict) as ctx:
+            if instruction.mnemonic == "loop" and ctx.get(instruction.mnemonic, 0) == 24:
+                self.killed = True
+                raise SerializeState("/tmp/collatz_checkpoint.pkl")
+            val = ctx.setdefault(instruction.mnemonic, 0)
+            ctx[instruction.mnemonic] = val + 1
+
+
+collatz_file = str(
+    Path(__file__).parent.parent.parent.joinpath("examples", "wasm", "collatz", "collatz.wasm")
+)
+
+
+class TestResume(unittest.TestCase):
+    def test_resume(self):
+        m = ManticoreWASM(collatz_file)
+        m.register_plugin(CallCounterPlugin())
+        m.collatz(lambda s: [I32(1337)])
+        m.run()
+
+        counts_canonical = m.context.get("<class 'test_state_saving.CallCounterPlugin'>").get(
+            "counter"
+        )
+
+        m = ManticoreWASM(collatz_file)
+        m.register_plugin(SerializerPlugin())
+        m.collatz(lambda s: [I32(1337)])
+        m.run()
+
+        counts_save = m.context.get("<class 'test_state_saving.SerializerPlugin'>").get("counter")
+
+        m = ManticoreWASM.from_saved_state("/tmp/collatz_checkpoint.pkl")
+        m.register_plugin(CallCounterPlugin())
+        m.run()
+
+        counts_resume = m.context.get("<class 'test_state_saving.CallCounterPlugin'>").get(
+            "counter"
+        )
+
+        for k in counts_canonical:
+            with self.subTest(k):
+                self.assertEqual(
+                    counts_save.get(k, 0) + counts_resume.get(k, 0),
+                    counts_canonical[k],
+                    f"Mismatched {k} count",
+                )
+
+        results = []
+        for idx, val_list in enumerate(m.collect_returns()):
+            results.append(val_list[0][0])
+
+        self.assertEqual(sorted(results), [44])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a `SerializeState` exception that (ab)uses the concretization system to save a copy of the current state to the disk. Also adds a helper method to ManticoreBase that makes resuming execution from a saved state a bit cleaner. Overall, this should allow you to pause a concrete execution halfway through and then resume your analysis from there as many times as desired. 

Currently, this works for WASM and native. I haven't tried it with EVM. On WASM, the `run` method will happily start executing whatever's in the instruction queue without trying to invoke any functions. Likewise, the native `run` method starts executing wherever the PC is pointing - the call to `_start` actually takes place during the initial state creation.

This isn't a full-blown checkpoint system. From the tests, you'll note that plugins and the shared context are not carried over. Also, since it only serializes a single state, if you want to resume execution after a point where you've forked on symbolic data, you'll need to rebuild the state lists yourself. 