### PR TITLE
Bump to CheckoutV2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -300,8 +300,14 @@ class Z3Solver(Solver):
         """
         # logger.debug('>%s', cmd)
         try:
-            self._proc.stdout.flush()
-            self._proc.stdin.write(f"{cmd}\n")
+            if self._proc.stdout:
+                self._proc.stdout.flush()
+            else:
+                raise SolverError("Could not flush stdout: file descriptor is None")
+            if self._proc.stdin:
+                self._proc.stdin.write(f"{cmd}\n")
+            else:
+                raise SolverError("Could not write to stdin: file descriptor is None")
         except IOError as e:
             raise SolverError(str(e))
 

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ def rtd_dependent_deps():
 
 # If you update native_deps please update the `REQUIREMENTS_TO_IMPORTS` dict in `utils/install_helper.py`
 # (we need to know how to import a given native dependency so we can check if native dependencies are installed)
-native_deps = ["capstone==4.0.1", "pyelftools", "unicorn==1.0.2rc1"]
+native_deps = ["capstone==4.0.1", "pyelftools", "unicorn==1.0.2rc2"]
 
-lint_deps = ["black==19.3b0", "mypy==0.740"]
+lint_deps = ["black==19.10b0", "mypy==0.770"]
 
 # Development dependencies without keystone
 dev_noks = (


### PR DESCRIPTION
Github actions is [currently failing](https://github.com/trailofbits/manticore/pull/1641/checks?check_run_id=564784041) to check out Manticore, possibly due to an outage.  Per slack, switching to checkoutV2 may fix it. 

Also updates Unicorn, black, and mypy to the latest versions. 