### PR TITLE
Ignore Gas Calculations by Default

### DIFF
--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -69,7 +69,7 @@ def globalfakesha3(data):
 
 consts.add(
     "oog",
-    default="complete",
+    default="ignore",
     description=(
         "Default behavior for symbolic gas."
         "pedantic: Fully faithful. Test at every instruction. Forks."


### PR DESCRIPTION
As I understand it, this is necessary to get the [building secure contracts](https://github.com/crytic/building-secure-contracts) repo passing by default. It's also a frequent first step for real-world EVM analysis, so perhaps it will save some time.

The tests are performing suspiciously well locally. I would have expected some changes to be required. Let's see how GH Actions handles them.