### PR TITLE
fix typo in Manticore.linux constructor docstring

### DIFF
--- a/manticore/native/manticore.py
+++ b/manticore/native/manticore.py
@@ -120,7 +120,7 @@ class Manticore(ManticoreBase):
         :param envp: Environment to provide to the binary
         :type envp: dict[str, str]
         :param entry_symbol: Entry symbol to resolve to start execution
-        :type envp: str
+        :type entry_symbol: str
         :param symbolic_files: Filenames to mark as having symbolic input
         :type symbolic_files: list[str]
         :param str concrete_start: Concrete stdin to use before symbolic input


### PR DESCRIPTION
noticed on the sphinx-generated docs that `entry_symbol` had no type specified and passing a string to `envp` didn't work, turns out there's a typo