### PR TITLE
Attempt to allow symbolic balances from the start

### DIFF
--- a/examples/evm/minimal.py
+++ b/examples/evm/minimal.py
@@ -24,8 +24,7 @@ contract NoDistpatcher {
     } 
 }
 """
-
-user_account = m.create_account(balance=1000, name="user_account")
+user_account = m.create_account(balance=m.make_symbolic_value(), name="user_account")
 print("[+] Creating a user account", user_account.name_)
 
 contract_account = m.solidity_create_contract(

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -801,7 +801,7 @@ class ManticoreEVM(ManticoreBase):
             raise EthereumError("Name already used")
 
         # Balance check
-        if not isinstance(balance, int):
+        if not isinstance(balance, (int, BitVec)):
             raise EthereumError("Balance invalid type")
 
         if isinstance(code, str):

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -3117,6 +3117,9 @@ class EVMWorld(Platform):
             # As per EIP 161, contract accounts are initialized with a nonce of 1
             nonce = 1 if len(code) > 0 else 0
 
+        if isinstance(balance, BitVec):
+            balance = Operators.ZEXTEND(balance, 512)
+
         if address is None:
             address = self.new_address()
 


### PR DESCRIPTION
```
owner_balance_symbolic = m.make_symbolic_value()
owner_account = m.create_account(balance = owner_balance_symbolic, name="owner_account", address = tx['from'])
```
generates the following error:
    owner_account = m.create_account(balance = owner_balance_symbolic, name="owner_account", address = tx['from'])
  File ".../.local/lib/python3.8/site-packages/manticore/ethereum/manticore.py", line 796, in create_account
    raise EthereumError("Balance invalid type")
manticore.exceptions.EthereumError: Balance invalid type