### PR TITLE
Specialized iterative serialization for Array

### DIFF
--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -987,6 +987,7 @@ class ArrayStore(ArrayOperation):
         index, value = state["_items"][0]
         self._operands = (array, index, value)
 
+
 class ArraySlice(ArrayOperation):
     def __init__(
         self, array: Union["Array", "ArrayProxy"], offset: int, size: int, *args, **kwargs
@@ -1154,7 +1155,6 @@ class ArrayProxy(Array):
         self._name = state["name"]
         self._concrete_cache = state["_concrete_cache"]
         self._written = None
-
 
     def __copy__(self):
         return ArrayProxy(self)

--- a/manticore/core/smtlib/expression.py
+++ b/manticore/core/smtlib/expression.py
@@ -966,6 +966,26 @@ class ArrayStore(ArrayOperation):
     def value(self):
         return self.operands[2]
 
+    def __getstate__(self):
+        state = {}
+        array = self
+        items = []
+        while isinstance(array, ArrayStore):
+            items.append((array.index, array.value))
+            array = array.array
+        state["_array"] = array
+        state["_items"] = items
+        return state
+
+    def __setstate__(self, state):
+        array = state["_array"]
+        for index, value in reversed(state["_items"][0:]):
+            array = array.store(index, value)
+        self._index_bits = array.index_bits
+        self._index_max = array.index_max
+        self._value_bits = array.value_bits
+        index, value = state["_items"][0]
+        self._operands = (array, index, value)
 
 class ArraySlice(ArrayOperation):
     def __init__(
@@ -1126,7 +1146,6 @@ class ArrayProxy(Array):
         state["_array"] = self._array
         state["name"] = self.name
         state["_concrete_cache"] = self._concrete_cache
-        state["_written"] = self._written
         return state
 
     def __setstate__(self, state):
@@ -1134,7 +1153,8 @@ class ArrayProxy(Array):
         self._array = state["_array"]
         self._name = state["name"]
         self._concrete_cache = state["_concrete_cache"]
-        self._written = state["_written"]
+        self._written = None
+
 
     def __copy__(self):
         return ArrayProxy(self)


### PR DESCRIPTION
This PR improves performance on serializing large ArrayStores. Pickling large ArrayStores would previously result in very deep recursion, which sometimes hit the python stack limit and caused a crash. Now, ArrayStores will iterate over their contents so that we instead pickle a flattened version. 