### PR TITLE
Improves namedtuple definition

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -144,7 +144,7 @@ def repe(old_method):
 
 
 class AMD64RegFile(RegisterFile):
-    Regspec = collections.namedtuple("RegSpec", "register_id ty offset size reset")
+    Regspec = collections.namedtuple("Regspec", "register_id ty offset size reset")
     _flags = {"CF": 0, "PF": 2, "AF": 4, "ZF": 6, "SF": 7, "IF": 9, "DF": 10, "OF": 11}
     _table = {
         "CS": Regspec("CS", int, 0, 16, False),


### PR DESCRIPTION
While working on https://github.com/python/mypy/pull/11206 I found that `Regspec` definition is not ideal.
It is recommended to use the same string name, as variable name. 
For example, it affects how `pickle` works.

Related https://github.com/trailofbits/manticore/pull/2501
Related https://github.com/trailofbits/manticore/commit/6e036f3034b76bbecf36b5469e49294e038ff705