### PR TITLE
Switch to Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Lint
       if: github.event_name == 'pull_request'
       env:
@@ -45,10 +45,10 @@ jobs:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Install NPM
       uses: actions/setup-node@v1
       with:
@@ -119,10 +119,10 @@ jobs:
     needs: tests
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Build Dist
       run: |
         python3 -m pip install wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
         #install yices
         sudo wget -O yices.tar.gz https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz
         sudo tar -xzf yices.tar.gz
-        sudo yices-2.6.2/install-yices
+        cd yices-2.6.2
+        sudo ./install-yices
         yices --version
         #install boolector
         mkdir -p /tmp/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Lint
       if: github.event_name == 'pull_request'
       env:
@@ -45,10 +45,10 @@ jobs:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install NPM
       uses: actions/setup-node@v1
       with:
@@ -119,10 +119,10 @@ jobs:
     needs: tests
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Build Dist
       run: |
         python3 -m pip install wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ on:
 jobs:
   # needs to run only on pull_request
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Lint
       if: github.event_name == 'pull_request'
       env:
@@ -39,16 +39,16 @@ jobs:
         mypy --version
         mypy
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install NPM
       uses: actions/setup-node@v1
       with:
@@ -105,7 +105,7 @@ jobs:
   # Send notification when all tests have finished to combine coverage results
   coverage-finish:
     needs: tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v1.1.2
@@ -113,15 +113,15 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true
   upload:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'schedule'
     needs: tests
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Build Dist
       run: |
         python3 -m pip install wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
         sudo chmod +x /usr/bin/cvc4
         cvc4 --version
         #install yices
-        sudo add-apt-repository ppa:sri-csl/formal-methods
-        sudo apt-get update
-        sudo apt-get install yices2
+        sudo wget -O yices.tar.gz https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz
+        sudo tar -xzf yices.tar.gz
+        sudo yices-2.6.2/install-yices
         yices --version
         #install boolector
         mkdir -p /tmp/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,18 @@ jobs:
         #install utils
         pip install coveralls
         pip install -e ".[dev-noks]"
+        # Get version info
+        pip freeze
+        z3 --version
         #install cvc4
         sudo wget -O /usr/bin/cvc4 https://github.com/CVC4/CVC4/releases/download/1.7/cvc4-1.7-x86_64-linux-opt
         sudo chmod +x /usr/bin/cvc4
+        cvc4 --version
         #install yices
         sudo add-apt-repository ppa:sri-csl/formal-methods
         sudo apt-get update
         sudo apt-get install yices2
+        yices --version
         #install boolector
         mkdir -p /tmp/build
         cd /tmp/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   # needs to run only on pull_request
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Lint
@@ -39,14 +39,14 @@ jobs:
         mypy --version
         mypy
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install NPM
@@ -106,7 +106,7 @@ jobs:
   # Send notification when all tests have finished to combine coverage results
   coverage-finish:
     needs: tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v1.1.2
@@ -114,13 +114,13 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true
   upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     if: github.event_name == 'schedule'
     needs: tests
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Build Dist

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install NPM

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,10 +14,10 @@ jobs:
         type: ["ethereum_truffle", "ethereum_bench", "ethereum", "ethereum_vm", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install NPM
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
         type: ["ethereum_truffle", "ethereum_bench", "examples", "ethereum", "ethereum_vm", "native", "wasm", "wasm_sym", "other"]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install NPM
       uses: actions/setup-node@v1
       with:
@@ -64,10 +64,10 @@ jobs:
     needs: tests
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Build Dist
       run: |
         python3 -m pip install wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install NPM
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Build Dist

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ for idx, val_list in enumerate(m.collect_returns()):
 </details>
 
 ## Requirements
-* Manticore requires Python 3.6 or greater 
+* Manticore requires Python 3.7 or greater 
 * Manticore officially supports the latest LTS version of Ubuntu provided by Github Actions
   * Manticore has experimental support for EVM and WASM (but not native Linux binaries) on MacOS 
 * We recommend running with increased stack size. This can be done by running `ulimit -s 100000` or by passing `--ulimit stack=100000000:100000000` to `docker run`

--- a/examples/script/concolic.py
+++ b/examples/script/concolic.py
@@ -29,7 +29,9 @@ from manticore.utils import config
 import copy
 from manticore.core.smtlib.expression import *
 
-prog = "../linux/simpleassert"
+from pathlib import Path
+
+prog = str(Path(__file__).parent.resolve().parent.joinpath("linux").joinpath("simpleassert"))
 VERBOSITY = 0
 
 

--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 if sys.version_info < (3, 6):
-    print("Manticore requires Python 3.6 or higher.")
+    print("Manticore requires Python 3.7 or higher.")
     sys.exit(-1)
 
 from .utils import config, log

--- a/manticore/__init__.py
+++ b/manticore/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     print("Manticore requires Python 3.7 or higher.")
     sys.exit(-1)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 files = manticore, tests
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     author="Trail of Bits",
     version=version,
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "pyyaml",
         "protobuf",


### PR DESCRIPTION
~Three days ago, the symbolic WASM tests started failing on `master`. There were no changes to manticore in between the failing tests and the passing ones. Presumably some kind of upstream update caused the failures, but Yices, Z3, and CVC don't seem to have published any releases that day. Interestingly, the failure always occurs in the `fib_L271`, which is a stress-test designed to test WASM functions with very high call depth. It also seems to take the form of SMTLib errors we've seen before, where an invalid SMT2 string is rendered into text and sent to the solver. For example, in today's failure, the exception is: `2021-07-23 12:12:49,417: [7396] m.c.worker:ERROR: Exception in state 0: SolverException('Error in smtlib: (error "at line 782, column 29: undefined identifier: BitV")',)`. I'm using this PR to try and diagnose the issue because I can't replicate the failure locally.~

This PR started out trying to fix the aforementioned test failures, which have now spontaneously resolved. In the course of working on it though, I noticed that Python 3.6 will be EOL at the end of 2021, which means we're probably okay to bump our minimum tested version of Python up to 3.7. 