### PR TITLE
Fix constructor args check for manticore-ethereum

### DIFF
--- a/manticore/ethereum/manticore.py
+++ b/manticore/ethereum/manticore.py
@@ -580,7 +580,7 @@ class ManticoreEVM(ManticoreBase):
                     constructor_types = md.get_constructor_arguments()
 
                     if constructor_types != "()":
-                        if args is None:
+                        if args is None or len(args) == 0:
                             args = self.make_symbolic_arguments(constructor_types)
 
                         constructor_data = ABI.serialize(constructor_types, *args)


### PR DESCRIPTION
## Motivation

`args` default to being an empty tuple. To make symbolic arguments out of the constructor arguments, it would make more sense to check if the arguments being provided are of length 0 rather than `None` (though I've given the choice here, so as not to break existing tests if there any that use it). 