### PR TITLE
New exploration stopping condition

### DIFF
--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 6):
 from .utils import config, log
 from .utils.log import set_verbosity
 from .core.smtlib import issymbolic, istainted
-from .ethereum.manticore import ManticoreEVM
+from .ethereum.manticore import ManticoreEVM, TermCondCovType
 from .core.plugin import Plugin
 from .exceptions import ManticoreError
 
@@ -17,4 +17,5 @@ __all__ = [
     ManticoreEVM.__name__,
     set_verbosity.__name__,
     ManticoreError.__name__,
+    TermCondCovType.__name__
 ]

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -154,7 +154,6 @@ def parse_arguments() -> argparse.Namespace:
         help="Maximum number of symbolic transactions to run (positive integer)",
     )
 
-
     eth_flags.add_argument(
         "--txnoether", action="store_true", help="Do not attempt to send ether to contract"
     )
@@ -206,7 +205,9 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     eth_flags.add_argument(
-        "--limit-loops", action="store_true", help="Limit loops depth",
+        "--limit-loops",
+        action="store_true",
+        help="Limit loops depth",
     )
 
     eth_flags.add_argument(

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -154,9 +154,6 @@ def parse_arguments() -> argparse.Namespace:
         help="Maximum number of symbolic transactions to run (positive integer)",
     )
 
