### PR TITLE
Better iterative optimization for expressions

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -39,6 +39,7 @@ consts.add(
 )
 consts.add("z3_bin", default="z3", description="Z3 binary to use")
 consts.add("defaultunsat", default=True, description="Consider solver timeouts as unsat core")
+consts.add("optimize", default=True, description="Use smtlib command optimize to find min/max if available")
 
 
 # Regular expressions used by the solver
@@ -486,7 +487,7 @@ class Z3Solver(Solver):
             self._send(aux.declaration)
 
             start = time.time()
-            if getattr(self, f"support_{goal}", False):
+            if consts.optimize and getattr(self, f"support_{goal}", False):
                 self._push()
                 try:
                     self._assert(operation(X, aux))

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -39,7 +39,9 @@ consts.add(
 )
 consts.add("z3_bin", default="z3", description="Z3 binary to use")
 consts.add("defaultunsat", default=True, description="Consider solver timeouts as unsat core")
-consts.add("optimize", default=True, description="Use smtlib command optimize to find min/max if available")
+consts.add(
+    "optimize", default=True, description="Use smtlib command optimize to find min/max if available"
+)
 
 
 # Regular expressions used by the solver

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -498,9 +498,9 @@ class Z3Solver(Solver):
                         # This will be a line like NAME |-> VALUE
                         maybe_sat = self._recv()
                         if maybe_sat == "sat":
-                            m = RE_MIN_MAX_OBJECTIVE_EXPR_VALUE.match(_status)
-                            if m:
-                                expr, value = m.group("expr"), m.group("value")
+                            match = RE_MIN_MAX_OBJECTIVE_EXPR_VALUE.match(_status)
+                            if match:
+                                expr, value = match.group("expr"), match.group("value")
                                 assert expr == aux.name
                                 return int(value)
                             else:
@@ -510,9 +510,9 @@ class Z3Solver(Solver):
                         if not (ret.startswith("(") and ret.endswith(")")):
                             raise SolverError("bad output on max, z3 may have been killed")
 
-                        m = RE_OBJECTIVES_EXPR_VALUE.match(ret)
-                        if m:
-                            expr, value = m.group("expr"), m.group("value")
+                        match = RE_OBJECTIVES_EXPR_VALUE.match(ret)
+                        if match:
+                            expr, value = match.group("expr"), match.group("value")
                             assert expr == aux.name
                             return int(value)
                         else:

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -544,7 +544,7 @@ class Z3Solver(Solver):
                 L = (m + M) // 2
                 self._push()
                 try:
-                    self._assert(operation(aux, value))
+                    self._assert(operation(aux, L))
                     sat = self._is_sat()
                 finally:
                     self._pop()

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -474,7 +474,7 @@ class Z3Solver(Solver):
         :param goal: goal to achieve, either 'maximize' or 'minimize'
         :param max_iter: maximum number of iterations allowed
         """
-        #TODO: consider adding a mode to return best known value on timeout
+        # TODO: consider adding a mode to return best known value on timeout
         assert goal in ("maximize", "minimize")
         operation = {"maximize": Operators.UGE, "minimize": Operators.ULE}[goal]
 
@@ -525,8 +525,7 @@ class Z3Solver(Solver):
             operation = {"maximize": Operators.UGE, "minimize": Operators.ULE}[goal]
             self._assert(aux == X)
 
-
-            #Find one value and use it as currently known min/Max
+            # Find one value and use it as currently known min/Max
             if not self._is_sat():
                 raise SolverException("UNSAT")
             last_value = self._getvalue(aux)
@@ -563,7 +562,7 @@ class Z3Solver(Solver):
             # Lets constrain it to that range
             self._assert(Operators.UGE(aux, m))
             self._assert(Operators.ULE(aux, M))
-            
+
             # And now check all remaining possible extremes
             last_value = None
             i = 0

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -429,6 +429,23 @@ class ExpressionTest(unittest.TestCase):
         cs.add(a >= 100)
         self.assertTrue(self.solver.check(cs))
         self.assertEqual(self.solver.minmax(cs, a), (100, 200))
+        from manticore import config
+        consts = config.get_group("smt")
+        consts.optimize=False
+        cs = ConstraintSet()
+        a = cs.new_bitvec(32)
+        cs.add(a <= 200)
+        cs.add(a >= 100)
+        self.assertTrue(self.solver.check(cs))
+        self.assertEqual(self.solver.minmax(cs, a), (100, 200))
+        consts.optimize=True
+
+    def testBitvector_max_noop(self):
+        from manticore import config
+        consts = config.get_group("smt")
+        consts.optimize=False
+        self.testBitvector_max()
+        consts.optimize=True
 
     def testBitvector_max1(self):
         cs = ConstraintSet()
@@ -437,6 +454,13 @@ class ExpressionTest(unittest.TestCase):
         cs.add(a > 100)
         self.assertTrue(self.solver.check(cs))
         self.assertEqual(self.solver.minmax(cs, a), (101, 199))
+        
+    def testBitvector_max1_noop(self):
+        from manticore import config
+        consts = config.get_group("smt")
+        consts.optimize=False
+        self.testBitvector_max1()
+        consts.optimize=True
 
     def testBool_nonzero(self):
         self.assertTrue(BoolConstant(True).__bool__())

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -430,22 +430,24 @@ class ExpressionTest(unittest.TestCase):
         self.assertTrue(self.solver.check(cs))
         self.assertEqual(self.solver.minmax(cs, a), (100, 200))
         from manticore import config
+
         consts = config.get_group("smt")
-        consts.optimize=False
+        consts.optimize = False
         cs = ConstraintSet()
         a = cs.new_bitvec(32)
         cs.add(a <= 200)
         cs.add(a >= 100)
         self.assertTrue(self.solver.check(cs))
         self.assertEqual(self.solver.minmax(cs, a), (100, 200))
-        consts.optimize=True
+        consts.optimize = True
 
     def testBitvector_max_noop(self):
         from manticore import config
+
         consts = config.get_group("smt")
-        consts.optimize=False
+        consts.optimize = False
         self.testBitvector_max()
-        consts.optimize=True
+        consts.optimize = True
 
     def testBitvector_max1(self):
         cs = ConstraintSet()
@@ -454,13 +456,14 @@ class ExpressionTest(unittest.TestCase):
         cs.add(a > 100)
         self.assertTrue(self.solver.check(cs))
         self.assertEqual(self.solver.minmax(cs, a), (101, 199))
-        
+
     def testBitvector_max1_noop(self):
         from manticore import config
+
         consts = config.get_group("smt")
-        consts.optimize=False
+        consts.optimize = False
         self.testBitvector_max1()
-        consts.optimize=True
+        consts.optimize = True
 
     def testBool_nonzero(self):
         self.assertTrue(BoolConstant(True).__bool__())


### PR DESCRIPTION
Instead of trying all the values until the max/min is found this uses a binary search.
(Used only in the case the solver does not support the "optimize" command.)