### PR TITLE
CI: have pytest report 100 slowest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
 
         run_tests_from_dir() {
             DIR=$1
-            pytest --cov=manticore -n auto "tests/$DIR"
+            pytest --durations=100 --cov=manticore -n auto "tests/$DIR"
             coverage xml
         }
 


### PR DESCRIPTION
This change merely passes an extra argument to `pytest` when it's invoked via GitHub Actions, so that the 100 slowest tests are reported.  This information is useful to identify possible places to tighten up the test suite.