### PR TITLE
Add manticore reference property to States

### DIFF
--- a/manticore/core/manticore.py
+++ b/manticore/core/manticore.py
@@ -613,6 +613,7 @@ class ManticoreBase(Eventful):
                       +-------+
 
         """
+        state.manticore = self
         self._publish("will_enqueue_state", state, can_raise=False)
         state_id = self._save(state, state_id=state.id)
         with self._lock:

--- a/manticore/core/state.py
+++ b/manticore/core/state.py
@@ -179,6 +179,7 @@ class StateBase(Eventful):
 
     def __init__(self, constraints, platform, **kwargs):
         super().__init__(**kwargs)
+        self.manticore = None
         self._platform = platform
         self._constraints = constraints
         self._platform.constraints = constraints
@@ -238,6 +239,7 @@ class StateBase(Eventful):
         new_state._input_symbols = list(self._input_symbols)
         new_state._context = copy.copy(self._context)
         new_state._id = None
+        new_state.manticore = self.manticore
         new_state._total_exec = self._total_exec
         self.copy_eventful_state(new_state)
 


### PR DESCRIPTION
This was added a while ago when loading states from their serialized
form in https://github.com/trailofbits/manticore/pull/1609 and this PR
makes this feature a bit more robust.