### PR TITLE
Fix handling of the program base address in Linux

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -870,8 +870,8 @@ class Linux(Platform):
         self.argv = argv
         self.stubs = SyscallStubs(parent=self)
         # Load addresses
-        self.interp_base = None
-        self.program_base = None
+        self.interp_base: Optional[int] = None
+        self.program_base: Optional[int] = None
 
         # dict of [int -> (int, int)] where tuple is (soft, hard) limits
         self._rlimits = {


### PR DESCRIPTION
Some small improvements to the `Linux` platform: 
* Distinguish interpreter and program base addresses
* Serialise base addresses in `__setstate__` and `__getstate__`