### PR TITLE
Add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ setup(
     + rtd_dependent_deps(),
     extras_require=extra_require,
     entry_points={"console_scripts": ["manticore = manticore.__main__:main"]},
+    classifiers=["License :: OSI Approved :: GNU Affero General Public License v3"],
 )


### PR DESCRIPTION
This will allow PyPI to parse the license

See here for more details:
* https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py
* https://pypi.org/classifiers/ (Listed as `License :: OSI Approved :: GNU Affero General Public License v3`)