### PR TITLE
Fix EVM account existence checks for selfdestruct and call

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2141,10 +2141,9 @@ class EVM(Eventful):
         GCALLNEW = 25000
         wanted_gas = Operators.ZEXTEND(wanted_gas, 512)
         fee = Operators.ITEBV(512, value == 0, 0, GCALLVALUE)
-        known_address = False
-        for address_i in self.world.accounts:
-            known_address = Operators.OR(known_address, address == address_i)
-        fee += Operators.ITEBV(512, Operators.OR(known_address, value == 0), 0, GCALLNEW)
+        fee += Operators.ITEBV(
+            512, Operators.OR(self.world.account_exists(address), value == 0), 0, GCALLNEW
+        )
         fee += self._get_memfee(in_offset, in_size)
 
         exception = False

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2277,7 +2277,7 @@ class EVM(Eventful):
         CreateBySelfdestructGas = 25000
         SelfdestructRefundGas = 24000
         fee = 0
-        if recipient not in self.world and self.world.get_balance(self.address) != 0:
+        if not self.world.account_exists(recipient) and self.world.get_balance(self.address) != 0:
             fee += CreateBySelfdestructGas
 
         if self.address not in self.world._deleted_accounts:

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -2897,6 +2897,15 @@ class EVMWorld(Platform):
             return 0
         return Operators.EXTRACT(self._world_state[address]["balance"], 0, 256)
 
+    def account_exists(self, address):
+        if address not in self._world_state:
+            return False  # accounts default to nonexistent
+        return (
+            self.has_code(address)
+            or Operators.UGT(self.get_nonce(address), 0)
+            or Operators.UGT(self.get_balance(address), 0)
+        )
+
     def add_to_balance(self, address, value):
         if isinstance(value, BitVec):
             value = Operators.ZEXTEND(value, 512)

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -1435,6 +1435,20 @@ class EthHelpersTest(unittest.TestCase):
         # wasn't requested.
         inner_func(None, self.bv, 123)
 
+    def test_account_exists(self):
+        constraints = ConstraintSet()
+        world = evm.EVMWorld(constraints)
+        default = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        empty = world.create_account(nonce=0, balance=0, code=b"")
+        has_code = world.create_account(nonce=0, balance=0, code=b"ff")
+        has_nonce = world.create_account(nonce=1, balance=0, code=b"")
+        has_balance = world.create_account(nonce=0, balance=1, code=b"")
+        self.assertTrue(world.account_exists(has_code))
+        self.assertTrue(world.account_exists(has_nonce))
+        self.assertTrue(world.account_exists(has_balance))
+        self.assertFalse(world.account_exists(empty))
+        self.assertFalse(world.account_exists(default))
+
 
 class EthSolidityMetadataTests(unittest.TestCase):
     def test_tuple_signature_for_components(self):

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -1799,6 +1799,8 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
         GCALLSTIPEND = 2300 # additional gas sent with a call if value > 0
 
         with disposable_mevm() as m:
+            # empty call target
+            m.create_account(address=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
             # nonempty call target
             m.create_account(
                 address=0x111111111111111111111111111111111111111,
@@ -1812,7 +1814,7 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
                                             PUSH1 0x0
                                             PUSH1 0X0
                                             PUSH1 0x0
-                                            PUSH20 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                                            PUSH20 0xfffffffffffffffffffffffffffffffffffffff
                                             PUSH1 0x0
                                             CALL
                                             STOP
@@ -1834,7 +1836,7 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
                                             PUSH1 0x0
                                             PUSH1 0X0
                                             PUSH1 0x1
-                                            PUSH20 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+                                            PUSH20 0xfffffffffffffffffffffffffffffffffffffff
                                             PUSH1 0x0
                                             CALL
                                             STOP


### PR DESCRIPTION
Addresses #1798 and adds some tests for selfdestruct gas costs.

The changes to `test_call_gas` make sure that it covers the account existence check.