### PR TITLE
Update EVM usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ contract Adder {
 """
 m = ManticoreEVM()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=10000000)
 contract_account = m.solidity_create_contract(contract_src,
                                               owner=user_account,
                                               balance=0)


### PR DESCRIPTION
Addresses #1771 (at least for the example in the readme). Increases the balance of the created account so the user has enough eth to send the contract creation transaction with the default transaction gas.

It's possible it would be more helpful to specify the gas for `solidity_create_contract` instead, but this keeps the example as simple as possible.