### PR TITLE
Basic solver stats

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -1106,6 +1106,10 @@ class ManticoreBase(Eventful):
         """
         Runs analysis.
         """
+        # Start measuring the execution time
+        with self.locked_context() as context:
+            context["time_started"] = time.time()
+
         # Delete state cache
         # The cached version of a state may get out of sync if a worker in a
         # different process modifies the state
@@ -1229,6 +1233,17 @@ class ManticoreBase(Eventful):
             )
 
         logger.info("Results in %s", self._output.store.uri)
+
+        time_ended = time.time()
+
+        with self.locked_context() as context:
+            time_elapsed = time_ended - context["time_started"]
+
+            logger.info("Total time: %s", time_elapsed)
+
+            context["time_ended"] = time_ended
+            context["time_elapsed"] = time_elapsed
+
         self.wait_for_log_purge()
 
     def introspect(self) -> typing.Dict[int, StateDescriptor]:

--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -14,7 +14,7 @@ import functools
 import shlex
 
 from ..core.plugin import Plugin, IntrospectionAPIPlugin, StateDescriptor
-from ..core.smtlib import Expression
+from ..core.smtlib import Expression, SOLVER_STATS
 from ..core.state import StateBase
 from ..core.workspace import ManticoreOutput
 from ..exceptions import ManticoreError
@@ -1218,6 +1218,15 @@ class ManticoreBase(Eventful):
 
         with self._output.save_stream("manticore.yml") as f:
             config.save(f)
+
+        with self._output.save_stream("global.solver_stats") as f:
+            for s, n in sorted(SOLVER_STATS.items()):
+                f.write("%s: %d\n" % (s, n))
+
+        if SOLVER_STATS["timeout"] > 0 or SOLVER_STATS["unknown"] > 0:
+            logger.info(
+                "Warning: the SMT solvers returned timeout or unknown for certain program paths. Results could not cover the entire set of possible paths"
+            )
 
         logger.info("Results in %s", self._output.store.uri)
         self.wait_for_log_purge()

--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -1228,8 +1228,8 @@ class ManticoreBase(Eventful):
                 f.write("%s: %d\n" % (s, n))
 
         if SOLVER_STATS["timeout"] > 0 or SOLVER_STATS["unknown"] > 0:
