### PR TITLE
Ignore missing unicorn registers in the fallback emulator

### DIFF
--- a/manticore/utils/fallback_emulator.py
+++ b/manticore/utils/fallback_emulator.py
@@ -215,7 +215,8 @@ class UnicornEmulator:
             "0x%x:\t%s\t%s" % (instruction.address, instruction.mnemonic, instruction.op_str)
         )
 
-        registers = set(self._cpu.canonical_registers)
+        ignore_registers = {"FIP", "FOP", "FDS", "FCS", "FDP", "MXCSR_MASK"}
+        registers = set(self._cpu.canonical_registers) - ignore_registers
 
         # Refer to EFLAGS instead of individual flags for x86
         if self._cpu.arch == CS_ARCH_X86:
@@ -279,7 +280,7 @@ class UnicornEmulator:
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("=" * 10)
-            for register in self._cpu.canonical_registers:
+            for register in registers:
                 logger.debug(
                     f"Register {register:3s}  "
                     f"Manticore: {self._cpu.read_register(register):08x}, "


### PR DESCRIPTION
As described in https://github.com/trailofbits/manticore/issues/2528, we need to exclude some FPU registers from the unicorn <-> manticore context switch when using the emulator, because those registers aren't supported in unicorn yet.

It turns out that the FPU registers also need to be ignored in the fallback emulator (different than the regular emulator), which is what this PR does. 