### PR TITLE
Disable "tactic.solve_eqs.context_solve"

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -164,6 +164,11 @@ class Z3Solver(Solver):
             "(set-logic QF_AUFBV)",
             # The declarations and definitions will be scoped
             "(set-option :global-decls false)",
+            # sam.moelius: Option "tactic.solve_eqs.context_solve" was turned on by this commit in z3:
+            #   https://github.com/Z3Prover/z3/commit/3e53b6f2dbbd09380cd11706cabbc7e14b0cc6a2
+            # Turning it off greatly improves Manticore's performance on test_integer_overflow_storageinvariant
+            # in test_consensys_benchmark.py.
+            "(set-option :tactic.solve_eqs.context_solve false)",
         ]
 
         self._get_value_fmt = (RE_GET_EXPR_VALUE_FMT, 16)


### PR DESCRIPTION
Option "tactic.solve_eqs.context_solve" was turned on by this commit in z3:
https://github.com/Z3Prover/z3/commit/3e53b6f2dbbd09380cd11706cabbc7e14b0cc6a2
Turning it off greatly improves Manticore's performance on [`test_integer_overflow_storageinvariant`](https://github.com/trailofbits/manticore/blob/96bfc80ea0545f67e9c335bb194f297051d51cdb/tests/ethereum_bench/test_consensys_benchmark.py#L106). Sample timings follow.

On commit [`96bfc80ea0545f67e9c335bb194f297051d51cdb`](https://github.com/trailofbits/manticore/commit/96bfc80ea0545f67e9c335bb194f297051d51cdb):
```
time pytest test_consensys_benchmark.py::EthBenchmark::test_integer_overflow_storageinvariant
...
real	11m45.771s
user	9m33.436s
sys	7m24.337s
```
After this change:
```
time pytest test_consensys_benchmark.py::EthBenchmark::test_integer_overflow_storageinvariant
...
real	2m49.696s
user	4m36.160s
sys	3m14.856s
```