### PR TITLE
Fix plugin docs

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,7 +6,7 @@ Core
 
 .. py:function:: will_fork_state_callback(self, state, expression, solutions, policy)
 
-.. py:function:: did_fork_state_callback(self, new_state, expression, new_value,policy)
+.. py:function:: did_fork_state_callback(self, new_state, expression, solutions, policy, children)
 
 .. py:function:: will_load_state_callback(self, state_id)
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -40,9 +40,9 @@ EVM
 
 .. py:function:: did_evm_execute_instruction_callback(self, last_unstruction, last_arguments, result)
 
-.. py:function:: did_evm_read_memory_callback(self, offset, operators)
+.. py:function:: did_evm_read_memory_callback(self, offset, value, size)
 
-.. py:function:: did_evm_write_memory_callback(self, offset, operators)
+.. py:function:: did_evm_write_memory_callback(self, offset, value, size)
 
 .. py:function:: on_symbolic_sha3_callback(self, data, know_sha3)
 


### PR DESCRIPTION
Noticed some callbacks in the [plugin docs](https://github.com/trailofbits/manticore/blob/master/docs/plugins.rst) were not accurate.
Updated them based on how they were being `_publish`ed in the codebase, hopefully it is accurate.

1. `did_fork_state_callback`
    - Based on [1](https://github.com/trailofbits/manticore/blob/2de39b84cfaf51ac38ec07a183ac9eaf9ef094fb/manticore/core/manticore.py#L560) and [2](https://github.com/trailofbits/manticore/blob/2de39b84cfaf51ac38ec07a183ac9eaf9ef094fb/manticore/core/manticore.py#L538)
2. `did_evm_read_callback` / `did_evm_write_callback`
    - Based on [1](https://github.com/trailofbits/manticore/blob/2de39b84cfaf51ac38ec07a183ac9eaf9ef094fb/manticore/platforms/evm.py#L1430) and [2](https://github.com/trailofbits/manticore/blob/2de39b84cfaf51ac38ec07a183ac9eaf9ef094fb/manticore/platforms/evm.py#L1436)