### PR TITLE
native/cpu/x86: Add support for CPUID EAX=80000000h

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -961,6 +961,10 @@ class X86Cpu(Cpu):
                 0x0: (0x00000000, 0x00000000, 0x00000000, 0x00000000),
                 0x1: (0x00000000, 0x00000000, 0x00000000, 0x00000000),
             },
+            # CPUID with EAX=80000000h returns the highest supported extended function
+            # query in EAX. We don't currently support any other than 80000000h itself,
+            # so just return it back.
+            0x80000000: (0x80000000, 0x00000000, 0x00000000, 0x00000000),
         }
 
         if cpu.EAX not in conf:


### PR DESCRIPTION
`cpuid` with `EAX=80000000h` is meant to return the highest "extended function" ID back via `EAX`.

Both Intel's and AMD's docs are a little oblique when it comes to what exactly an "extended function" ID *is*, but it *seems* to just be another `EAX` value (i.e., `CPUID` "leaf") with the high bit (i.e. `EAX=8xxxxxxxh`) set.

Longer term, we should probably support some of these higher extended functions/leaves. In particular, it looks like recent versions of the Linux VDSO check for `CPUID EAX=80000001h` and then check if `EDX.RDTSCP[bit 27]` is high in order to use `rdtscp` (in lieu of `rdtsc` + a serializing hack?).