### PR TITLE
Add hashing to constraintSets

### DIFF
--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 consts = config.get_group("smt")
 consts.add(
-    "related_constraints", default=True, description="Try slicing the current path constraint to contain only related items"
+    "related_constraints", default=False, description="Try slicing the current path constraint to contain only related items"
 )
 
 
@@ -63,7 +63,7 @@ class ConstraintSet:
         )
 
     def __hash__(self):
-        return hash((self._parent, tuple(self._constraints)))
+        return hash(self.constraints)
 
     def __enter__(self) -> "ConstraintSet":
         assert self._child is None

--- a/manticore/core/smtlib/constraints.py
+++ b/manticore/core/smtlib/constraints.py
@@ -27,6 +27,7 @@ consts.add(
     "related_constraints", default=True, description="Try slicing the current path constraint to contain only related items"
 )
 
+
 class ConstraintException(SmtlibError):
     """
     Constraint exception
@@ -60,6 +61,7 @@ class ConstraintSet:
                 "_declarations": self._declarations,
             },
         )
+
     def __hash__(self):
         return hash((self._parent, tuple(self._constraints)))
 
@@ -104,7 +106,6 @@ class ConstraintSet:
             else:
                 return
         self._constraints.append(constraint)
-
 
     def _get_sid(self) -> int:
         """ Returns a unique id. """

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -18,6 +18,7 @@ import threading
 import collections
 import shlex
 import time
+from functools import lru_cache
 from typing import Dict, Tuple
 from subprocess import PIPE, Popen
 import re
@@ -421,6 +422,7 @@ class Z3Solver(Solver):
         """Recall the last pushed constraint store and state."""
         self._send("(pop 1)")
 
+    @lru_cache(maxsize=32)
     def can_be_true(self, constraints: ConstraintSet, expression: Union[bool, Bool] = True) -> bool:
         """Check if two potentially symbolic values can be equal"""
         if isinstance(expression, bool):
@@ -438,6 +440,7 @@ class Z3Solver(Solver):
             return self._is_sat()
 
     # get-all-values min max minmax
+    @lru_cache(maxsize=32)
     def get_all_values(self, constraints, expression, maxcnt=None, silent=False):
         """Returns a list with all the possible values for the symbol x"""
         if not isinstance(expression, Expression):

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -871,10 +871,10 @@ class ManticoreEVM(ManticoreBase):
             caller = int(caller)
         # Defaults, call data is empty
         if data is None:
-            data = bytearray(b"")
-        if isinstance(data, (str, bytes)):
-            data = bytearray(data)
-        if not isinstance(data, (bytearray, Array)):
+            data = b""
+        if isinstance(data, str):
+            data = bytes(data)
+        if not isinstance(data, (bytes, Array)):
             raise TypeError("code bad type")
 
         # Check types

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2416,7 +2416,7 @@ class EVMWorld(Platform):
         )
         if sort == "CREATE":
             bytecode = bytecode_or_data
-            data = bytearray()
+            data = bytes()
         else:
             bytecode = self.get_code(address)
             data = bytecode_or_data
@@ -2790,7 +2790,6 @@ class EVMWorld(Platform):
         return new_address
 
     def execute(self):
-
         self._process_pending_transaction()
         if self.current_vm is None:
             raise TerminateState("Trying to execute an empty transaction", testcase=False)


### PR DESCRIPTION
Add __hash__ capabilities to ConstraintSet so we can use simple lru caching.
This improves commons case of re-doing the exact same query twice.
-baby steps towards query cache.