### PR TITLE
Blacken a few more files

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -347,9 +347,16 @@ class ManticoreEVM(ManticoreBase):
                 source_code, contract_name, libraries, crytic_compile_args
             )
 
-        name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi = (
-            compilation_result
-        )
+        (
+            name,
+            source_code,
+            bytecode,
+            runtime,
+            srcmap,
+            srcmap_runtime,
+            hashes,
+            abi,
+        ) = compilation_result
         warnings = ""
 
         return (name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi, warnings)
@@ -910,9 +917,12 @@ class ManticoreEVM(ManticoreBase):
                 address = world.new_address(caller)
 
             # Migrate any expression to state specific constraint set
-            caller_migrated, address_migrated, value_migrated, data_migrated = self._migrate_tx_expressions(
-                state, caller, address, value, data
-            )
+            (
+                caller_migrated,
+                address_migrated,
+                value_migrated,
+                data_migrated,
+            ) = self._migrate_tx_expressions(state, caller, address, value, data)
 
             # Different states may CREATE a different set of accounts. Accounts
             # that were crated by a human have the same address in all states.

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -246,7 +246,7 @@ class Transaction:
                 "Return_data: 0x{} ({}) {}\n".format(
                     binascii.hexlify(return_data).decode(),
                     printable_bytes(return_data),
-                    flagged(issymbolic(self.return_data))
+                    flagged(issymbolic(self.return_data)),
                 )
             )
 
@@ -733,8 +733,8 @@ class EVM(Eventful):
         )
         self.address = address
         self.caller = (
-            caller
-        )  # address of the account that is directly responsible for this execution
+            caller  # address of the account that is directly responsible for this execution
+        )
         self.data = data
         self.value = value
         self._bytecode = bytecode
@@ -1265,9 +1265,14 @@ class EVM(Eventful):
 
             def setstate(state, value):
                 current_vm = state.platform.current_vm
-                _pc, _old_gas, _instruction, _arguments, _fee, _allocated = (
-                    current_vm._checkpoint_data
-                )
+                (
+                    _pc,
+                    _old_gas,
+                    _instruction,
+                    _arguments,
+                    _fee,
+                    _allocated,
+                ) = current_vm._checkpoint_data
                 current_vm._checkpoint_data = (
                     _pc,
                     _old_gas,
@@ -1288,9 +1293,14 @@ class EVM(Eventful):
 
             def setstate(state, value):
                 current_vm = state.platform.current_vm
-                _pc, _old_gas, _instruction, _arguments, _fee, _allocated = (
-                    current_vm._checkpoint_data
-                )
+                (
+                    _pc,
+                    _old_gas,
+                    _instruction,
+                    _arguments,
+                    _fee,
+                    _allocated,
+                ) = current_vm._checkpoint_data
                 new_arguments = []
                 for old_arg in _arguments:
                     if len(new_arguments) == pos:

--- a/manticore/utils/helpers.py
+++ b/manticore/utils/helpers.py
@@ -33,9 +33,7 @@ def interval_intersection(min1, max1, min2, max2):
 
 
 def printable_bytes(bytes: bytes):
-    return "".join(
-        [c for c in map(chr, bytes) if c in string.printable]
-    )
+    return "".join([c for c in map(chr, bytes) if c in string.printable])
 
 
 class CacheDict(OrderedDict):

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -472,7 +472,7 @@ class EthTests(unittest.TestCase):
         self.assertEqual(str(e.exception), expected_exception)
 
     def test_solidity_create_contract_with_payable_constructor_and_balance_owner_insufficient_founds(
-        self
+        self,
     ):
         source_code = "contract A { constructor() public payable {} }"
         owner = self.mevm.create_account(balance=1)


### PR DESCRIPTION
Some of these seem to have gotten passed over by our CI, which only checks files that have been modified by a given PR. Not sure how this happened, but `black` on my machine tries to reformat them every time I push code. Perhaps GH Actions will disagree?