### PR TITLE
Make CodeCov wait for reports from all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,13 @@ jobs:
             # concolic assumes presence of ../linux/simpleassert
             echo "Running concolic.py..."
             HW=../linux/helloworld
-            python ./concolic.py
+            coverage run ./concolic.py
             if [ $? -ne 0 ]; then
                 return 1
             fi
 
             echo "Running count_instructions.py..."
-            python ./count_instructions.py $HW |grep -q Executed
+            coverage run ./count_instructions.py $HW |grep -q Executed
             if [ $? -ne 0 ]; then
                 return 1
             fi
@@ -81,21 +81,21 @@ jobs:
             gcc -static -g src/state_explore.c -o state_explore
             ADDRESS=0x$(objdump -S state_explore | grep -A 1 '((value & 0xff) != 0)' |
                     tail -n 1 | sed 's|^\s*||g' | cut -f1 -d:)
-            python ./introduce_symbolic_bytes.py state_explore $ADDRESS
+            coverage run ./introduce_symbolic_bytes.py state_explore $ADDRESS
             if [ $? -ne 0 ]; then
                 return 1
             fi
 
             echo "Running run_simple.py..."
             gcc -x c -static -o hello test_run_simple.c
-            python ./run_simple.py hello
+            coverage run ./run_simple.py hello
             if [ $? -ne 0 ]; then
                 return 1
             fi
 
             echo "Running run_hook.py..."
             MAIN_ADDR=$(nm $HW|grep 'T main' | awk '{print "0x"$1}')
-            python ./run_hook.py $HW $MAIN_ADDR
+            coverage run ./run_hook.py $HW $MAIN_ADDR
             if [ $? -ne 0 ]; then
                 return 1
             fi
@@ -105,7 +105,7 @@ jobs:
             gcc -static -g src/state_explore.c -o state_explore
             SE_ADDR=0x$(objdump -S state_explore | grep -A 1 'value == 0x41' |
                        tail -n 1 | sed 's|^\s*||g' | cut -f1 -d:)
-            python ./state_control.py state_explore $SE_ADDR
+            coverage run ./state_control.py state_explore $SE_ADDR
             if [ $? -ne 0 ]; then
                 return 1
             fi
@@ -194,6 +194,7 @@ jobs:
             RESULT=$?
             echo Ran example scripts
             popd
+            coverage xml
             return $RESULT
         }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,4 +242,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         yml: ./codecov.yml
-        fail_ci_if_error: true
+# Disabled this line because Codecov has been extra flaky lately, and having to re-run the entire
+# test suite until every coverage upload step succeeds is more of a hassle than it's worth. 
+#        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
             echo Ran example scripts
             coverage xml
             popd
-            cp examples/linux/coverage.xml .
+            cp examples/script/coverage.xml .
             return $RESULT
         }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,3 +240,4 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         yml: ./codecov.yml
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,9 @@ jobs:
             launch_examples
             RESULT=$?
             echo Ran example scripts
-            popd
             coverage xml
+            popd
+            cp examples/linux/coverage.xml .
             return $RESULT
         }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,6 @@
 comment: false
+
+codecov:
+  notify:
+    after_n_builds: 8
+    wait_for_ci: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,7 @@ comment: false
 
 codecov:
   notify:
+    # We have 8 test steps that produce coverage data.
+    # If we add or remove any, we need to change this number.
     after_n_builds: 8
     wait_for_ci: yes


### PR DESCRIPTION
This should prevent the red 'X' from appearing as soon as the first job finishes.