### PR TITLE
Use the PTable Python module to implement prettytable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     install_requires=[
         "pyyaml",
         "pysha3",
-        "prettytable",
+        "PTable",
         "ply",
         "rlp",
         "crytic-compile>=0.1.8",


### PR DESCRIPTION
The original prettytable Python module was hosted on Google Code, and is
no longer maintained. PTable is a fork of prettytable, as found at
https://pypi.org/project/PTable/.