-            logger.info(
-                "Warning: the SMT solvers returned timeout or unknown for certain program paths. Results could not cover the entire set of possible paths"
+            logger.warning(
+                "The SMT solvers returned timeout or unknown for certain program paths. Results could not cover the entire set of possible paths"
             )
 
         logger.info("Results in %s", self._output.store.uri)
@@ -1243,7 +1243,7 @@ class ManticoreBase(Eventful):
                 context["time_ended"] = time_ended
                 context["time_elapsed"] = time_elapsed
             else:
-                logger.info("Warning: manticore failed to run")
+                logger.warning("Manticore failed to run")
 
         self.wait_for_log_purge()
 

--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -1237,12 +1237,13 @@ class ManticoreBase(Eventful):
         time_ended = time.time()
 
         with self.locked_context() as context:
-            time_elapsed = time_ended - context["time_started"]
-
-            logger.info("Total time: %s", time_elapsed)
-
-            context["time_ended"] = time_ended
-            context["time_elapsed"] = time_elapsed
+            if "time_started" in context:
+                time_elapsed = time_ended - context["time_started"]
+                logger.info("Total time: %s", time_elapsed)
+                context["time_ended"] = time_ended
+                context["time_elapsed"] = time_elapsed
+            else:
+                logger.info("Warning: manticore failed to run")
 
         self.wait_for_log_purge()
 

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -263,7 +263,7 @@ class SmtlibProc:
 
 
 class SMTLIBSolver(Solver):
-    sname = None
+    sname: Optional[str] = None
 
     def __init__(
         self,
@@ -675,6 +675,8 @@ class SMTLIBSolver(Solver):
 
 
 class Z3Solver(SMTLIBSolver):
+    sname = "z3"
+
     def __init__(self):
         """
         Build a Z3 solver instance.
@@ -749,6 +751,8 @@ class Z3Solver(SMTLIBSolver):
 
 
 class YicesSolver(SMTLIBSolver):
+    sname = "yices"
+
     def __init__(self):
         init = ["(set-logic QF_AUFBV)"]
         command = f"{consts.yices_bin} --timeout={consts.timeout}  --incremental"
@@ -762,6 +766,8 @@ class YicesSolver(SMTLIBSolver):
 
 
 class CVC4Solver(SMTLIBSolver):
+    sname = "cvc4"
+
     def __init__(self):
         init = ["(set-logic QF_AUFBV)", "(set-option :produce-models true)"]
         command = f"{consts.cvc4_bin} --lang=smt2 --incremental"
@@ -769,6 +775,8 @@ class CVC4Solver(SMTLIBSolver):
 
 
 class BoolectorSolver(SMTLIBSolver):
+    sname = "boolector"
+
     def __init__(self):
         init = ["(set-logic QF_AUFBV)", "(set-option :produce-models true)"]
         command = f"{consts.boolector_bin} -i"
@@ -803,6 +811,4 @@ class SelectedSolver:
             "yices": YicesSolver,
             "z3": Z3Solver,
         }[cls.choice.name]
-        solver = SelectedSolver.instance()
-        solver.sname = cls.choice.name
-        return solver
+        return SelectedSolver.instance()

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -344,8 +344,7 @@ class SMTLIBSolver(Solver):
             raise SolverUnknown(status)
         else:
             assert self.sname is not None
-            if self.sname not in SOLVER_STATS:
-                SOLVER_STATS[self.sname] = 0
+            SOLVER_STATS.setdefault(self.sname, 0)
             SOLVER_STATS[self.sname] += 1
 
         return status == "sat"
@@ -605,8 +604,7 @@ class SMTLIBSolver(Solver):
             _status = self._smtlib.recv()
 
             assert self.sname is not None
-            if self.sname not in SOLVER_STATS:
-                SOLVER_STATS[self.sname] = 0
+            SOLVER_STATS.setdefault(self.sname, 0)
             SOLVER_STATS[self.sname] += 1
 
             if _status == "sat":

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -78,7 +78,7 @@ RE_OBJECTIVES_EXPR_VALUE = re.compile(
 )
 RE_MIN_MAX_OBJECTIVE_EXPR_VALUE = re.compile(r"(?P<expr>.*?)\s+\|->\s+(?P<value>.*)", re.DOTALL)
 
-SOLVER_STATS = dict({"unknown": 0, "timeout": 0})
+SOLVER_STATS = {"unknown": 0, "timeout": 0}
 
 
 class SingletonMixin(object):

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -604,6 +604,7 @@ class SMTLIBSolver(Solver):
             self._smtlib.send("(check-sat)")
             _status = self._smtlib.recv()
 
+            assert self.sname is not None
             if self.sname not in SOLVER_STATS:
                 SOLVER_STATS[self.sname] = 0
             SOLVER_STATS[self.sname] += 1

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -478,7 +478,7 @@ class SMTLIBSolver(Solver):
                     M = L
 
                 if time.time() - start > consts.timeout:
-                    SOLVER_STATS["unknown"] += 1
+                    SOLVER_STATS["timeout"] += 1
                     raise SolverError("Timeout")
 
         # reset to before the dichotomic search
@@ -501,12 +501,15 @@ class SMTLIBSolver(Solver):
                 self._assert(X != last_value)
                 i = i + 1
                 if i > max_iter:
+                    SOLVER_STATS["unknown"] += 1
                     raise SolverError("Optimizing error, maximum number of iterations was reached")
                 if time.time() - start > consts.timeout:
-                    SOLVER_STATS["unknown"] += 1
+                    SOLVER_STATS["timeout"] += 1
                     raise SolverError("Timeout")
             if last_value is not None:
                 return last_value
+
+            SOLVER_STATS["unknown"] += 1
             raise SolverError("Optimizing error, unsat or unknown core")
 
     @lru_cache(maxsize=32)
@@ -563,6 +566,7 @@ class SMTLIBSolver(Solver):
                     else:
                         raise TooManySolutions(result)
                 if time.time() - start > consts.timeout:
+                    SOLVER_STATS["timeout"] += 1
                     if silent:
                         logger.info("Timeout searching for all solutions")
                         return list(result)
@@ -599,6 +603,11 @@ class SMTLIBSolver(Solver):
             self._smtlib.send("(%s %s)" % (goal, aux.name))
             self._smtlib.send("(check-sat)")
             _status = self._smtlib.recv()
+
+            if self.sname not in SOLVER_STATS:
+                SOLVER_STATS[self.sname] = 0
+            SOLVER_STATS[self.sname] += 1
+
             if _status == "sat":
                 return self._getvalue(aux)
             raise SolverError("Optimize failed")
@@ -637,6 +646,7 @@ class SMTLIBSolver(Solver):
                         result.append(self.__getvalue_bv(var[i].name))
                     values.append(bytes(result))
                     if time.time() - start > consts.timeout:
+                        SOLVER_STATS["timeout"] += 1
                         raise SolverError("Timeout")
                     continue
 
@@ -654,6 +664,7 @@ class SMTLIBSolver(Solver):
                 if isinstance(expression, BitVec):
                     values.append(self.__getvalue_bv(var.name))
             if time.time() - start > consts.timeout:
+                SOLVER_STATS["timeout"] += 1
                 raise SolverError("Timeout")
 
         if len(expressions) == 1:

--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -343,6 +343,7 @@ class SMTLIBSolver(Solver):
             SOLVER_STATS["unknown"] += 1
             raise SolverUnknown(status)
         else:
+            assert self.sname is not None
             if self.sname not in SOLVER_STATS:
                 SOLVER_STATS[self.sname] = 0
             SOLVER_STATS[self.sname] += 1

--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1780,8 +1780,6 @@ class ManticoreEVM(ManticoreBase):
                     global_findings_stream.write("    ".join(source_code_snippet.splitlines(True)))
                     global_findings_stream.write("\n")
 
-        self.save_run_data()
-
         with self._output.save_stream("global.summary") as global_summary:
             # (accounts created by contract code are not in this list )
             global_summary.write("Global runtime coverage:\n")
@@ -1849,6 +1847,7 @@ class ManticoreEVM(ManticoreBase):
                 for o in sorted(visited):
                     f.write("0x%x\n" % o)
 
+        self.save_run_data()
         self.remove_all()
 
     def global_coverage(self, account):

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -412,17 +412,6 @@ class Manticore(ManticoreBase):
     def save_run_data(self):
         super().save_run_data()
 
-        time_ended = time.time()
-
-        with self.locked_context() as context:
-            time_elapsed = time_ended - context["time_started"]
-
-            logger.info("Total time: %s", time_elapsed)
-
-            context["time_ended"] = time_ended
-            context["time_elapsed"] = time_elapsed
-
-
 def _make_initial_state(binary_path, **kwargs):
     with open(binary_path, "rb") as f:
         magic = f.read(4)

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -412,6 +412,7 @@ class Manticore(ManticoreBase):
     def save_run_data(self):
         super().save_run_data()
 
+
 def _make_initial_state(binary_path, **kwargs):
     with open(binary_path, "rb") as f:
         magic = f.read(4)

--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -402,8 +402,6 @@ class Manticore(ManticoreBase):
             raise ValueError(f"The {self.binary_path} ELFfile does not contain symbol {symbol}")
 
     def run(self, timeout=None):
-        with self.locked_context() as context:
-            context["time_started"] = time.time()
         with self.kill_timeout(timeout):
             super().run()
 

--- a/manticore/wasm/manticore.py
+++ b/manticore/wasm/manticore.py
@@ -60,16 +60,6 @@ class ManticoreWASM(ManticoreBase):
     def save_run_data(self):
         super().save_run_data()
 
-        time_ended = time.time()
-
-        with self.locked_context() as context:
-            time_elapsed = time_ended - context["time_started"]
-
-            logger.info("Total time: %s", time_elapsed)
-
-            context["time_ended"] = time_ended
-            context["time_elapsed"] = time_elapsed
-
     def __getattr__(self, item):
         """
         Allows users to invoke & run functions in the same style as ethereum smart contracts. So:

--- a/manticore/wasm/manticore.py
+++ b/manticore/wasm/manticore.py
@@ -46,9 +46,6 @@ class ManticoreWASM(ManticoreBase):
 
         :param timeout: number of seconds after which to kill execution
         """
-        with self.locked_context() as context:
-            context["time_started"] = time.time()
-
         with self.kill_timeout(timeout):
             super().run()
 


### PR DESCRIPTION
This small PR includes a global dictionary that keeps tracks of when each solver is used succefully, timeouts or returns unknown. At the end, the result will be saved in a plain text file called `global.solver_stats`. If the solver returned either timeout or unknown, the user will be warned about it.