### PR TITLE
Support the examples from the building-secure-contracts repository

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -63,7 +63,7 @@ consts.add(
 
 consts.add(
     "solver",
-    default=SolverType.z3,
+    default=SolverType.auto,
     description="Choose default smtlib2 solver (z3, yices, cvc4, auto)",
 )
 

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -44,7 +44,7 @@ class SolverType(config.ConfigEnum):
 
 logger = logging.getLogger(__name__)
 consts = config.get_group("smt")
-consts.add("timeout", default=120, description="Timeout, in seconds, for each Z3 invocation")
+consts.add("timeout", default=240, description="Timeout, in seconds, for each Z3 invocation")
 consts.add("memory", default=1024 * 8, description="Max memory for Z3 to use (in Megabytes)")
 consts.add(
     "maxsolutions",

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -3307,7 +3307,7 @@ class EVMWorld(Platform):
             # Check depth
             failed = self.depth >= 1024
             # Fork on enough funds for value and gas
-            if not failed:
+            if not failed and consts.oog != "ignore":
                 aux_src_balance = Operators.ZEXTEND(self.get_balance(caller), 512)
                 aux_value = Operators.ZEXTEND(value, 512)
                 enough_balance = Operators.UGE(aux_src_balance, aux_value)

--- a/manticore/platforms/evm.py
+++ b/manticore/platforms/evm.py
@@ -69,7 +69,7 @@ def globalfakesha3(data):
 
 consts.add(
     "oog",
-    default="complete",
+    default="ignore",
     description=(
         "Default behavior for symbolic gas."
         "pedantic: Fully faithful. Test at every instruction. Forks."

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -45,6 +45,8 @@ solver = Z3Solver.instance()
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
+consts = config.get_group("evm")
+
 
 @contextmanager
 def disposable_mevm(*args, **kwargs):
@@ -1752,6 +1754,8 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
         self.assertFalse(world.has_storage(0x333333333333333333333333333333333333333))
 
     def test_gas_check(self):
+        default_gas = consts.oog
+        consts.oog = "complete"
         constraints = ConstraintSet()
         world = evm.EVMWorld(constraints)
         asm_acc = """  PUSH1 0x0
@@ -1774,6 +1778,7 @@ class EthSpecificTxIntructionTests(unittest.TestCase):
         except TerminateState as e:
             result = str(e)
         self.assertEqual(result, "SELFDESTRUCT")
+        consts.oog = default_gas
 
     def test_selfdestruct(self):
         with disposable_mevm() as m:

--- a/tests/ethereum_bench/test_consensys_benchmark.py
+++ b/tests/ethereum_bench/test_consensys_benchmark.py
@@ -16,7 +16,7 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from manticore.utils import config
 
-config.get_group("evm").oog = "ignore"
+config.get_group("evm").oog = "complete"
 config.get_group("core").mprocessing = "single"
 
 


### PR DESCRIPTION
Previously, contract creation would ignore the `consts.oog` variable and always check that the caller had the requisite balance. This change checks that we haven't explicitly ignored gas calculations when evaluating whether the transaction has enough balance to proceed.