### PR TITLE
codecov: Remove outdated 'yml' entry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-        yml: ./codecov.yml
 # Disabled this line because Codecov has been extra flaky lately, and having to re-run the entire
 # test suite until every coverage upload step succeeds is more of a hassle than it's worth.
 #        fail_ci_if_error: true
@@ -95,5 +94,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.2.2
       with:
         password: ${{ secrets.PYPI_UPLOAD }}
-
-


### PR DESCRIPTION
From these commits
https://github.com/codecov/codecov-action/commit/ebea5cacdf7d0b843f66bcb1ae27d8f27b758e81
https://github.com/codecov/codecov-action/commit/49c86d6a5fd072b05c31a42baa67b8fb2e87c8f7