### PR TITLE
Attempt to fix Truffle tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
+    - name: Install NPM
+      uses: actions/setup-node@v1
+      with:
+        node-version: '13.x'
     - name: Install dependencies
       env:
         TEST_TYPE: ${{ matrix.type }}
@@ -146,11 +150,6 @@ jobs:
         }
 
         install_truffle(){
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
-            source ~/.nvm/nvm.sh
-            nvm install --lts
-            nvm use --lts
-
             npm install -g truffle
         }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         }
 
         install_truffle(){
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
             source ~/.nvm/nvm.sh
             nvm install --lts
             nvm use --lts


### PR DESCRIPTION
All of our pull request builds are failing right now due to (apparently) upstream changes to Truffle. Perhaps bumping the version number will be enough to fix them?