### PR TITLE
Add `psubq` instruction (x86)

### DIFF
--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -5903,7 +5903,7 @@ class X86Cpu(Cpu):
         for i in reversed(range(0, dest.size, 64)):
             a = Operators.EXTRACT(value_a, i, 64)
             b = Operators.EXTRACT(value_b, i, 64)
-            result.append((a - b) & 0xFFFFFFFFFFFFFFFF)
+            result.append(a - b)
         dest.write(Operators.CONCAT(dest.size, *result))
 
     @instruction

--- a/manticore/native/cpu/x86.py
+++ b/manticore/native/cpu/x86.py
@@ -5882,6 +5882,31 @@ class X86Cpu(Cpu):
         dest.write(Operators.CONCAT(8 * len(result), *result))
 
     @instruction
+    def PSUBQ(cpu, dest, src):
+        """
+        PSUBQ: Packed add with quadruple words
+        Packed subtract with quad
+
+        Subtracts the second operand (source operand) from the first operand (destination operand) and stores
+        the result in the destination operand. When packed quadword operands are used, a SIMD subtract is performed.
+        When a quadword result is too large to be represented in 64 bits (overflow), the result is wrapped around
+        and the low 64 bits are written to the destination element (that is, the carry is ignored).
+
+        :param cpu: current CPU.
+        :param dest: destination operand.
+        :param src: source operand.
+        """
+        result = []
+        value_a = dest.read()
+        value_b = src.read()
+
+        for i in reversed(range(0, dest.size, 64)):
+            a = Operators.EXTRACT(value_a, i, 64)
+            b = Operators.EXTRACT(value_b, i, 64)
+            result.append((a - b) & 0xFFFFFFFFFFFFFFFF)
+        dest.write(Operators.CONCAT(dest.size, *result))
+
+    @instruction
     def POR(cpu, dest, src):
         """
         Performs a bitwise logical OR operation on the source operand (second operand) and the destination operand

--- a/tests/native/test_x86.py
+++ b/tests/native/test_x86.py
@@ -22318,7 +22318,7 @@ class CPUTest(unittest.TestCase):
         mem = Memory32()
         cpu = I386Cpu(mem)
         mem.mmap(0x08065000, 0x1000, "rwx")
-        
+
         # psubq xmm0, xmm1
         mem[0x08065000] = "\x66"
         mem[0x08065001] = "\x0f"


### PR DESCRIPTION
Adds support for `psubq` x86 instruction. Implementation very similar to `psubb`.
