### PR TITLE
Change the default to threading

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -62,7 +62,7 @@ consts.add(
 )
 consts.add("procs", default=10, description="Number of parallel processes to spawn")
 
-proc_type = MProcessingType.multiprocessing
+proc_type = MProcessingType.threading
 if sys.platform != "linux":
     logger.warning("Manticore is only supported on Linux. Proceed at your own risk!")
     proc_type = MProcessingType.threading


### PR DESCRIPTION
Mprocessing uses a manager process to share data. It adds to much overhead in the common case.