### PR TITLE
Move truffle to its own CI type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        type: ["ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
+        type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.6
@@ -206,11 +206,12 @@ jobs:
                 echo "Running only the tests from 'tests/$TEST_TYPE' directory"
                 run_tests_from_dir $TEST_TYPE
                 RV=$?
-
+                ;;
+            ethereum_truffle)
                 echo "Running truffle test"
                 install_truffle
                 run_truffle_tests
-                RV=$(($RV + $?))
+                RV=$?
                 ;;
             wasm)
                 make_wasm_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
 
         run_tests_from_dir() {
             DIR=$1
+            echo "Running only the tests from 'tests/$DIR' directory"
             pytest --durations=100 --cov=manticore -n auto "tests/$DIR"
             coverage xml
         }
@@ -203,31 +204,24 @@ jobs:
         case $TEST_TYPE in
             ethereum_vm)
                 make_vmtests
-                echo "Running only the tests from 'tests/$TEST_TYPE' directory"
                 run_tests_from_dir $TEST_TYPE
-                RV=$?
                 ;;
             ethereum_truffle)
                 echo "Running truffle test"
                 install_truffle
                 run_truffle_tests
-                RV=$?
                 ;;
             wasm)
                 make_wasm_tests
-                echo "Running only the tests from 'tests/$TEST_TYPE' directory"
                 run_tests_from_dir $TEST_TYPE
-                RV=$?
                 ;;
             wasm_sym)
-                make_wasm_sym_tests ;&
+                make_wasm_sym_tests ;&  # Fallthrough
             native)                 ;&  # Fallthrough
             ethereum)               ;&  # Fallthrough
             ethereum_bench)         ;&  # Fallthrough
             other)
-                echo "Running only the tests from 'tests/$TEST_TYPE' directory"
                 run_tests_from_dir $TEST_TYPE
-                RV=$?
                 ;;
             examples)
                 run_examples


### PR DESCRIPTION
This simply moves the ethereum truffle related smoke test to its own CI entity.