### PR TITLE
Split off ENDBR32/64 from CHESS branch

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -5572,6 +5572,35 @@ class X86Cpu(Cpu):
         """
 
     @instruction
+    def ENDBR32(cpu):
+        """
+        The ENDBRANCH is a new instruction that is used to mark valid jump target
+        addresses of indirect calls and jumps in the program. This instruction
+        opcode is selected to be one that is a NOP on legacy machines such that
+        programs compiled with ENDBRANCH new instruction continue to function on
+        old machines without the CET enforcement. On processors that support CET
+        the ENDBRANCH is still a NOP and is primarily used as a marker instruction
+        by the processor pipeline to detect control flow violations.
+        This is the 32-bit variant.
+        :param cpu: current CPU.
+        """
+        pass
+
+    @instruction
+    def ENDBR64(cpu):
+        """
+        The ENDBRANCH is a new instruction that is used to mark valid jump target
+        addresses of indirect calls and jumps in the program. This instruction
+        opcode is selected to be one that is a NOP on legacy machines such that
+        programs compiled with ENDBRANCH new instruction continue to function on
+        old machines without the CET enforcement. On processors that support CET
+        the ENDBRANCH is still a NOP and is primarily used as a marker instruction
+        by the processor pipeline to detect control flow violations.
+        :param cpu: current CPU.
+        """
+        pass
+
+    @instruction
     def MOVD(cpu, op0, op1):
         cpu._writeCorrectSize(op0, op1)
 


### PR DESCRIPTION
Seeing as they're fancy NOP's, I don't think there's any reason not to merge them into `master`, and thus avoid aggressively concretizing the state in order to emulate them under Unicorn.

Thanks for the implementation, @lordidiot