### PR TITLE
Remove duplicated entries in issue config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bug Report
-    url: https://github.com/trailofbits/manticore/issues/new?labels=bug&template=bug_report.md
-    about: Report a bug in Manticore
-  - name: Feature Request
-    url: https://github.com/trailofbits/manticore/issues/new?labels=idea&template=feature_request.md
-    about: Request a new feature in Manticore
   - name: Ask a Question
     url: https://github.com/trailofbits/manticore/discussions/new
     about: Ask for help or clarification from the developers


### PR DESCRIPTION
Github automatically parses the issue templates and adds them to the config file, so they don't actually need to be included here.