### PR TITLE
Prioritize LD_LIBRARY_PATH over system default path

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -1366,8 +1366,8 @@ class Linux(Platform):
                         _clean_interp_stream()
                         interpreter = ELFFile(open(interpreter_path_filename, "rb"))
                         break
-            elif os.path.exists(interpreter_filename):
-                _clean_interp_stream()
+
+            if interpreter is None and os.path.exists(interpreter_filename):
                 interpreter = ELFFile(open(interpreter_filename, "rb"))
 
             break


### PR DESCRIPTION
By prioritizing `LD_LIBRARY_PATH`, it enables the ability to run binaries with custom loaders without any patching. This is useful when trying to run a dynamically linked binary with a specific version of libc which differs from the system default.