### PR TITLE
Fix yices timeout argument

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -722,7 +722,7 @@ class Z3Solver(SMTLIBSolver):
 class YicesSolver(SMTLIBSolver):
     def __init__(self):
         init = ["(set-logic QF_AUFBV)"]
-        command = f"{consts.yices_bin} --timeout={consts.timeout * 1000}  --incremental"
+        command = f"{consts.yices_bin} --timeout={consts.timeout}  --incremental"
         super().__init__(
             command=command,
             init=init,


### PR DESCRIPTION
```
$yices-smt2 --help
        --timeout=<timeout>       Set a timeout in seconds (default = no timeout)
        -t <timeout>
```