### PR TITLE
Add missing support for ARM modified immediate encodings

### DIFF
--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -26,7 +26,7 @@ def HighBit(n):
 ARMV7_CPU_ADDRESS_BIT_SIZE = 32
 
 
-def instruction(body=None, *, can_take_denormalized_mod_imm: bool = False):
+def instruction(instruction_body=None, *, can_take_denormalized_mod_imm: bool = False):
     """
     This decorator is used to annotate Armv7Cpu methods as
     instruction-implementing methods.
@@ -130,8 +130,8 @@ def instruction(body=None, *, can_take_denormalized_mod_imm: bool = False):
     # `@instruction` and like `@instruction(can_take_denormalized_mod_imm=True)`.
     # See https://stackoverflow.com/questions/3888158/making-decorators-with-optional-arguments
     # for some decorator-fu.
-    if body is not None:
-        return decorator(body)
+    if instruction_body is not None:
+        return decorator(instruction_body)
     else:
         return decorator
 

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1521,9 +1521,9 @@ class Armv7Cpu(Cpu):
         else:
             cpu._bitwise_instruction(lambda x, y: x & y, dest, dest, op1)
 
-    @instruction
-    def TEQ(cpu, *operands):
-        cpu._bitwise_instruction(lambda x, y: x ^ y, None, *operands)
+    @instruction(can_take_denormalized_mod_imm=True)
+    def TEQ(cpu, op1, op2=None):
+        cpu._bitwise_instruction(lambda x, y: x ^ y, None, op1, op2)
         cpu.commit_flags()
 
     @instruction

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1618,7 +1618,7 @@ class Armv7Cpu(Cpu):
         dest.write(result & Mask(width))
         cpu.set_flags(N=HighBit(result), Z=(result == 0))
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def MVN(cpu, dest, op):
         cpu._bitwise_instruction(lambda x: ~x, dest, op)
 

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1135,7 +1135,7 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         return result, carry, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def SBC(cpu, dest, op1, op2=None):
         carry = cpu.regfile.read("APSR_C")
         if op2 is not None:

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1124,7 +1124,7 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         return result, carry, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def SUB(cpu, dest, src, add=None):
         if add is not None:
             result, carry, overflow = cpu._ADD(src.read(), ~add.read(), 1)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1089,7 +1089,7 @@ class Armv7Cpu(Cpu):
 
         return result, carry_out, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def ADC(cpu, dest, op1, op2=None):
         carry = cpu.regfile.read("APSR_C")
         if op2 is not None:

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1493,7 +1493,7 @@ class Armv7Cpu(Cpu):
             dest.write(result)
         cpu.set_flags(C=carry, N=HighBit(result), Z=(result == 0))
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def ORR(cpu, dest, op1, op2=None):
         if op2 is not None:
             cpu._bitwise_instruction(lambda x, y: x | y, dest, op1, op2)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1500,7 +1500,7 @@ class Armv7Cpu(Cpu):
         else:
             cpu._bitwise_instruction(lambda x, y: x | y, dest, dest, op1)
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def ORN(cpu, dest, op1, op2=None):
         if op2 is not None:
             cpu._bitwise_instruction(lambda x, y: x | ~y, dest, op1, op2)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1116,7 +1116,7 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         return result, carry, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def RSC(cpu, dest, src, add):
         carry = cpu.regfile.read("APSR_C")
         inv_src = GetNBits(~src.read(), cpu.address_bit_size)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1514,7 +1514,7 @@ class Armv7Cpu(Cpu):
         else:
             cpu._bitwise_instruction(lambda x, y: x ^ y, dest, dest, op1)
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def AND(cpu, dest, op1, op2=None):
         if op2 is not None:
             cpu._bitwise_instruction(lambda x, y: x & y, dest, op1, op2)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -46,6 +46,7 @@ def instruction(body=None, *, can_take_denormalized_mod_imm: bool = False):
     for some decorator-fu specific to making this work both when used both like
     `@instruction` and like `@instruction(can_take_denormalized_mod_imm=True)`.
     """
