### PR TITLE
Update Regex in Solver.py

### DIFF
--- a/manticore/core/smtlib/solver.py
+++ b/manticore/core/smtlib/solver.py
@@ -57,7 +57,7 @@ consts.add(
 
 # Regular expressions used by the solver
 RE_GET_EXPR_VALUE_ALL = re.compile(
-    "\(([a-zA-Z0-9_]*)[ \\n\\s]*(#b[0-1]*|#x[0-9a-fA-F]*|[\(]?_ bv[0-9]* [0-9]*|true|false)\\)"
+    r"\(([a-zA-Z0-9_]*)[ \n\s]*(#b[0-1]*|#x[0-9a-fA-F]*|[(]?_ bv[0-9]* [0-9]*|true|false)\)"
 )
 RE_GET_EXPR_VALUE_FMT_BIN = re.compile(r"\(\((?P<expr>(.*))[ \n\s]*#b(?P<value>([0-1]*))\)\)")
 RE_GET_EXPR_VALUE_FMT_DEC = re.compile(r"\(\((?P<expr>(.*))\ \(_\ bv(?P<value>(\d*))\ \d*\)\)\)")


### PR DESCRIPTION
Between 2021-10-16 and 2021-10-23, only three dependencies changed their versions according to our CI: `protobuf`, `git`, and `regex`. It's difficult to imagine how this could break the WASM/EVM tests, until you notice the following lines in the 10/16 logs, but _not_ the 10/23 logs:
```
2021-10-16T12:38:09.5387382Z manticore/core/smtlib/solver.py:60
2021-10-16T12:38:09.5388574Z   /home/runner/work/manticore/manticore/manticore/core/smtlib/solver.py:60: DeprecationWarning: invalid escape sequence \(
2021-10-16T12:38:09.5390752Z     "\(([a-zA-Z0-9_]*)[ \\n\\s]*(#b[0-1]*|#x[0-9a-fA-F]*|[\(]?_ bv[0-9]* [0-9]*|true|false)\\)"
2021-10-16T12:38:09.5391316Z 
```

I believe this fixes the character escaping so the regex should work now. Hopefully this fixes the tests as well!