### PR TITLE
Fix `BitVecExtract` simplification for constant folding

### DIFF
--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -384,7 +384,7 @@ class ConstantFolderSimplifier(Visitor):
             begining = expression.begining
             end = expression.end
             value = value >> begining
-            mask = (1 << (end - begining)) - 1
+            mask = (1 << (end - begining+1)) - 1
             value = value & mask
             return BitVecConstant(size=expression.size, value=value, taint=expression.taint)
 

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -384,7 +384,7 @@ class ConstantFolderSimplifier(Visitor):
             begining = expression.begining
             end = expression.end
             value = value >> begining
-            mask = (1 << (end - begining+1)) - 1
+            mask = (1 << (end - begining + 1)) - 1
             value = value & mask
             return BitVecConstant(size=expression.size, value=value, taint=expression.taint)
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -824,7 +824,7 @@ class ExpressionTest(unittest.TestCase):
     def test_constant_folding_extract(self):
         cs = ConstraintSet()
         x = BitVecConstant(size=32, value=0xAB123456, taint=("important",))
-        z = constant_folder(BitVecExtract(x, 8, 16))
+        z = constant_folder(BitVecExtract(operand=x, offset=8, size=16))
         self.assertItemsEqual(z.taint, ("important",))
         self.assertEqual(z.value, 0x1234)
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -15,6 +15,7 @@ from manticore.core.smtlib import (
     constant_folder,
     replace,
     BitVecConstant,
+    BitVecExtract
 )
 from manticore.core.smtlib.solver import (
     Z3Solver,
@@ -819,6 +820,13 @@ class ExpressionTest(unittest.TestCase):
             translate_to_smtlib(c), "(concat ((_ extract 23 16) VARA) ((_ extract 15 8) VARA))"
         )
         self.assertEqual(translate_to_smtlib(simplify(c)), "((_ extract 23 8) VARA)")
+
+    def test_constant_folding_extract(self):
+        cs = ConstraintSet()
+        x = BitVecConstant(size=32, value=0xab123456, taint=("important",))
+        z = constant_folder(BitVecExtract(x, 8, 16))
+        self.assertItemsEqual(z.taint, ("important",))
+        self.assertEqual(z.value, 0x1234)
 
     def test_arithmetic_simplify_udiv(self):
         cs = ConstraintSet()

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -15,7 +15,7 @@ from manticore.core.smtlib import (
     constant_folder,
     replace,
     BitVecConstant,
-    BitVecExtract
+    BitVecExtract,
 )
 from manticore.core.smtlib.solver import (
     Z3Solver,
@@ -281,7 +281,7 @@ class ExpressionTest(unittest.TestCase):
         self.assertTrue(x.value == 0)
 
     def testBasicAST_001(self):
-        """ Can't build abstract classes """
+        """Can't build abstract classes"""
         a = BitVecConstant(size=32, value=100)
 
         self.assertRaises(TypeError, Expression, ())
@@ -290,7 +290,7 @@ class ExpressionTest(unittest.TestCase):
         self.assertRaises(TypeError, Operation, a)
 
     def testBasicOperation(self):
-        """ Add """
+        """Add"""
         a = BitVecConstant(size=32, value=100)
         b = BitVecVariable(size=32, name="VAR")
         c = a + b
@@ -823,7 +823,7 @@ class ExpressionTest(unittest.TestCase):
 
     def test_constant_folding_extract(self):
         cs = ConstraintSet()
-        x = BitVecConstant(size=32, value=0xab123456, taint=("important",))
+        x = BitVecConstant(size=32, value=0xAB123456, taint=("important",))
         z = constant_folder(BitVecExtract(x, 8, 16))
         self.assertItemsEqual(z.taint, ("important",))
         self.assertEqual(z.value, 0x1234)
@@ -864,7 +864,7 @@ class ExpressionTest(unittest.TestCase):
         self.assertTrue(self.solver.check(cs))
 
     def testBasicReplace(self):
-        """ Add """
+        """Add"""
         a = BitVecConstant(size=32, value=100)
         b1 = BitVecVariable(size=32, name="VAR1")
         b2 = BitVecVariable(size=32, name="VAR2")


### PR DESCRIPTION
This PR fixes an SMT simplification pattern for `BitVecExtract` on constants. 
The current implementation was ignoring the most significant bit of the extracted value.