### PR TITLE
Track last_pc in StateDescriptors

### DIFF
--- a/manticore/core/plugin.py
+++ b/manticore/core/plugin.py
@@ -442,6 +442,8 @@ class StateDescriptor:
     own_execs: typing.Optional[int] = None
     #: Last program counter (if set)
     pc: typing.Optional[typing.Any] = None
+    #: Last concrete program counter, useful when a state forks and the program counter becomes symbolic
+    last_pc: typing.Optional[typing.Any] = None
     #: Dict mapping field names to the time that field was last updated
     field_updated_at: typing.Dict[str, datetime] = field(default_factory=dict)
     #: Message attached to the TerminateState exception that ended this state

--- a/manticore/native/state.py
+++ b/manticore/native/state.py
@@ -352,9 +352,10 @@ class State(StateBase):
     def _update_state_descriptor(self, descriptor, *args, **kwargs):
         """
         Called on execution_intermittent to update the descriptor for this state.
-        This one should apply any native-specific information to the descriptor. Right now, that's just the PC
+        This one should apply any native-specific information to the descriptor. Right now, that's just the PC and _last_pc
 
         :param descriptor: StateDescriptor for this state
         """
         super()._update_state_descriptor(descriptor, *args, **kwargs)
         descriptor.pc = self.cpu.PC
+        descriptor.last_pc = self.cpu._last_pc


### PR DESCRIPTION
Start tracking `_last_pc` inside StateDescriptors. This is helpful for figuring out which instruction causes a state to fork.