### PR TITLE
Fix bug in register_log_callback

### DIFF
--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -22,13 +22,11 @@ class CallbackStream(io.TextIOBase):
         self.callback(log_str)
 
 
-def register_log_callback(cb):
-    for name in get_manticore_logger_names():
-        logger = logging.getLogger(name)
-        handler_internal = logging.StreamHandler(CallbackStream(cb))
-        if name.startswith("manticore"):
-            handler_internal.setFormatter(formatter)
-        # logger.addHandler(handler_internal)
+def register_log_callback(cb) -> None:
+    callback_handler = logging.StreamHandler(CallbackStream(cb))
+    callback_handler.setFormatter(formatter)
+    callback_handler.addFilter(ManticoreContextFilter())
+    init_logging(callback_handler)
 
 
 class ManticoreContextFilter(logging.Filter):

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import io
 
-from typing import List, Set, Tuple, Optional
+from typing import List, Set, Tuple, Optional, Callable
 
 manticore_verbosity = 0
 DEFAULT_LOG_LEVEL = logging.WARNING
@@ -20,13 +20,6 @@ class CallbackStream(io.TextIOBase):
 
     def write(self, log_str):
         self.callback(log_str)
-
-
-def register_log_callback(cb) -> None:
-    callback_handler = logging.StreamHandler(CallbackStream(cb))
-    callback_handler.setFormatter(formatter)
-    callback_handler.addFilter(ManticoreContextFilter())
-    init_logging(callback_handler)
 
 
 class ManticoreContextFilter(logging.Filter):
@@ -157,6 +150,13 @@ def set_verbosity(setting: int) -> None:
         # This means if you explicitly call setLevel somewhere else in the source, and it's *more*
         # verbose, it'll stay that way even if manticore_verbosity is 0.
         logger.setLevel(min(get_verbosity(logger_name), logger.getEffectiveLevel()))
+
+
+def register_log_callback(callback: Callable[[Optional[str]], None]) -> None:
+    callback_handler = logging.StreamHandler(CallbackStream(callback))
+    callback_handler.setFormatter(formatter)
+    callback_handler.addFilter(ManticoreContextFilter())
+    init_logging(callback_handler)
 
 
 def default_handler() -> logging.Handler:

--- a/manticore/utils/log.py
+++ b/manticore/utils/log.py
@@ -14,7 +14,7 @@ def get_manticore_logger_names() -> List[str]:
     return [name for name in logging.root.manager.loggerDict if name.startswith("manticore")]  # type: ignore
 
 
-class CallbackStream(io.TextIOBase):
+class CallbackStream(io.StringIO):
     def __init__(self, callback):
         self.callback = callback
 


### PR DESCRIPTION
Currently a test in `test_tui_api.py` is failing and the TUI itself doesn't send logs over as a protobuf message because the LogCaptureWorker's `log_callback` isn't being registered correctly. This PR fixes that!