### PR TITLE
Add set_verbosity to the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Manticore is a symbolic execution tool for analysis of binaries and smart contra
    wasm
    plugins
    gotchas
+   utilities
 
 
 Indices and tables

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1,0 +1,7 @@
+Utilities
+---------
+
+Logging
+^^^^^^^
+
+.. autofunction:: manticore.utils.log.set_verbosity

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -149,6 +149,7 @@ def get_verbosity(logger_name: str) -> int:
 
 
 def set_verbosity(setting: int) -> None:
+    """Set the global verbosity (0-5)."""
     global manticore_verbosity
     manticore_verbosity = min(max(setting, 0), len(get_levels()) - 1)
     for logger_name in all_loggers:


### PR DESCRIPTION
Setting `verbosity` on `ManticoreBase` appears deprecated, but the preferred method is not yet documented.