### PR TITLE
Add walrus operator to shorten code

### DIFF
--- a/tests/auto_generators/trace.py
+++ b/tests/auto_generators/trace.py
@@ -165,8 +165,7 @@ STACK_INSTRUCTIONS = [
 while True:
     try:
         stepped = False
-        pc = gdb.getR({"i386": "EIP", "amd64": "RIP"}[arch])
-        print(hex(pc))
+        print(hex(pc := gdb.getR({"i386": "EIP", "amd64": "RIP"}[arch])))
         gdb.stepi()
         print(gdb.correspond("info registers\n"))
     except Exception as e:


### PR DESCRIPTION
PLEASE NOTE: This will ONLY function on Python 3.8 or above. If you do not intend running this within those versions, please discard my pull request. Thank you!
This will shorten the code by adding the walrus operator, which can set variables inside of expressions. If there happen to be any other sections that could use this, it could be very helpful in shortening more code in this repository