### PR TITLE
Reduce concrete hash log messages

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1180,12 +1180,13 @@ class ManticoreEVM(ManticoreBase):
         if value is not None:
             with self.locked_context("ethereum", dict) as ethereum_context:
                 global_known_pairs = ethereum_context.get(f"symbolic_func_conc_{name}", set())
-                global_known_pairs.add((data, value))
-                ethereum_context[f"symbolic_func_conc_{name}"] = global_known_pairs
+                if (data, value) not in global_known_pairs:
+                    global_known_pairs.add((data, value))
+                    ethereum_context[f"symbolic_func_conc_{name}"] = global_known_pairs
+                    logger.info(f"Found a concrete {name} {data} -> {value}")
             concrete_pairs = state.context.get(f"symbolic_func_conc_{name}", set())
             concrete_pairs.add((data, value))
             state.context[f"symbolic_func_conc_{name}"] = concrete_pairs
-            logger.info(f"Found a concrete {name} {data} -> {value}")
         else:
             # we can not calculate the concrete value lets use a fresh symbol
             with self.locked_context("ethereum", dict) as ethereum_context:


### PR DESCRIPTION
Manticore produces many log messages of the following form, and many of them are redundant:
```
m.e.manticore:INFO: Found a concrete globalsha3 ... -> ...
```
This PR makes it so that only one log message is generated for each new find.