### PR TITLE
Use fixed owner and attacker accounts in multi_tx_analysis

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -1065,8 +1065,8 @@ class ManticoreEVM(ManticoreBase):
         args=None,
         compile_args=None,
     ):
-        owner_account = self.create_account(balance=10 ** 10, name="owner")
-        attacker_account = self.create_account(balance=10 ** 10, name="attacker")
+        owner_account = self.create_account(balance=10 ** 10, name="owner", address=0x10000)
+        attacker_account = self.create_account(balance=10 ** 10, name="attacker", address=0x20000)
         # Pretty print
         logger.info("Starting symbolic create contract")
 


### PR DESCRIPTION
This small change will hardcode the owner and attacker accounts in `multi_tx_analysis` to make results easier to read and it will force smt constraints to be the same at every run.