### PR TITLE
Allow double-adding exact same config option

### DIFF
--- a/manticore/utils/config.py
+++ b/manticore/utils/config.py
@@ -103,6 +103,10 @@ class _Group:
 
         """
         if name in self._vars:
+            # Be kind when double-adding the same exact config
+            existing = self._vars[name]
+            if default == existing.default and description == existing.description:
+                return
             raise ConfigError(f"{self.name}.{name} already defined.")
 
         if name == "name":

--- a/manticore/wasm/cli.py
+++ b/manticore/wasm/cli.py
@@ -4,6 +4,7 @@ from ..core.plugin import Profiler
 from ..utils import config
 
 consts = config.get_group("cli")
+consts.add("profile", default=False, description="Enable worker profiling mode")
 consts.add("target_func", default="main", description="WASM Function to execute")
 
 

--- a/tests/other/utils/test_config.py
+++ b/tests/other/utils/test_config.py
@@ -41,11 +41,16 @@ class ConfigTest(unittest.TestCase):
         self.assertFalse(g._vars["val1"].was_set)
         self.assertTrue(g._vars["val2"].was_set)
 
-    def test_double_add(self):
+    def test_double_add_different(self):
         g = config.get_group("test1")
         g.add("val1", default="foo")
         with self.assertRaises(config.ConfigError):
             g.add("val1")
+
+    def test_double_add_exact_duplicate(self):
+        g = config.get_group("test2")
+        g.add("val1", default="foo", description="Some description")
+        g.add("val1", default="foo", description="Some description")
 
     def test_update(self):
         g = config.get_group("update")

--- a/tests/wasm/test_examples.py
+++ b/tests/wasm/test_examples.py
@@ -121,7 +121,6 @@ class TestCollatz(unittest.TestCase):
         self.assertEqual(sorted(results), [70])
 
     def test_wasm_main(self):
-        config.get_group("cli").add("profile", False)
         m = wasm_main(
             namedtuple("Args", ["argv", "workspace", "policy"])([collatz_file], "mcore_tmp", "ALL"),
             None,


### PR DESCRIPTION
Extracted from #2394 

The `config` system is a little brittle when Manticore tries to import all platform modules since we set the config options upon import and declaring the same config option in two different platforms will cause issues.

This is a bit of a band-aid over the real problem, which might look something like moving shared `config` options to a separate file that each platform can import.

Looks to be some related refactoring work here https://github.com/trailofbits/manticore/pull/1636