### PR TITLE
Optimise forking when there is only 1 solution

### DIFF
--- a/tests/ethereum/test_general.py
+++ b/tests/ethereum/test_general.py
@@ -779,7 +779,7 @@ class EthTests(unittest.TestCase):
             for ext in ("summary", "constraints", "pkl", "tx.json", "tx", "trace", "logs")
         }
 
-        expected_files.add("state_00000001.pkl")
+        expected_files.add("state_00000000.pkl")
 
         actual_files = set((fn for fn in os.listdir(self.mevm.workspace) if not fn.startswith(".")))
         self.assertEqual(actual_files, expected_files)

--- a/tests/native/test_models.py
+++ b/tests/native/test_models.py
@@ -263,39 +263,6 @@ class StrlenTest(ModelTest):
         # Assert that every expected stdout has a matching output
         self.assertEqual(expected, stdouts)
 
-    def test_symbolic_fork_unique_solution(self):
-        # This binary is compiled using gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
-        # with flags: -g -static -fno-builtin
-        BIN_PATH = os.path.join(
-            os.path.dirname(__file__), "binaries/str_model_tests", "sym_strlen_test"
-        )
-        tmp_dir = tempfile.TemporaryDirectory(prefix="mcore_test_sym_")
-        m = Manticore(BIN_PATH, stdin_size=10, workspace_url=str(tmp_dir.name))
-
-        addr_of_strlen = 0x04404D0
-
-        @m.hook(addr_of_strlen)
-        def strlen_model(state):
-            stdin_1 = ArrayProxy(array=state.constraints.get_variable("STDIN")).select(1)
-            state.constrain(stdin_1 == 0)
-            state.invoke_model(strlen_exact)
-
-        m.run()
-        m.finalize()
-
-        # Expected stdout outputs
-        expected = {"Length of string is: 0", "Length of string is: 1"}
-
-        # Make a list of the generated output states
-        outputs = f"{str(m.workspace)}/test_*.stdout"
-        stdouts = set()
-        for out in glob(outputs):
-            with open(out) as f:
-                stdouts.add(f.read())
-
-        # Assert that every expected stdout has a matching output
-        self.assertEqual(expected, stdouts)
-
     def test_symbolic_mixed(self):
         sy = self.state.symbolicate_buffer("a+b+\0")
         s = self._push_string(sy)

--- a/tests/other/test_fork.py
+++ b/tests/other/test_fork.py
@@ -28,7 +28,7 @@ class TestFork(unittest.TestCase):
 
         # Check that no additional state was created when forking
         states = f"{str(m.workspace)}/state_*.pkl"
-        self.assertEqual(len(glob(outputs)), 1)
+        self.assertEqual(len(glob(states)), 1)
 
 
 if __name__ == "__main__":

--- a/tests/other/test_fork.py
+++ b/tests/other/test_fork.py
@@ -27,7 +27,7 @@ class TestFork(unittest.TestCase):
         m.finalize()
 
         # Check that no additional state was created when forking
-        states = f"{str(m.workspace)}/state_*.pkl"
+        states = f"{str(m.workspace)}/test_*.pkl"
         self.assertEqual(len(glob(states)), 1)
 
 

--- a/tests/other/test_fork.py
+++ b/tests/other/test_fork.py
@@ -1,0 +1,35 @@
+import unittest
+import tempfile
+from manticore.native import Manticore
+from manticore.core.state import Concretize
+from pathlib import Path
+from glob import glob
+
+
+class TestFork(unittest.TestCase):
+    def test_fork_unique_solution(self):
+        binary = str(
+            Path(__file__).parent.parent.parent.joinpath(
+                "tests", "native", "binaries", "hello_world"
+            )
+        )
+        tmp_dir = tempfile.TemporaryDirectory(prefix="mcore_test_fork_")
+        m = Manticore(binary, stdin_size=10, workspace_url=str(tmp_dir.name))
+
+        @m.hook(0x3E50)  # Entrypoint
+        def concretize_var(state):
+            # Concretize symbolic var that has only 1 solution
+            var = BitVecVariable(size=32, name="bar")
+            state.constrain(var == 5)
+            raise Concretize(var)
+
+        m.run()
+        m.finalize()
+
+        # Check that no additional state was created when forking
+        states = f"{str(m.workspace)}/state_*.pkl"
+        self.assertEqual(len(glob(outputs)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR improves the forking process when there is only one possible solution for the symbolic expression upon which we fork. In that case, we re-use the same `State`  instead of copying the entire state to create a new one.

I don't think that Manticore has many tests for forks except this one: https://github.com/trailofbits/manticore/blob/93211002a9cea6074790c0de974fb9e603881577/tests/native/test_models.py#L227-L263 

I did test this PR in CHESS, but we should add a Manticore testcase for forking on  a single solution since it hits a rarer and slightly different code path than regular forking. 

