### PR TITLE
Skip basic blocks that unavoidably end in REVERT.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        type: ["examples", "ethereum", "ethereum_bench", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
+        type: ["ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.6

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -16,7 +16,13 @@ from .detectors import (
 )
 from ..core.plugin import Profiler
 from .manticore import ManticoreEVM
-from .plugins import FilterFunctions, LoopDepthLimiter, VerboseTrace, KeepOnlyIfStorageChanges, SkipRevertBasicBlocks
+from .plugins import (
+    FilterFunctions,
+    LoopDepthLimiter,
+    VerboseTrace,
+    KeepOnlyIfStorageChanges,
+    SkipRevertBasicBlocks,
+)
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils import config
 

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -16,7 +16,7 @@ from .detectors import (
 )
 from ..core.plugin import Profiler
 from .manticore import ManticoreEVM
-from .plugins import FilterFunctions, LoopDepthLimiter, VerboseTrace, KeepOnlyIfStorageChanges
+from .plugins import FilterFunctions, LoopDepthLimiter, VerboseTrace, KeepOnlyIfStorageChanges, SkipRevertBasicBlocks
 from ..utils.nointerrupt import WithKeyboardInterruptAs
 from ..utils import config
 
@@ -26,6 +26,12 @@ consts.add(
     "explore_balance",
     default=False,
     description="Explore states in which only the balance was changed",
+)
+
+consts.add(
+    "skip_reverts",
+    default=False,
+    description="Simply avoid exploring basic blocks that end in a REVERT",
 )
 
 
@@ -83,8 +89,12 @@ def ethereum_main(args, logger):
         args.only_alive_testcases = True
         consts_evm = config.get_group("evm")
         consts_evm.oog = "ignore"
+        consts.skip_reverts = True
 
     with WithKeyboardInterruptAs(m.kill):
+        if consts.skip_reverts:
+            m.register_plugin(SkipRevertBasicBlocks())
+
         if consts.explore_balance:
             m.register_plugin(KeepOnlyIfStorageChanges())
 

--- a/manticore/ethereum/plugins.py
+++ b/manticore/ethereum/plugins.py
@@ -240,6 +240,7 @@ class SkipRevertBasicBlocks(Plugin):
         world = state.platform
         if state.platform.current_transaction.sort != "CREATE":
             if instruction.semantics == "JUMPI":
+
                 # if the bb after the jumpi ends ina revert do not explore it.
                 if self._is_revert_bb(state, world.current_vm.pc + instruction.size):
                     state.constrain(arguments[1] == True)

--- a/manticore/ethereum/plugins.py
+++ b/manticore/ethereum/plugins.py
@@ -5,7 +5,8 @@ from functools import reduce
 import re
 
 from ..core.plugin import Plugin
-from ..core.smtlib import Operators
+from ..core.smtlib import Operators, to_constant
+import pyevmasm as EVMAsm
 
 
 class FilterFunctions(Plugin):
@@ -218,3 +219,30 @@ class KeepOnlyIfStorageChanges(Plugin):
                 stream.write(
                     "State was removed from ready list because the last tx did not write to the storage"
                 )
+
+class SkipRevertBasicBlocks(Plugin):
+    def _is_revert_bb(self, state, pc):
+        world = state.platform
+        def read_code(_pc=None):
+            while True:
+                yield to_constant(world.current_vm.read_code(_pc)[0])
+                _pc += 1
+        for inst in EVMAsm.disassemble_all(read_code(pc), pc):
+            if inst.name =='REVERT':
+                return True
+            if inst.is_terminator:
+                return False
+
+    def will_evm_execute_instruction_callback(self, state, instruction, arguments):
+        world = state.platform
+        if state.platform.current_transaction.sort != 'CREATE':
+            if instruction.semantics == "JUMPI":
+                #if the bb after the jumpi ends ina revert do not explore it.
+                if self._is_revert_bb(state, world.current_vm.pc + instruction.size):
+                    state.constrain(arguments[1] == True)
+
+                #if the target of the jumpi ends up in a revert avoid it
+                if self._is_revert_bb(state, arguments[0]):
+                    state.constrain(arguments[1] == False)
+
+                #This may have added an impossible constraint.


### PR DESCRIPTION
This assumes nobody is using the result of REVERT and is not checking if the returned value is empty. Fixes https://github.com/trailofbits/manticore/issues/1593