### PR TITLE
Option to kill Manticore if any state fails on unrecoverable error

### DIFF
--- a/manticore/core/worker.py
+++ b/manticore/core/worker.py
@@ -17,6 +17,11 @@ import typing
 consts = config.get_group("core")
 consts.add("HOST", "localhost", "Address to bind the log & state servers to")
 consts.add("PORT", 3214, "Port to use for the log server. State server runs one port higher.")
+consts.add(
+    "fast_fail",
+    False,
+    "Kill Manticore if _any_ state encounters an unrecoverable exception/assertion.",
+)
 
 logger = logging.getLogger(__name__)
 # logger.setLevel(9)
@@ -188,6 +193,10 @@ class Worker:
                         m._kill_state(current_state.id)
                         m._publish("did_kill_state", current_state, exc)
                         current_state = None
+                    if consts.fast_fail:
+                        # Kill Manticore if _any_ state encounters unrecoverable
+                        # exception/assertion
+                        m.kill()
                     break
 
             # Getting out.


### PR DESCRIPTION
This is useful for having more strict runs of Manticore where we want to know about any unrecoverable errors encountered during state exploration.