### PR TITLE
Swap remaining uses of `Z3Solver()` to use the singleton interface

### DIFF
--- a/manticore/core/workspace.py
+++ b/manticore/core/workspace.py
@@ -651,5 +651,5 @@ class ManticoreOutput:
     def save_input_symbols(testcase, state):
         with testcase.open_stream("input") as f:
             for symbol in state.input_symbols:
-                buf = Z3Solver().get_value(state.constraints, symbol)
+                buf = Z3Solver.instance().get_value(state.constraints, symbol)
                 f.write(f"{symbol.name}: {buf!r}\n")

--- a/manticore/native/cpu/abstractcpu.py
+++ b/manticore/native/cpu/abstractcpu.py
@@ -907,7 +907,9 @@ class Cpu(Eventful):
                         vals = visitors.simplify_array_select(c)
                         c = bytes([vals[0]])
                     except visitors.ArraySelectSimplifier.ExpressionNotSimple:
-                        c = struct.pack("B", Z3Solver().get_value(self.memory.constraints, c))
+                        c = struct.pack(
+                            "B", Z3Solver.instance().get_value(self.memory.constraints, c)
+                        )
                 elif isinstance(c, Constant):
                     c = bytes([c.value])
                 else:

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -189,7 +189,7 @@ class Manticore(ManticoreBase):
         # This will interpret the buffer specification written in INTEL ASM.
         # (It may dereference pointers)
         assertion = parse(program, state.cpu.read_int, state.cpu.read_register)
-        if not Z3Solver().can_be_true(state.constraints, assertion):
+        if not Z3Solver.instance().can_be_true(state.constraints, assertion):
             logger.info(str(state.cpu))
             logger.info(
                 "Assertion %x -> {%s} does not hold. Aborting state.", state.cpu.pc, program

--- a/manticore/native/models.py
+++ b/manticore/native/models.py
@@ -46,7 +46,7 @@ def _find_zero(cpu, constrs, ptr):
         byt = cpu.read_int(ptr + offset, 8)
 
         if issymbolic(byt):
-            if not Z3Solver().can_be_true(constrs, byt != 0):
+            if not Z3Solver.instance().can_be_true(constrs, byt != 0):
                 break
         else:
             if byt == 0:

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -1184,7 +1184,7 @@ class EVM(Eventful):
         if isinstance(should_check_jumpdest, Constant):
             should_check_jumpdest = should_check_jumpdest.value
         elif issymbolic(should_check_jumpdest):
-            should_check_jumpdest_solutions = Z3Solver().get_all_values(
+            should_check_jumpdest_solutions = Z3Solver.instance().get_all_values(
                 self.constraints, should_check_jumpdest
             )
             if len(should_check_jumpdest_solutions) != 1:
@@ -1732,7 +1732,7 @@ class EVM(Eventful):
         self._consume(copyfee)
 
         if issymbolic(size):
-            max_size = Z3Solver().max(self.constraints, size)
+            max_size = Z3Solver.instance().max(self.constraints, size)
         else:
             max_size = size
 
@@ -2127,7 +2127,7 @@ class EVM(Eventful):
         # FIXME for on the known addresses
         if issymbolic(recipient):
             logger.info("Symbolic recipient on self destruct")
-            recipient = Z3Solver().get_value(self.constraints, recipient)
+            recipient = Z3Solver.instance().get_value(self.constraints, recipient)
 
         if recipient not in self.world:
             self.world.create_account(address=recipient)

--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -2036,7 +2036,7 @@ class Linux(Platform):
             size = cpu.read_int(iov + i * sizeof_iovec + (sizeof_iovec // 2), ptrsize)
 
             if issymbolic(size):
-                size = Z3Solver().get_value(self.constraints, size)
+                size = Z3Solver.instance().get_value(self.constraints, size)
 
             data = [Operators.CHR(cpu.read_int(buf + i, 8)) for i in range(size)]
             data = self._transform_write_data(data)
@@ -2978,7 +2978,7 @@ class SLinux(Linux):
         for c in data:
             if issymbolic(c):
                 bytes_concretized += 1
-                c = bytes([Z3Solver().get_value(self.constraints, c)])
+                c = bytes([Z3Solver.instance().get_value(self.constraints, c)])
             concrete_data += cast(bytes, c)
 
         if bytes_concretized > 0:
@@ -2990,7 +2990,7 @@ class SLinux(Linux):
 
     def sys_exit_group(self, error_code):
         if issymbolic(error_code):
-            error_code = Z3Solver().get_value(self.constraints, error_code)
+            error_code = Z3Solver.instance().get_value(self.constraints, error_code)
             return self._exit(
                 f"Program finished with exit status: {ctypes.c_int32(error_code).value} (*)"
             )
@@ -3177,7 +3177,7 @@ class SLinux(Linux):
             try:
                 for c in data:
                     if issymbolic(c):
-                        c = Z3Solver().get_value(self.constraints, c)
+                        c = Z3Solver.instance().get_value(self.constraints, c)
                     fd.write(make_chr(c))
             except SolverError:
                 fd.write("{SolverError}")


### PR DESCRIPTION
It turns out that in smaller programs, like examples/linux/binaries/multiple-styles, something like 15-20% of total runtime is spent redundantly initializing the Z3 solver!