-    eth_flags.add_argument(
-        "--txnocoverage", action="store_true", help="Do not use coverage as stopping criteria"
-    )
 
     eth_flags.add_argument(
         "--txnoether", action="store_true", help="Do not attempt to send ether to contract"

--- a/manticore/ethereum/__init__.py
+++ b/manticore/ethereum/__init__.py
@@ -1,6 +1,6 @@
 # Exports (for `from manticore.ethereum import ...`)
 from .abi import ABI
-from .manticore import ManticoreEVM, config
+from .manticore import ManticoreEVM, config, TermCondCovType
 from .state import State
 from .detectors import (
     Detector,

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -41,9 +41,11 @@ consts.add(
 )
 
 from enum import Enum
+
+
 class TermCondCovType(Enum):
     """Used as configuration constant for choosing the coverage based termination
-     condition"""
+    condition"""
 
     no = "no"
     local = "local"
@@ -56,9 +58,9 @@ class TermCondCovType(Enum):
     def from_string(cls, name):
         return cls.__members__[name]
 
+
 consts.add(
-    "txcoverage", default=TermCondCovType.local,
-    description="Set coverage stopping criteria"
+    "txcoverage", default=TermCondCovType.local, description="Set coverage stopping criteria"
 )
 
 

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -42,28 +42,6 @@ consts.add(
 
 from enum import Enum
 
-
-class TermCondCovType(Enum):
-    """Used as configuration constant for choosing the coverage based termination
-    condition"""
-
-    no = "no"
-    local = "local"
-    wide = "wide"
-
-    def title(self):
-        return self._name_.title()
-
-    @classmethod
-    def from_string(cls, name):
-        return cls.__members__[name]
-
-
-consts.add(
-    "txcoverage", default=TermCondCovType.local, description="Set coverage stopping criteria"
-)
-
-
 def get_detectors_classes():
     return [
         DetectInvalid,

--- a/manticore/ethereum/cli.py
+++ b/manticore/ethereum/cli.py
@@ -40,6 +40,27 @@ consts.add(
     description="Simply avoid exploring basic blocks that end in a REVERT",
 )
 
+from enum import Enum
+class TermCondCovType(Enum):
+    """Used as configuration constant for choosing the coverage based termination
+     condition"""
+
+    no = "no"
+    local = "local"
+    wide = "wide"
+
+    def title(self):
+        return self._name_.title()
+
+    @classmethod
+    def from_string(cls, name):
+        return cls.__members__[name]
+
+consts.add(
+    "txcoverage", default=TermCondCovType.local,
+    description="Set coverage stopping criteria"
+)
+
 
 def get_detectors_classes():
     return [
@@ -134,7 +155,7 @@ def ethereum_main(args, logger):
                 args.argv[0],
                 contract_name=args.contract,
                 tx_limit=args.txlimit,
-                tx_use_coverage=not args.txnocoverage,
+                tx_use_coverage=consts.txcoverage,
                 tx_send_ether=not args.txnoether,
                 tx_account=args.txaccount,
                 tx_preconstrain=args.txpreconstrain,

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -111,43 +111,43 @@ def calculate_coverage(runtime_bytecode, seen):
 
 
 class ManticoreEVM(ManticoreBase):
-    """ Manticore EVM manager
+    """Manticore EVM manager
 
-        Usage Ex::
+    Usage Ex::
 
-            from manticore.ethereum import ManticoreEVM, ABI
-            m = ManticoreEVM()
-            #And now make the contract account to analyze
-            source_code = '''
-                pragma solidity ^0.4.15;
-                contract AnInt {
-                    uint private i=0;
-                    function set(uint value){
-                        i=value
-                    }
+        from manticore.ethereum import ManticoreEVM, ABI
+        m = ManticoreEVM()
+        #And now make the contract account to analyze
+        source_code = '''
+            pragma solidity ^0.4.15;
+            contract AnInt {
+                uint private i=0;
+                function set(uint value){
+                    i=value
                 }
-            '''
-            #Initialize user and contracts
-            user_account = m.create_account(balance=1000)
-            contract_account = m.solidity_create_contract(source_code, owner=user_account, balance=0)
-            contract_account.set(12345, value=100)
+            }
+        '''
+        #Initialize user and contracts
+        user_account = m.create_account(balance=1000)
+        contract_account = m.solidity_create_contract(source_code, owner=user_account, balance=0)
+        contract_account.set(12345, value=100)
 
-            m.finalize()
+        m.finalize()
     """
 
     def make_symbolic_buffer(self, size, name=None, avoid_collisions=False):
-        """ Creates a symbolic buffer of size bytes to be used in transactions.
-            You can operate on it normally and add constraints to manticore.constraints
-            via manticore.constrain(constraint_expression)
+        """Creates a symbolic buffer of size bytes to be used in transactions.
+        You can operate on it normally and add constraints to manticore.constraints
+        via manticore.constrain(constraint_expression)
 
-            Example use::
+        Example use::
 
-                symbolic_data = m.make_symbolic_buffer(320)
-                m.constrain(symbolic_data[0] == 0x65)
-                m.transaction(caller=attacker_account,
-                                address=contract_account,
-                                data=symbolic_data,
-                                value=100000 )
+            symbolic_data = m.make_symbolic_buffer(320)
+            m.constrain(symbolic_data[0] == 0x65)
+            m.transaction(caller=attacker_account,
+                            address=contract_account,
+                            data=symbolic_data,
+                            value=100000 )
         """
         if name is None:
             name = "TXBUFFER"
@@ -163,19 +163,19 @@ class ManticoreEVM(ManticoreBase):
         )
 
     def make_symbolic_value(self, nbits=256, name=None):
-        """ Creates a symbolic value, normally a uint256, to be used in transactions.
-            You can operate on it normally and add constraints to manticore.constraints
-            via manticore.constrain(constraint_expression)
+        """Creates a symbolic value, normally a uint256, to be used in transactions.
+        You can operate on it normally and add constraints to manticore.constraints
+        via manticore.constrain(constraint_expression)
 
-            Example use::
+        Example use::
 
-                symbolic_value = m.make_symbolic_value()
-                m.constrain(symbolic_value > 100)
-                m.constrain(symbolic_value < 1000)
-                m.transaction(caller=attacker_account,
-                                address=contract_account,
-                                data=data,
-                                value=symbolic_value )
+            symbolic_value = m.make_symbolic_value()
+            m.constrain(symbolic_value > 100)
+            m.constrain(symbolic_value < 1000)
+            m.transaction(caller=attacker_account,
+                            address=contract_account,
+                            data=data,
+                            value=symbolic_value )
 
         """
         avoid_collisions = False
@@ -319,16 +319,16 @@ class ManticoreEVM(ManticoreBase):
 
     @staticmethod
     def _compile(source_code, contract_name, libraries=None, crytic_compile_args=None):
-        """ Compile a Solidity contract, used internally
+        """Compile a Solidity contract, used internally
 
-            :param source_code: solidity source
-            :type source_code: string (filename, directory, etherscan address) or a file handle
-            :param contract_name: a string with the name of the contract to analyze
-            :param libraries: an itemizable of pairs (library_name, address)
-            :param crytic_compile_args: crytic compile options (https://github.com/crytic/crytic-compile/wiki/Configuration)
-            :type crytic_compile_args: dict
-            :return: name, source_code, bytecode, srcmap, srcmap_runtime, hashes
-            :return: name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi, warnings
+        :param source_code: solidity source
+        :type source_code: string (filename, directory, etherscan address) or a file handle
+        :param contract_name: a string with the name of the contract to analyze
+        :param libraries: an itemizable of pairs (library_name, address)
+        :param crytic_compile_args: crytic compile options (https://github.com/crytic/crytic-compile/wiki/Configuration)
+        :type crytic_compile_args: dict
+        :return: name, source_code, bytecode, srcmap, srcmap_runtime, hashes
+        :return: name, source_code, bytecode, runtime, srcmap, srcmap_runtime, hashes, abi, warnings
         """
 
         crytic_compile_args = dict() if crytic_compile_args is None else crytic_compile_args
@@ -336,10 +336,13 @@ class ManticoreEVM(ManticoreBase):
         if isinstance(source_code, io.IOBase):
             source_code = source_code.name
 
-        if (isinstance(source_code, str) and
-                not is_supported(source_code) and
-                # Until https://github.com/crytic/crytic-compile/issues/103 is implemented
-                "ignore_compile" not in crytic_compile_args):
+        if (
+            isinstance(source_code, str)
+            and not is_supported(source_code)
+            and
+            # Until https://github.com/crytic/crytic-compile/issues/103 is implemented
+            "ignore_compile" not in crytic_compile_args
+        ):
             with tempfile.NamedTemporaryFile("w+", suffix=".sol") as temp:
                 temp.write(source_code)
                 temp.flush()
@@ -489,7 +492,7 @@ class ManticoreEVM(ManticoreBase):
 
     def make_symbolic_arguments(self, types):
         """
-            Build a reasonable set of symbolic arguments matching the types list
+        Build a reasonable set of symbolic arguments matching the types list
         """
         from . import abitypes
 
@@ -542,24 +545,24 @@ class ManticoreEVM(ManticoreBase):
         gas=None,
         compile_args=None,
     ):
-        """ Creates a solidity contract and library dependencies
+        """Creates a solidity contract and library dependencies
 
-            :param source_code: solidity source code
-            :type source_code: string (filename, directory, etherscan address) or a file handle
-            :param owner: owner account (will be default caller in any transactions)
-            :type owner: int or EVMAccount
-            :param contract_name: Name of the contract to analyze (optional if there is a single one in the source code)
-            :type contract_name: str
-            :param balance: balance to be transferred on creation
-            :type balance: int or BitVecVariable
-            :param address: the address for the new contract (optional)
-            :type address: int or EVMAccount
-            :param tuple args: constructor arguments
-            :param compile_args: crytic compile options #FIXME(https://github.com/crytic/crytic-compile/wiki/Configuration)
-            :type compile_args: dict
-            :param gas: gas budget for each contract creation needed (may be more than one if several related contracts defined in the solidity source)
-            :type gas: int
-            :rtype: EVMAccount
+        :param source_code: solidity source code
+        :type source_code: string (filename, directory, etherscan address) or a file handle
+        :param owner: owner account (will be default caller in any transactions)
+        :type owner: int or EVMAccount
+        :param contract_name: Name of the contract to analyze (optional if there is a single one in the source code)
+        :type contract_name: str
+        :param balance: balance to be transferred on creation
+        :type balance: int or BitVecVariable
+        :param address: the address for the new contract (optional)
+        :type address: int or EVMAccount
+        :param tuple args: constructor arguments
+        :param compile_args: crytic compile options #FIXME(https://github.com/crytic/crytic-compile/wiki/Configuration)
+        :type compile_args: dict
+        :param gas: gas budget for each contract creation needed (may be more than one if several related contracts defined in the solidity source)
+        :type gas: int
+        :rtype: EVMAccount
         """
         if compile_args is None:
             compile_args = dict()
@@ -665,17 +668,17 @@ class ManticoreEVM(ManticoreBase):
             return next(iter(nonces))
 
     def create_contract(self, owner, balance=0, address=None, init=None, name=None, gas=None):
-        """ Creates a contract
+        """Creates a contract
 
-            :param owner: owner account (will be default caller in any transactions)
-            :type owner: int or EVMAccount
-            :param balance: balance to be transferred on creation
-            :type balance: int or BitVecVariable
-            :param int address: the address for the new contract (optional)
-            :param str init: initializing evm bytecode and arguments
-            :param str name: a unique name for reference
-            :param gas: gas budget for the creation/initialization of the contract
-            :rtype: EVMAccount
+        :param owner: owner account (will be default caller in any transactions)
+        :type owner: int or EVMAccount
+        :param balance: balance to be transferred on creation
+        :type balance: int or BitVecVariable
+        :param int address: the address for the new contract (optional)
+        :param str init: initializing evm bytecode and arguments
+        :param str name: a unique name for reference
+        :param gas: gas budget for the creation/initialization of the contract
+        :rtype: EVMAccount
         """
         if not self.count_ready_states():
             raise NoAliveStates
@@ -751,34 +754,34 @@ class ManticoreEVM(ManticoreBase):
             world.end_block()
 
     def transaction(self, caller, address, value, data, gas=None, price=1):
-        """ Issue a symbolic transaction in all running states
+        """Issue a symbolic transaction in all running states
 
-            :param caller: the address of the account sending the transaction
-            :type caller: int or EVMAccount
-            :param address: the address of the contract to call
-            :type address: int or EVMAccount
-            :param value: balance to be transfered on creation
-            :type value: int or BitVecVariable
-            :param data: initial data
-            :param gas: gas budget
-            :param price: gas unit price
-            :raises NoAliveStates: if there are no alive states to execute
+        :param caller: the address of the account sending the transaction
+        :type caller: int or EVMAccount
+        :param address: the address of the contract to call
+        :type address: int or EVMAccount
+        :param value: balance to be transfered on creation
+        :type value: int or BitVecVariable
+        :param data: initial data
+        :param gas: gas budget
+        :param price: gas unit price
+        :raises NoAliveStates: if there are no alive states to execute
         """
         self._transaction(
             "CALL", caller, value=value, address=address, data=data, gas=gas, price=price
         )
 
     def create_account(self, balance=0, address=None, code=None, name=None, nonce=None):
-        """ Low level creates an account. This won't generate a transaction.
+        """Low level creates an account. This won't generate a transaction.
 
-            :param balance: balance to be set on creation (optional)
-            :type balance: int or BitVecVariable
-            :param address: the address for the new account (optional)
-            :type address: int
-            :param code: the runtime code for the new account (None means normal account), str or bytes (optional)
-            :param nonce: force a specific nonce
-            :param name: a global account name eg. for use as reference in the reports (optional)
-            :return: an EVMAccount
+        :param balance: balance to be set on creation (optional)
+        :type balance: int or BitVecVariable
+        :param address: the address for the new account (optional)
+        :type address: int
+        :param code: the runtime code for the new account (None means normal account), str or bytes (optional)
+        :param nonce: force a specific nonce
+        :param name: a global account name eg. for use as reference in the reports (optional)
+        :return: an EVMAccount
         """
         # Need at least one state where to apply this
         if not self.count_ready_states():
@@ -874,17 +877,17 @@ class ManticoreEVM(ManticoreBase):
         return caller, address, value, data, gas, price
 
     def _transaction(self, sort, caller, value=0, address=None, data=None, gas=None, price=1):
-        """ Initiates a transaction
+        """Initiates a transaction
 
-            :param caller: caller account
-            :type caller: int or EVMAccount
-            :param int address: the address for the transaction (optional)
-            :param value: value to be transferred
-            :param price: the price of gas for this transaction.
-            :type value: int or BitVecVariable
-            :param str data: initializing evm bytecode and arguments or transaction call data
-            :param gas: gas budget for current transaction
-            :rtype: EVMAccount
+        :param caller: caller account
+        :type caller: int or EVMAccount
+        :param int address: the address for the transaction (optional)
+        :param value: value to be transferred
+        :param price: the price of gas for this transaction.
+        :type value: int or BitVecVariable
+        :param str data: initializing evm bytecode and arguments or transaction call data
+        :param gas: gas budget for current transaction
+        :rtype: EVMAccount
         """
         if gas is None:
             gas = consts.defaultgas
@@ -991,13 +994,13 @@ class ManticoreEVM(ManticoreBase):
         value: Optional[Union[int, Expression]] = None,
         contract_metadata: Optional[SolidityMetadata] = None,
     ):
-        """ Returns a constraint that excludes combinations of value and data that would cause an exception in the EVM
-            contract dispatcher.
+        """Returns a constraint that excludes combinations of value and data that would cause an exception in the EVM
+        contract dispatcher.
 
-            :param address: address of the contract to call
-            :param value: balance to be transferred (optional)
-            :param data: symbolic transaction data
-            :param contract_metadata: SolidityMetadata for the contract (optional)
+        :param address: address of the contract to call
+        :param value: balance to be transferred (optional)
+        :param data: symbolic transaction data
+        :param contract_metadata: SolidityMetadata for the contract (optional)
         """
         if isinstance(address, EVMAccount):
             address = int(address)
@@ -1034,12 +1037,12 @@ class ManticoreEVM(ManticoreBase):
 
     def local_coverage_progress(self) -> bool:
         for state in self.ready_states:
-            new_local_coverage = len(set(state.context['evm.trace']))
-            if 'evm.localcoverage' in state.context:
-                old_local_coverage = state.context['evm.localcoverage']
+            new_local_coverage = len(set(state.context["evm.trace"]))
+            if "evm.localcoverage" in state.context:
+                old_local_coverage = state.context["evm.localcoverage"]
             else:
                 old_local_coverage = 0
-            state.context['evm.localcoverage'] = new_local_coverage
+            state.context["evm.localcoverage"] = new_local_coverage
             if new_local_coverage != old_local_coverage:
                 return True
         return False
@@ -1094,7 +1097,9 @@ class ManticoreEVM(ManticoreBase):
         prev_coverage = 0
         current_coverage = 0
         tx_no = 0
-        while (current_coverage < 100 or tx_use_coverage is tx_use_coverage.no) and not self.is_killed():
+        while (
+            current_coverage < 100 or tx_use_coverage is tx_use_coverage.no
+        ) and not self.is_killed():
             try:
 
                 logger.info("Starting symbolic transaction: %d", tx_no)
@@ -1153,8 +1158,7 @@ class ManticoreEVM(ManticoreBase):
                         logger.info("No state made any progress")
                         break
                 except Exception as e:
-                    print (e)
-
+                    print(e)
 
             tx_no += 1
 
@@ -1292,8 +1296,8 @@ class ManticoreEVM(ManticoreBase):
         result.append(value)
 
     def fix_unsound_symbolication_fake(self, state):
-        """ This method goes through all the applied symbolic functions and tries
-            to find a concrete matching set of pairs
+        """This method goes through all the applied symbolic functions and tries
+        to find a concrete matching set of pairs
         """
 
         def make_cond(state, table):
@@ -1311,8 +1315,8 @@ class ManticoreEVM(ManticoreBase):
         return state.can_be_true(True)
 
     def fix_unsound_symbolication_sound(self, state):
-        """ This method goes through all the applied symbolic functions and tries
-            to find a concrete matching set of pairs
+        """This method goes through all the applied symbolic functions and tries
+        to find a concrete matching set of pairs
         """
 
         def concretize_known_pairs(state, symbolic_pairs, known_pairs):
@@ -1329,7 +1333,7 @@ class ManticoreEVM(ManticoreBase):
                     return
 
         def match(state, func, symbolic_pairs, concrete_pairs, start=None):
-            """ Tries to find a concrete match for the symbolic pairs. It uses
+            """Tries to find a concrete match for the symbolic pairs. It uses
             concrete_pairs (and potentially extends it with solved pairs) until
             a matching set of concrete pairs is found, or fail.
 
@@ -1446,9 +1450,9 @@ class ManticoreEVM(ManticoreBase):
         return state.context["soundcheck"]
 
     def _terminate_state_callback(self, state, e):
-        """ INTERNAL USE
-            Every time a state finishes executing the last transaction, we save it in
-            our private list
+        """INTERNAL USE
+        Every time a state finishes executing the last transaction, we save it in
+        our private list
         """
         if isinstance(e, AbandonState):
             # do nothing
@@ -1505,8 +1509,8 @@ class ManticoreEVM(ManticoreBase):
         )
 
     def get_metadata(self, address) -> Optional[SolidityMetadata]:
-        """ Gets the solidity metadata for address.
-            This is available only if address is a contract created from solidity
+        """Gets the solidity metadata for address.
+        This is available only if address is a contract created from solidity
         """
         return self.metadata.get(address)
 
@@ -1871,9 +1875,9 @@ class ManticoreEVM(ManticoreBase):
         self.remove_all()
 
     def global_coverage(self, account):
-        """ Returns code coverage for the contract on `account_address`.
-            This sums up all the visited code lines from any of the explored
-            states.
+        """Returns code coverage for the contract on `account_address`.
+        This sums up all the visited code lines from any of the explored
+        states.
         """
         account_address = int(account)
         runtime_bytecode = None

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -61,8 +61,7 @@ class ContextFilter(logging.Filter):
 
 ctxfilter = ContextFilter()
 
-
-class CustomLogger(logging.Logger):
+class CustomLogger(logging.getLoggerClass()):
     """
     Custom Logger class that can grab the correct verbosity level from this module
     """

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -21,7 +21,6 @@ from manticore.core.smtlib.visitors import to_constant
 from manticore.core.state import TerminateState
 from manticore.ethereum import (
     ManticoreEVM,
-    State,
     DetectExternalCallAndLeak,
     DetectIntegerOverflow,
     Detector,
@@ -30,11 +29,12 @@ from manticore.ethereum import (
     EthereumError,
     EVMContract,
     verifier,
+    TermCondCovType
 )
 from manticore.ethereum.plugins import FilterFunctions
 from manticore.ethereum.solidity import SolidityMetadata
 from manticore.platforms import evm
-from manticore.platforms.evm import EVMWorld, ConcretizeArgument, concretized_args, Return, Stop
+from manticore.platforms.evm import ConcretizeArgument, concretized_args, Return, Stop
 from manticore.utils.deprecated import ManticoreDeprecationWarning
 from manticore.utils import config
 import io
@@ -67,6 +67,45 @@ class EthDetectorsIntegrationTest(unittest.TestCase):
         self.assertIn("Unsigned integer overflow at SUB instruction", all_findings)
         self.assertIn("Unsigned integer overflow at ADD instruction", all_findings)
         self.assertIn("Unsigned integer overflow at MUL instruction", all_findings)
+
+    def test_multitx_term_cond_wide(self):
+
+        mevm = ManticoreEVM()
+        source_code = """
+         contract MotivatingExample {
+    event Log(string);
+    int private stateA = 0;
+    int private stateB = 0;
+    function f(int input) public {
+    	stateA=input;
+        }
+    function g() public {
+        stateB = stateA;
+        }
+    function h() payable public {
+        if(stateB == 61){
+          emit Log("Bug found");
+         }
+    }
+}"""
+        #This will stop before the bug is found
+        mevm.multi_tx_analysis(source_code, tx_use_coverage=TermCondCovType.wide )
+        found_log = 0
+        for state in mevm.all_states:
+            if state.platform.logs:
+                found_log += 1
+        self.assertEqual(found_log,0)
+
+
+        #This will never stop :joy:
+        mevm = ManticoreEVM()
+        with mevm.kill_timeout(timeout=600):
+            mevm.multi_tx_analysis(source_code, tx_limit=4, tx_use_coverage=TermCondCovType.local )
+        found_log = 0
+        for state in mevm.all_states:
+            if state.platform.logs:
+                found_log += 1
+        self.assertGreater(found_log,0)
 
 
 class EthVerifierIntegrationTest(unittest.TestCase):

--- a/tests/ethereum/test_regressions.py
+++ b/tests/ethereum/test_regressions.py
@@ -118,7 +118,7 @@ class IntegrationTest(unittest.TestCase):
 
     def test_regressions_676(self):
         issue = {"number": 676, "contract": None, "txlimit": 1}
-        self._simple_cli_run(
+        self.   _simple_cli_run(
             f'{issue["number"]}.sol',
             contract=issue["contract"],
             tx_limit=issue["txlimit"],


### PR DESCRIPTION
Rather than stopping when the last tx has not uncovered any new code at any of the explored states.
Stop when each state in its own did not find any new code.

What?


Consider this example....

```
contract MotivatingExample {
    event Log(string);
    int  stateA = 0;
    int  stateB = 0;
    function f(int input) public {
    	stateA=input;
        }
    function g() public {
        stateB = stateA;
        }
    function h() payable public {
        if(stateB == 61){
          emit Log("Bug found");
         }
    }
}
```

You need a trace with f()-g()-h() to emit the bug log. though in the first explored tx manticore will fork and explore f(), and g(), and h() all in different states hitting most of the code. Then in the second TX no new coverage would be found  and the third tx will never be tried. IFFyou used the global coverage stopping condition


This adds a way to stop only when no state made any progress in its own world. Clearly a longer process. 


