### PR TITLE
bugfix in DetectUninitializedStorage

### DIFF
--- a/manticore/ethereum/detectors.py
+++ b/manticore/ethereum/detectors.py
@@ -706,7 +706,7 @@ class DetectUninitializedStorage(Detector):
     CONFIDENCE = DetectorClassification.HIGH
 
     def did_evm_read_storage_callback(self, state, address, offset, value):
-        if not state.can_be_true(value != 0):
+        if state.can_be_true(value != 0):
             # Not initialized memory should be zero
             return
         # check if offset is known


### PR DESCRIPTION
testcase:

```python
from manticore.ethereum import ManticoreEVM
from manticore.ethereum.detectors import DetectUninitializedStorage

source_code = """
contract Test {
    uint a;
    uint b;

    function Test(){
        a = b;
    }
}
"""

m = ManticoreEVM()
m.register_detector(DetectUninitializedStorage())
contract_account = m.solidity_create_contract(source_code, owner=m.create_account(balance=1000000000))
m.finalize()
print(m.global_findings)
```

current output: `set()`
expected (fixed) output: `{(address, 19, 'Potentially reading uninitialized storage', True)}`