### PR TITLE
Unpin Truffle Version, Use Latest crytic-compile

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -95,7 +95,7 @@ make_wasm_sym_tests(){
 }
 
 install_truffle(){
-    npm install -g truffle@5.3.13
+    npm install -g truffle
 }
 
 run_truffle_tests(){

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "ply",
         "rlp",
         "intervaltree",
-        "crytic-compile>=0.2.0",
+        "crytic-compile>=0.2.1",
         "wasm",
         "dataclasses; python_version < '3.7'",
         "pyevmasm>=0.2.3",


### PR DESCRIPTION
This PR allows us to support Truffle version 5.3.14, which is now supported by the [latest release of crytic-compile](https://github.com/crytic/crytic-compile/releases/tag/0.2.1)