### PR TITLE
Update CI and suggest to use pip3 instead of pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   # Send notification when all tests have finished to combine coverage results
   coverage-finish:
     needs: tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v1.1.2
@@ -92,7 +92,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     if: github.event_name == 'schedule'
     needs: tests
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # needs to run only on pull_request
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
@@ -39,7 +39,7 @@ jobs:
         mypy --version
         mypy
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]

--- a/manticore/utils/install_helper.py
+++ b/manticore/utils/install_helper.py
@@ -6,7 +6,7 @@ REQUIREMENTS_TO_IMPORTS = {
 def ensure_native_deps():
     if not has_native:
         raise ImportError(
-            "Missing some packages for native binary analysis. Please install them with pip install manticore[native]."
+            "Missing some packages for native binary analysis. Please install them with pip3 install manticore[native]."
         )
 
 


### PR DESCRIPTION
A very small change in an error message to use `pip3` instead of `pip`.