### PR TITLE
Revert default gas limit

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -728,7 +728,7 @@ class ManticoreEVM(ManticoreBase):
             if new_address not in all_addresses:
                 return new_address
 
-    def transaction(self, caller, address, value, data, gas=21000, price=1):
+    def transaction(self, caller, address, value, data, gas=None, price=1):
         """ Issue a symbolic transaction in all running states
 
             :param caller: the address of the account sending the transaction


### PR DESCRIPTION
Reverts one of the [changes](https://github.com/trailofbits/manticore/pull/1652/files#diff-e4836efb704ed46c30e5cfb02496a419R725) from #1652 to fix the sporadically-failing `test_integer_overflow_multitx_onefunc_feasible` test in `ethereum_bench`