### PR TITLE
Improve crytic-compile support

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -336,7 +336,10 @@ class ManticoreEVM(ManticoreBase):
         if isinstance(source_code, io.IOBase):
             source_code = source_code.name
 
-        if isinstance(source_code, str) and not is_supported(source_code):
+        if (isinstance(source_code, str) and
+                not is_supported(source_code) and
+                # Until https://github.com/crytic/crytic-compile/issues/103 is implemented
+                "ignore_compile" not in crytic_compile_args):
             with tempfile.NamedTemporaryFile("w+", suffix=".sol") as temp:
                 temp.write(source_code)
                 temp.flush()

--- a/manticore/ethereum/verifier.py
+++ b/manticore/ethereum/verifier.py
@@ -500,4 +500,5 @@ def main():
         psender=psender,
         timeout=args.timeout,
         propre=args.propre,
+        compile_args=vars(parsed)
     )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "prettytable",
         "ply",
         "rlp",
-        "crytic-compile>=0.1.1",
+        "crytic-compile>=0.1.8",
         "wasm",
         "dataclasses; python_version < '3.7'",
         "pyevmasm>=0.2.3",


### PR DESCRIPTION
- crytic-compile: use latest release
- manticore-verifier: enable crytic-compile cli flags

The crytic-compile version currently used by Manticore is out of date.

Additionally, `manticore-verifier` did not use the crytic-compile cli flags

To test this:
```
$ npx truffle unbox metacoin
```
Update `contracts/MetaCoin.sol` and add
```solidity
    function crytic_test() public returns(bool){
        return balances[msg.sender] > 1;
    }
```
Then
```
$ manticore-verifier . --contract MetaCoin
$ rm truffle-config.js 
$ manticore-verifier . --contract MetaCoin --compile-force-framework Truffle --ignore-compile
```

The last command re-run Manticore, but fails without this PR