### PR TITLE
Updated proc/self error message to show which proc/self filename is trying to be read

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1850,7 +1850,9 @@ class Linux(Platform):
             elif filename == "/proc/self/maps":
                 return ProcSelfMaps(flags, self)
             else:
-                raise EnvironmentError("/proc/self is largely unsupported")
+                raise EnvironmentError(
+                    f"Trying to read from {filename}.\nThe /proc/self filesystem is largely unsupported."
+                )
 
         if os.path.isdir(filename):
             return Directory(filename, flags)


### PR DESCRIPTION
Error message should now read:

manticore.platforms.linux.EnvironmentError: Trying to read from /proc/self/\<filename\>.
The /proc/self filesystem is largely unsupported.