### PR TITLE
Disabled EVM events in testcases by default

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -52,6 +52,11 @@ consts.add(
     60 * 60,
     "Default timeout for matching sha3 for unsound states (see unsound symbolication).",
 )
+consts.add(
+    "events",
+    False,
+    "Show EVM events in the testcases.",
+)
 
 
 def flagged(flag):
@@ -1666,27 +1671,28 @@ class ManticoreEVM(ManticoreBase):
                 json.dump(txlist, txjson)
 
         # logs
-        with testcase.open_stream("logs") as logs_summary:
-            is_something_symbolic = False
-            for log_item in blockchain.logs:
-                is_log_symbolic = issymbolic(log_item.memlog)
-                is_something_symbolic = is_log_symbolic or is_something_symbolic
-                solved_memlog = state.solve_one(log_item.memlog)
+        if consts.events:
+            with testcase.open_stream("logs") as logs_summary:
+                is_something_symbolic = False
+                for log_item in blockchain.logs:
+                    is_log_symbolic = issymbolic(log_item.memlog)
+                    is_something_symbolic = is_log_symbolic or is_something_symbolic
+                    solved_memlog = state.solve_one(log_item.memlog)
 
-                logs_summary.write("Address: %x\n" % log_item.address)
-                logs_summary.write(
-                    "Memlog: %s (%s) %s\n"
-                    % (
-                        binascii.hexlify(solved_memlog).decode(),
-                        printable_bytes(solved_memlog),
-                        flagged(is_log_symbolic),
-                    )
-                )
-                logs_summary.write("Topics:\n")
-                for i, topic in enumerate(log_item.topics):
+                    logs_summary.write("Address: %x\n" % log_item.address)
                     logs_summary.write(
-                        "\t%d) %x %s" % (i, state.solve_one(topic), flagged(issymbolic(topic)))
+                        "Memlog: %s (%s) %s\n"
+                        % (
+                            binascii.hexlify(solved_memlog).decode(),
+                            printable_bytes(solved_memlog),
+                            flagged(is_log_symbolic),
+                        )
                     )
+                    logs_summary.write("Topics:\n")
+                    for i, topic in enumerate(log_item.topics):
+                        logs_summary.write(
+                            "\t%d) %x %s" % (i, state.solve_one(topic), flagged(issymbolic(topic)))
+                        )
 
         with testcase.open_stream("constraints") as smt_summary:
             smt_summary.write(str(state.constraints))

--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -752,6 +752,8 @@ class EthTests(unittest.TestCase):
             }
         }
         """
+        consts = config.get_group("evm")
+        consts.events = True
         user_account = self.mevm.create_account(balance=10 ** 10)
         contract_account = self.mevm.solidity_create_contract(source_code, owner=user_account)
         input_sym = self.mevm.make_symbolic_value()


### PR DESCRIPTION
This small PR can save a few calls to the SMT solver avoiding getting the EVM events by default. Fixes #2416  