### PR TITLE
In Symbolic Files, do wildcard comparison in bytes

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -400,7 +400,7 @@ class SymbolicFile(File):
         path: str = "sfile",
         flags: int = os.O_RDWR,
         max_size: int = 100,
-        wildcard: str = "+",
+        wildcard: bytes = b"+",
     ):
         """
         Builds a symbolic file
@@ -426,7 +426,7 @@ class SymbolicFile(File):
 
         symbols_cnt = 0
         for i in range(size):
-            if data[i] != wildcard:
+            if data[i] != wildcard[0]:
                 self.array[i] = data[i]
             else:
                 symbols_cnt += 1


### PR DESCRIPTION
This PR changes the wildcard character in `SymbolicFile` to a bytes-like object from a string.

Background:

Given the program in `main.c`: 

```c
#include <stdlib.h>
#include <stdio.h>

int main(int argc, char **argv)
{
    FILE *f = fopen(argv[1], "r");
    char x  = fgetc(f);
    if (x == 'x')
        exit(1);
    exit(0);
}
```

If I run 

```
$ gcc main.c -o main
$ echo '+' > f
$ manticore --file f ./main f
```

I get back one testcase in the resulting workspace. This is because in `SymbolicFile`, the wildcard character (`+`) is a `str` while the data read from `f` is `bytes` -- hence the `+` written to `f` above is never actually interpreted as a wildcard indicating that the contents are symbolic.