### PR TITLE
Add support for `sys_arm_fadvise64_64`

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2141,6 +2141,10 @@ class Linux(Platform):
         logger.info("Ignoring sys_fadvise64")
         return 0
 
+    def sys_arm_fadvise64_64(self, fd: int, offset: int, length: int, advice: int) -> int:
+        logger.info("Ignoring sys_arm_fadvise64_64")
+        return 0
+
     def sys_socket(self, domain, socket_type, protocol):
         if domain != socket.AF_INET:
             return -errno.EINVAL

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2137,7 +2137,7 @@ class Linux(Platform):
         logger.info("Ignoring sys_madvise")
         return 0
 
-    def sys_fadvise64(self, fd, offset, length, advice):
+    def sys_fadvise64(self, fd: int, offset: int, length: int, advice: int) -> int:
         logger.info("Ignoring sys_fadvise64")
         return 0
 


### PR DESCRIPTION
We support this syscall as a no-op, similar to the existing `sys_fadvise64` and `sys_madvise` syscalls.

With this addition, Manticore gets much much farther emulating some GNU Coreutils programs build for ARMv7 Thumb2.