### PR TITLE
Inline Sync Manager to Locked Context

### DIFF
--- a/tests/other/test_locking.py
+++ b/tests/other/test_locking.py
@@ -1,0 +1,20 @@
+import unittest
+from manticore.native import Manticore
+from pathlib import Path
+
+
+ms_file = str(
+    Path(__file__).parent.parent.parent.joinpath("examples", "linux", "binaries", "multiple-styles")
+)
+
+
+class TestResume(unittest.TestCase):
+    def test_resume(self):
+        m = Manticore(ms_file, stdin_size=17)
+
+        with m.locked_context() as ctx:
+            self.assertNotIn("unlocked", str(m._lock))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It looks like the `@sync` and `@contextmanager` decorators don't play nicely together. This PR is a check to see whether replacing the sync decorator with direct access to the lock breaks any tests. 