### PR TITLE
Attempt to Fix solc Installation

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,6 +1,8 @@
 name: MacOS Tests
 
 on:
+  # Remove this once the tests are passing
+  pull_request:
   schedule:
     # Run every day at 11 PM.
     - cron:  '0 23 * * *'
@@ -31,12 +33,12 @@ jobs:
     - name: Install Mac Dependencies
       run: |
         brew install bash
-        brew tap ethereum/ethereum
-        brew install solidity@4
         brew install wabt
         brew install SRI-CSL/sri-csl/yices2
         brew tap cvc4/cvc4
         brew install cvc4/cvc4/cvc4
+        pip install solc-select
+        solc-select use 0.4.26
     - name: Run Tests
       env:
         TEST_TYPE: ${{ matrix.type }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -38,6 +38,7 @@ jobs:
         brew tap cvc4/cvc4
         brew install cvc4/cvc4/cvc4
         pip install solc-select
+        solc-select install 0.4.26
         solc-select use 0.4.26
     - name: Run Tests
       env:

--- a/tests/other/test_tui_api.py
+++ b/tests/other/test_tui_api.py
@@ -94,8 +94,8 @@ def fetch_update():
         time.sleep(0.5)
 
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
+class TestTui(unittest.TestCase):
+    def test_simple_state_updates(self):
         global finished
 
         fetch_thread = threading.Thread(target=fetch_update)
@@ -128,7 +128,7 @@ class MyTestCase(unittest.TestCase):
         )
 
         # Check that state lists seem correct
-        self.assertEqual(
+        self.assertLessEqual(
             max(len(list(filter(lambda x: x.type == State.BUSY, i))) for i in state_captures), 10
         )  # At most ten running states
 


### PR DESCRIPTION
Prefer `solc-select` over `brew` for installing Solidity 0.4.x, as the latter doesn't seem to work on MacOS.