+
     def decorator(body):
         if can_take_denormalized_mod_imm:
             # Need to possibly normalize a modified immediate argument that's

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1538,7 +1538,7 @@ class Armv7Cpu(Cpu):
             logger.warning(f"Bad SVC number: {op.read():08}")
         raise Interruption(0)
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def CMN(cpu, src, add):
         result, carry, overflow = cpu._ADD(src.read(), add.read())
         return result, carry, overflow

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1099,7 +1099,7 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         return result, carry, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def ADD(cpu, dest, src, add=None):
         if add is not None:
             result, carry, overflow = cpu._ADD(src.read(), add.read())

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1482,9 +1482,9 @@ class Armv7Cpu(Cpu):
     def STMDB(cpu, base, *regs):
         cpu._STM(cs.arm.ARM_INS_STMDB, base, regs)
 
-    def _bitwise_instruction(cpu, operation, dest, op1, *op2):
+    def _bitwise_instruction(cpu, operation, dest, op1, op2=None):
         if op2:
-            op2_val, carry = op2[0].read(with_carry=True)
+            op2_val, carry = op2.read(with_carry=True)
             result = operation(op1.read(), op2_val)
         else:
             op1_val, carry = op1.read(with_carry=True)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1526,10 +1526,10 @@ class Armv7Cpu(Cpu):
         cpu._bitwise_instruction(lambda x, y: x ^ y, None, op1, op2)
         cpu.commit_flags()
 
-    @instruction
-    def TST(cpu, Rn, Rm):
-        shifted, carry = Rm.read(with_carry=True)
-        result = Rn.read() & shifted
+    @instruction(can_take_denormalized_mod_imm=True)
+    def TST(cpu, op1, op2):
+        shifted, carry = op2.read(with_carry=True)
+        result = op1.read() & shifted
         cpu.set_flags(N=HighBit(result), Z=(result == 0), C=carry)
 
     @instruction

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1323,7 +1323,7 @@ class Armv7Cpu(Cpu):
 
         cpu.PC += offset << 1
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def CMP(cpu, reg, compare):
         notcmp = ~compare.read() & Mask(cpu.address_bit_size)
         cpu._ADD(reg.read(), notcmp, 1)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1507,7 +1507,7 @@ class Armv7Cpu(Cpu):
         else:
             cpu._bitwise_instruction(lambda x, y: x | ~y, dest, dest, op1)
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def EOR(cpu, dest, op1, op2=None):
         if op2 is not None:
             cpu._bitwise_instruction(lambda x, y: x ^ y, dest, op1, op2)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1633,7 +1633,7 @@ class Armv7Cpu(Cpu):
         dest.write(result & Mask(cpu.address_bit_size))
         cpu.set_flags(N=HighBit(result), Z=(result == 0))
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def BIC(cpu, dest, op1, op2=None):
         if op2 is not None:
             result = (op1.read() & ~op2.read()) & Mask(cpu.address_bit_size)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -1109,7 +1109,7 @@ class Armv7Cpu(Cpu):
         dest.write(result)
         return result, carry, overflow
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def RSB(cpu, dest, src, add):
         inv_src = GetNBits(~src.read(), cpu.address_bit_size)
         result, carry, overflow = cpu._ADD(inv_src, add.read(), 1)

--- a/manticore/native/cpu/arm.py
+++ b/manticore/native/cpu/arm.py
@@ -843,7 +843,7 @@ class Armv7Cpu(Cpu):
             )
         dest.write(Operators.CONCAT(32, *reversed(result)))
 
