### PR TITLE
Fix BitVec with symbolic offset and fix TranslatorSmtlib.unique thread safety

### DIFF
--- a/manticore/core/smtlib/operators.py
+++ b/manticore/core/smtlib/operators.py
@@ -124,7 +124,7 @@ def ULE(a, b):
 
 
 def EXTRACT(x, offset, size):
-    if isinstance(x, BitVec):
+    if isinstance(x, BitVec) and not isinstance(offset, BitVec):
         if offset == 0 and size == x.size:
             return x
         return BitVecExtract(x, offset, size)

--- a/manticore/core/smtlib/operators.py
+++ b/manticore/core/smtlib/operators.py
@@ -124,7 +124,9 @@ def ULE(a, b):
 
 
 def EXTRACT(x, offset, size):
-    if isinstance(x, BitVec) and not isinstance(offset, BitVec):
+    if isinstance(x, BitVec) and isinstance(offset, BitVec):
+        return BitVecExtract(x >> offset, 0, size)
+    elif isinstance(x, BitVec):
         if offset == 0 and size == x.size:
             return x
         return BitVecExtract(x, offset, size)

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -877,7 +877,7 @@ class TranslatorSmtlib(Translator):
             return self._bindings_cache[smtlib]
 
         with TranslatorSmtlib.unique_lock:
-          TranslatorSmtlib.unique += 1
+            TranslatorSmtlib.unique += 1
         name = "a_%d" % TranslatorSmtlib.unique
 
         self._bindings.append((name, expression, smtlib))

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -6,6 +6,7 @@ import copy
 import logging
 import operator
 import math
+import threading
 from decimal import Decimal
 
 logger = logging.getLogger(__name__)
@@ -859,6 +860,7 @@ class TranslatorSmtlib(Translator):
     """
 
     unique = 0
+    unique_lock = threading.Lock()
 
     def __init__(self, use_bindings=False, *args, **kw):
         assert "bindings" not in kw
@@ -874,7 +876,8 @@ class TranslatorSmtlib(Translator):
         if smtlib in self._bindings_cache:
             return self._bindings_cache[smtlib]
 
-        TranslatorSmtlib.unique += 1
+        with TranslatorSmtlib.unique_lock:
+          TranslatorSmtlib.unique += 1
         name = "a_%d" % TranslatorSmtlib.unique
 
         self._bindings.append((name, expression, smtlib))


### PR DESCRIPTION
The EVM BYTE opcode with a symbolic offset argument needs the second handler or it asserts (first obviously on the offset == 0)

And I was seeing name collisions on the SMT vars, first I disabled threading to fix, but then added a lock around the unique variable.