### PR TITLE
Capture return values in run.sh

### DIFF
--- a/manticore/ethereum/verifier.py
+++ b/manticore/ethereum/verifier.py
@@ -411,7 +411,7 @@ def main():
     )
     eth_flags.add_argument(
         "--propre",
-        default == r"crytic_.*",
+        default=r"crytic_.*",
         type=str,
         help="A regular expression for selecting properties",
     )

--- a/manticore/ethereum/verifier.py
+++ b/manticore/ethereum/verifier.py
@@ -229,7 +229,7 @@ def manticore_verifier(
                 break
             current_coverage = new_coverage
 
-            # check if timeout was requested
+            # Make sure we didn't time out before starting first transaction
             if m.is_killed():
                 print("Cancelled or timeout.")
                 break
@@ -256,6 +256,11 @@ def manticore_verifier(
                 data=symbolic_data,
             )
 
+            # check if timeout was requested during the previous transaction
+            if m.is_killed():
+                print("Cancelled or timeout.")
+                break
+
             m.clear_terminated_states()  # no interest in reverted states
             m.take_snapshot()  # make a copy of all ready states
             print(
@@ -263,6 +268,11 @@ def manticore_verifier(
                 f"RT Coverage: {m.global_coverage(contract_account):3.2f}%, "
                 f"Failing properties: {broken_properties}/{len(properties)}"
             )
+
+            # check if timeout was requested while we were taking the snapshot
+            if m.is_killed():
+                print("Cancelled or timeout.")
+                break
 
             # And now explore all properties (and only the properties)
             filter_no_crytic.disable()  # Allow crytic_porperties
@@ -315,6 +325,8 @@ def manticore_verifier(
 
             m.clear_terminated_states()  # no interest in reverted states for now!
             m.goto_snapshot()
+        else:
+            print("Cancelled or timeout.")
 
     m.clear_terminated_states()
     m.clear_ready_states()

--- a/manticore/ethereum/verifier.py
+++ b/manticore/ethereum/verifier.py
@@ -200,7 +200,7 @@ def manticore_verifier(
         f"Failing properties: 0/{len(properties)}"
     )
     with m.kill_timeout(timeout=timeout):
-        while True:
+        while not m.is_killed():
             # check if we found a way to break more than MAXFAIL properties
             broken_properties = sum(int(len(x) != 0) for x in properties.values())
             if broken_properties >= MAXFAIL:
@@ -410,7 +410,10 @@ def main():
         "--psender", type=str, help="(optional) address from where the property is tested"
     )
     eth_flags.add_argument(
-        "--propre", type=str, help="A regular expression for selecting properties"
+        "--propre",
+        default == r"crytic_.*",
+        type=str,
+        help="A regular expression for selecting properties",
     )
     eth_flags.add_argument(
         "--timeout", default=240, type=int, help="Exploration timeout in seconds"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -116,7 +116,9 @@ run_tests_from_dir() {
     COVERAGE_RCFILE=$GITHUB_WORKSPACE/.coveragerc
     echo "Running only the tests from 'tests/$DIR' directory"
     pytest --durations=100 --cov=manticore --cov-config=$GITHUB_WORKSPACE/.coveragerc -n auto "tests/$DIR"
+    RESULT=$?
     coverage xml
+    return $RESULT
 }
 
 run_examples() {

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -78,7 +78,7 @@ class EthVerifierIntegrationTest(unittest.TestCase):
             filename = os.path.join(THIS_DIR, "contracts/prop_verifier.sol")
             f = io.StringIO()
             with contextlib.redirect_stdout(f):
-                verifier.manticore_verifier(filename, "TestToken", timeout=240)
+                verifier.manticore_verifier(filename, "TestToken")
             output = f.getvalue()
             self.assertIsNotNone(
                 re.compile(

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -72,14 +72,13 @@ class EthDetectorsIntegrationTest(unittest.TestCase):
 class EthVerifierIntegrationTest(unittest.TestCase):
     def test_propverif(self):
         smtcfg = config.get_group("smt")
-        smtcfg.solver = smtcfg.solver.yices
         with smtcfg.temp_vals():
             smtcfg.solver = smtcfg.solver.yices
 
             filename = os.path.join(THIS_DIR, "contracts/prop_verifier.sol")
             f = io.StringIO()
             with contextlib.redirect_stdout(f):
-                verifier.manticore_verifier(filename, "TestToken")
+                verifier.manticore_verifier(filename, "TestToken", timeout=240)
             output = f.getvalue()
             self.assertIsNotNone(
                 re.compile(


### PR DESCRIPTION
Switching from YAML to a script means that individual steps can fail, but the tests will still pass if the return value of the entire script is okay.