-    @instruction
+    @instruction(can_take_denormalized_mod_imm=True)
     def MOV(cpu, dest, src):
         """
         Implement the MOV{S} instruction.

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1371,7 +1371,7 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_setregs("R1=0x18010", "APSR_C=0")
     def test_sbc_mod_imm_2(self):
         self.cpu.execute()
-        self.assertEqual(self.rf.read("R3"), 0xf)
+        self.assertEqual(self.rf.read("R3"), 0xF)
 
     @itest_custom("sbc r3, r1, #24, 20")
     @itest_setregs("R1=0x18010", "APSR_C=1")
@@ -1383,7 +1383,7 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_setregs("R1=0x18010", "APSR_C=0")
     def test_sbc_mod_imm_4(self):
         self.cpu.execute()
-        self.assertEqual(self.rf.read("R3"), 0xf)
+        self.assertEqual(self.rf.read("R3"), 0xF)
 
     # LDM/LDMIB/LDMDA/LDMDB
 
@@ -1661,13 +1661,13 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_setregs("R3=0xA")
     def test_eor_mod_imm_1(self):
         self.cpu.execute()
-        self.assertEqual(self.rf.read("R2"), 0x1800a)
+        self.assertEqual(self.rf.read("R2"), 0x1800A)
 
     @itest_custom("eor r2, r3, #24, 20")
     @itest_setregs("R3=0xA")
     def test_eor_mod_imm_2(self):
         self.cpu.execute()
-        self.assertEqual(self.rf.read("R2"), 0x1800a)
+        self.assertEqual(self.rf.read("R2"), 0x1800A)
 
     # LDRH - see also LDR tests
 

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1921,11 +1921,23 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_asrw_thumb(self):
         self.assertEqual(self.cpu.R5, 16 >> 3)
 
+    # RSB
+
     @itest_setregs("R2=29")
     @itest("RSB r2, r2, #31")
     def test_rsb_imm(self):
         # Diverging instruction from trace
         self.assertEqual(self.rf.read("R2"), 2)
+
+    @itest_setregs("R2=0x17000")
+    @itest("RSB r2, r2, #0x18000")
+    def test_rsb_mod_imm_1(self):
+        self.assertEqual(self.rf.read("R2"), 0x1000)
+
+    @itest_setregs("R2=0x17000")
+    @itest("RSB r2, r2, #24, 20")
+    def test_rsb_mod_imm_2(self):
+        self.assertEqual(self.rf.read("R2"), 0x1000)
 
     @itest_setregs("R6=2", "R8=0xfffffffe")
     @itest("RSBS r8, r6, #0")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1787,6 +1787,37 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_tst_mod_imm_2(self):
         self._checkFlagsNZCV(0, 1, 0, 0)
 
+    # TEQ
+    @itest_setregs("R1=1", "R3=0")
+    @itest("teq r3, r1")
+    def test_teq_1(self):
+        self._checkFlagsNZCV(0, 0, 0, 0)
+
+    @itest_setregs("R1=1", "R3=1")
+    @itest("teq r3, r1")
+    def test_teq_2(self):
+        self._checkFlagsNZCV(0, 1, 0, 0)
+
+    @itest_setregs("R3=0")
+    @itest("teq r3, #0x18000")
+    def test_teq_mod_imm_1(self):
+        self._checkFlagsNZCV(0, 0, 0, 0)
+
+    @itest_setregs("R3=0x18000")
+    @itest("teq r3, #0x18000")
+    def test_teq_mod_imm_2(self):
+        self._checkFlagsNZCV(0, 1, 0, 0)
+
+    @itest_setregs("R3=0")
+    @itest("teq r3, #24, 20")
+    def test_teq_mod_imm_3(self):
+        self._checkFlagsNZCV(0, 0, 0, 0)
+
+    @itest_setregs("R3=0x18000")
+    @itest("teq r3, #24, 20")
+    def test_teq_mod_imm_4(self):
+        self._checkFlagsNZCV(0, 1, 0, 0)
+
     # AND
     @itest_setregs("R2=5")
     @itest("and r2, r2, #1")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1992,6 +1992,16 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_thumb_bic_reg_imm(self):
         self.assertEqual(self.rf.read("R1"), 0xEF)
 
+    @itest_setregs("R1=0x18002")
+    @itest("BIC R2, R1, #0x18000")
+    def test_bic_reg_mod_imm_1(self):
+        self.assertEqual(self.rf.read("R2"), 0x2)
+
+    @itest_setregs("R1=0x18002")
+    @itest("BIC R2, R1, #24, 20")
+    def test_bic_reg_mod_imm_2(self):
+        self.assertEqual(self.rf.read("R2"), 0x2)
+
     @itest_setregs("R1=0x1008")
     @itest("BLX R1")
     def test_blx_reg(self):

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -498,11 +498,13 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R3"), 0x60000000)
 
+    # ADCS
     @itest_setregs("R3=0xfffffff6", "R4=10")
     @itest_thumb("adcs r3, r4")
     def test_thumb_adc_basic(self):
         self.assertEqual(self.rf.read("R3"), 0)
 
+    # ADC
     @itest_custom("adc r3, r1, r2")
     @itest_setregs("R1=1", "R2=2", "APSR_C=1")
     def test_adc_basic(self):
@@ -516,6 +518,18 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.rf.write("R2", 0x3)
         self.cpu.execute()
         self.assertEqual(self.rf.read("R3"), 0x60000001)
+
+    @itest_custom("adc r3, r1, #0x18000")
+    @itest_setregs("R1=1", "APSR_C=1")
+    def test_adc_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0x18002)
+
+    @itest_custom("adc r3, r1, #24, 20")
+    @itest_setregs("R1=1", "APSR_C=1")
+    def test_adc_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0x18002)
 
     # TODO what is shifter_carry_out in the manual, A8-291? it gets set to
     # Bit[0] presumably, but i have no clue what it is. Not mentioned again in

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1268,6 +1268,8 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R1"), 1)
 
+    # SUB
+
     @itest_custom("sub r3, r1, r2")
     @itest_setregs("R1=4", "R2=2")
     def test_sub_basic(self):
@@ -1284,6 +1286,18 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_sub_imm(self):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R3"), 5)
+
+    @itest_custom("sub r3, r1, #0x18000")
+    @itest_setregs("R1=0x18000")
+    def test_sub_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
+
+    @itest_custom("sub r3, r1, #24, 20")
+    @itest_setregs("R1=0x18000")
+    def test_sub_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
 
     @itest_custom("uqsub8 r3, r1, r2")
     @itest_setregs("R1=0x04030201", "R2=0x01010101")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1322,6 +1322,32 @@ class Armv7CpuInstructions(unittest.TestCase):
         all_vals = solver.get_all_values(self.cpu.memory.constraints, self.cpu.R3)
         self.assertIn(0x03020100, all_vals)
 
+    # RSC
+
+    @itest_custom("rsc r3, r1, #0x18000")
+    @itest_setregs("R1=0x18000", "APSR_C=1")
+    def test_rsc_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
+
+    @itest_custom("rsc r3, r1, #0x18000")
+    @itest_setregs("R1=0x17fff", "APSR_C=0")
+    def test_rsc_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
+
+    @itest_custom("rsc r3, r1, #24, 20")
+    @itest_setregs("R1=0x18000", "APSR_C=1")
+    def test_rsc_mod_imm_3(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
+
+    @itest_custom("rsc r3, r1, #24, 20")
+    @itest_setregs("R1=0x17fff", "APSR_C=0")
+    def test_rsc_mod_imm_4(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0)
+
     @itest_custom("sbc r3, r1, #5")
     @itest_setregs("R1=10")
     def test_sbc_imm(self):

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1034,8 +1034,28 @@ class Armv7CpuInstructions(unittest.TestCase):
 
     # ADR
 
-    @itest_custom("adr r0, #16", mode=CS_MODE_THUMB)
+    @itest_custom("adr r0, #16")
     def test_adr(self):
+        pre_pc = self.rf.read("PC")
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R0"), (pre_pc + 8) + 16)
+
+    # Note, ARM ARM says that the following is an alternative encoding for a form of ADR
+    @itest_custom("add r0, PC, #0x10")
+    def test_adr_mod_imm_1(self):
+        pre_pc = self.rf.read("PC")
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R0"), (pre_pc + 8) + 0x10)
+
+    # Note, ARM ARM says that the following is an alternative encoding for a form of ADR
+    @itest_custom("add r0, PC, #1, 28")
+    def test_adr_mod_imm_2(self):
+        pre_pc = self.rf.read("PC")
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R0"), (pre_pc + 8) + 0x10)
+
+    @itest_custom("adr r0, #16", mode=CS_MODE_THUMB)
+    def test_adr_thumb(self):
         pre_pc = self.rf.read("PC")
         self.cpu.execute()
         self.assertEqual(self.rf.read("R0"), (pre_pc + 4) + 16)  # adr is 4 bytes long

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1573,6 +1573,18 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_thumb_orr_imm(self):
         self.assertEqual(self.rf.read("R3"), 0x1005)
 
+    @itest_custom("orr r2, r3, #0x18000")
+    @itest_setregs("R3=0x1000")
+    def test_orr_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R2"), 0x19000)
+
+    @itest_custom("orr r2, r3, #24, 20")
+    @itest_setregs("R3=0x1000")
+    def test_orr_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R2"), 0x19000)
+
     @itest_custom("orrs r2, r3")
     @itest_setregs("R2=0x5", "R3=0x80000000")
     def test_orrs_imm_flags(self):

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -224,6 +224,23 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.rf.read("APSR_C"), c)
         self.assertEqual(self.rf.read("APSR_V"), v)
 
+    # MVN
+    @itest("mvn r0, #0x0")
+    def test_mvn_imm_min(self):
+        self.assertEqual(self.rf.read("R0"), 0xFFFFFFFF)
+
+    @itest("mvn r0, #0xFFFFFFFF")
+    def test_mvn_imm_max(self):
+        self.assertEqual(self.rf.read("R0"), 0x0)
+
+    @itest("mvn r0, #0x18000")
+    def test_mvn_mod_imm_1(self):
+        self.assertEqual(self.rf.read("R0"), 0xFFFE7FFF)
+
+    @itest("mvn r0, #24, 20")
+    def test_mvn_mod_imm_2(self):
+        self.assertEqual(self.rf.read("R0"), 0xFFFE7FFF)
+
     # MOV
 
     @itest("mov r0, 0x0")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1764,7 +1764,27 @@ class Armv7CpuInstructions(unittest.TestCase):
     # TST
     @itest_setregs("R1=1", "R3=0")
     @itest("tst r3, r1")
-    def test_tst(self):
+    def test_tst_1(self):
+        self._checkFlagsNZCV(0, 1, 0, 0)
+
+    @itest_setregs("R1=1", "R3=1")
+    @itest("tst r3, r1")
+    def test_tst_2(self):
+        self._checkFlagsNZCV(0, 0, 0, 0)
+
+    @itest_setregs("R1=1", "R3=3")
+    @itest("tst r3, r1")
+    def test_tst_3(self):
+        self._checkFlagsNZCV(0, 0, 0, 0)
+
+    @itest_setregs("R3=0")
+    @itest("tst r3, #0x18000")
+    def test_tst_mod_imm_1(self):
+        self._checkFlagsNZCV(0, 1, 0, 0)
+
+    @itest_setregs("R3=0")
+    @itest("tst r3, #24, 20")
+    def test_tst_mod_imm_2(self):
         self._checkFlagsNZCV(0, 1, 0, 0)
 
     # AND

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1182,6 +1182,18 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("PC"), (pre_pc + 4) + 42)  # tbh is 4 bytes long
 
+    # CMN
+
+    @itest_setregs("R0=-0x18000")
+    @itest("cmn r0, #0x18000")
+    def test_cmn_eq_mod_imm_1(self):
+        self._checkFlagsNZCV(0, 1, 1, 0)
+
+    @itest_setregs("R0=-0x18000")
+    @itest("cmn r0, #24, 20")
+    def test_cmn_eq_mod_imm_2(self):
+        self._checkFlagsNZCV(0, 1, 1, 0)
+
     # CMP
 
     @itest_setregs("R0=3")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -259,6 +259,14 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_mov_imm_modified_imm_max(self):
         self.assertEqual(self.rf.read("R0"), 0xFF000000)
 
+    @itest("mov r0, #0x18000")
+    def test_mov_mod_imm_1(self):
+        self.assertEqual(self.rf.read("R0"), 0x18000)
+
+    @itest("mov r0, #24, 20")
+    def test_mov_mod_imm_2(self):
+        self.assertEqual(self.rf.read("R0"), 0x18000)
+
     @itest_custom("mov r0, r1")
     def test_mov_immreg(self):
         self.rf.write("R1", 0)

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1657,6 +1657,18 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R2"), 0x5)
 
+    @itest_custom("eor r2, r3, #0x18000")
+    @itest_setregs("R3=0xA")
+    def test_eor_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R2"), 0x1800a)
+
+    @itest_custom("eor r2, r3, #24, 20")
+    @itest_setregs("R3=0xA")
+    def test_eor_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R2"), 0x1800a)
+
     # LDRH - see also LDR tests
 
     @itest_custom("ldrh r1, [sp]")

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1348,6 +1348,8 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R3"), 0)
 
+    # SBC
+
     @itest_custom("sbc r3, r1, #5")
     @itest_setregs("R1=10")
     def test_sbc_imm(self):
@@ -1358,6 +1360,30 @@ class Armv7CpuInstructions(unittest.TestCase):
     @itest_thumb("sbcs r0, r3")
     def test_sbc_thumb(self):
         self.assertEqual(self.rf.read("R0"), 0)
+
+    @itest_custom("sbc r3, r1, #0x18000")
+    @itest_setregs("R1=0x18010", "APSR_C=1")
+    def test_sbc_mod_imm_1(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0x10)
+
+    @itest_custom("sbc r3, r1, #0x18000")
+    @itest_setregs("R1=0x18010", "APSR_C=0")
+    def test_sbc_mod_imm_2(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0xf)
+
+    @itest_custom("sbc r3, r1, #24, 20")
+    @itest_setregs("R1=0x18010", "APSR_C=1")
+    def test_sbc_mod_imm_3(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0x10)
+
+    @itest_custom("sbc r3, r1, #24, 20")
+    @itest_setregs("R1=0x18010", "APSR_C=0")
+    def test_sbc_mod_imm_4(self):
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 0xf)
 
     # LDM/LDMIB/LDMDA/LDMDB
 

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1201,6 +1201,16 @@ class Armv7CpuInstructions(unittest.TestCase):
     def test_cmp_eq(self):
         self._checkFlagsNZCV(0, 1, 1, 0)
 
+    @itest_setregs("R0=0x18000")
+    @itest("cmp r0, #0x18000")
+    def test_cmp_eq_mod_imm_1(self):
+        self._checkFlagsNZCV(0, 1, 1, 0)
+
+    @itest_setregs("R0=0x18000")
+    @itest("cmp r0, #24, 20")
+    def test_cmp_eq_mod_imm_2(self):
+        self._checkFlagsNZCV(0, 1, 1, 0)
+
     @itest_setregs("R0=3")
     @itest("cmp r0, 5")
     def test_cmp_lt(self):

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -1835,6 +1835,16 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.assertEqual(self.rf.read("R1"), 3 & 5)
         self.assertEqual(self.rf.read("APSR_C"), 1)
 
+    @itest_setregs("R2=5")
+    @itest("and r2, r2, #0x18000")
+    def test_and_mod_imm_1(self):
+        self.assertEqual(self.rf.read("R2"), 0)
+
+    @itest_setregs("R2=5")
+    @itest("and r2, r2, #24, 20")
+    def test_and_mod_imm_2(self):
+        self.assertEqual(self.rf.read("R2"), 0)
+
     # svc
 
     def test_svc(self):

--- a/tests/native/test_armv7cpu.py
+++ b/tests/native/test_armv7cpu.py
@@ -391,6 +391,18 @@ class Armv7CpuInstructions(unittest.TestCase):
         self.cpu.execute()
         self.assertEqual(self.rf.read("R3"), 44 + 0x100)
 
+    @itest_custom("add r3, r1, 0x18000")
+    def test_add_imm_mod_imm_case1(self):
+        self.rf.write("R1", 44)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 44 + 0x18000)
+
+    @itest_custom("add r3, r1, 24, 20")
+    def test_add_imm_mod_imm_case2(self):
+        self.rf.write("R1", 44)
+        self.cpu.execute()
+        self.assertEqual(self.rf.read("R3"), 44 + 0x18000)
+
     @itest_custom("add r3, r1, 0xff000000")
     def test_add_imm_mod_imm_max(self):
         self.rf.write("R1", 44)


### PR DESCRIPTION
Fixes #1621.

After cleaning some things up in the existing implementation, it became clearer how to make the decorator-based approach work, so I ended up going with that.

I added a bunch of additional unit tests as I did this work.