### PR TITLE
Randomize test suite order when using pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ dev_noks = (
     native_deps
     + [
         "coverage",
-        "Sphinx",
-        "pytest==5.3.0",
-        "pytest-xdist==1.30.0",
-        "pytest-cov==2.8.1",
         "jinja2",
+        "pytest==5.3.0",
+        "pytest-cov==2.8.1",
+        "pytest-xdist==1.30.0",
+        "Sphinx",
     ]
     + lint_deps
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ dev_noks = (
         "jinja2",
         "pytest==5.3.0",
         "pytest-cov==2.8.1",
+        "pytest-randomly==3.2.1",
         "pytest-xdist==1.30.0",
         "Sphinx",
     ]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,14 @@ lint_deps = ["black==19.10b0", "mypy==0.770"]
 # Development dependencies without keystone
 dev_noks = (
     native_deps
-    + ["coverage", "Sphinx", "pytest==5.3.0", "pytest-xdist==1.30.0", "pytest-cov==2.8.1", "jinja2"]
+    + [
+        "coverage",
+        "Sphinx",
+        "pytest==5.3.0",
+        "pytest-xdist==1.30.0",
+        "pytest-cov==2.8.1",
+        "jinja2",
+    ]
     + lint_deps
 )
 


### PR DESCRIPTION
The idea behind running tests in a random order is that it will help to identify hidden ordering dependencies among test cases.  The principle is that test cases (or perhaps groups of related test cases) shouldn't be order-dependent; they should succeed regardless of the order that they're run in.