### PR TITLE
DetectUninitializedMemory bug fixes

### DIFF
--- a/manticore/ethereum/detectors.py
+++ b/manticore/ethereum/detectors.py
@@ -667,8 +667,8 @@ class DetectUninitializedMemory(Detector):
         current_contract = state.platform.current_vm.address
         for known_contract, known_offset in initialized_memory:
             if current_contract == known_contract:
-                for offset_i in range(offset, offset + size):
-                    cbu = Operators.AND(cbu, offset_i != known_offset)
+                for i in range(0, size):
+                    cbu = Operators.AND(cbu, offset + i != known_offset)
         if state.can_be_true(cbu):
             self.add_finding_here(
                 state,
@@ -680,9 +680,9 @@ class DetectUninitializedMemory(Detector):
         current_contract = state.platform.current_vm.address
 
         # concrete or symbolic write
-        for offset_i in range(offset, offset + size):
+        for i in range(0, size):
             state.context.setdefault("{:s}.initialized_memory".format(self.name), set()).add(
-                (current_contract, offset)
+                (current_contract, offset + i)
             )
 
 


### PR DESCRIPTION
`did_evm_write_memory_callback` did not use `offset_i`.

For both `did_evm_read_memory_callback` and `did_evm_write_memory_callback`, the old code would complain when `offset` was symbolic (because `range`'s arguments were symbolic).