### PR TITLE
Install pinned version of truffle to fix CI

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -95,7 +95,7 @@ make_wasm_sym_tests(){
 }
 
 install_truffle(){
-    npm install -g truffle
+    npm install -g truffle@5.3.13
 }
 
 run_truffle_tests(){


### PR DESCRIPTION
This pinned version should be reverted when https://github.com/crytic/crytic-compile/issues/199 is fixed.