### PR TITLE
Pin protobuf version to 3.20.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "pyyaml",
-        "protobuf",
+        "protobuf==3.20.1",
         # evm dependencies
         "pysha3",
         "prettytable",


### PR DESCRIPTION
Protobuf introduced major version 4.21.0, which contains breaking changes 

This is a quick fix which pins protobuf to 3.20.1 before we eventually migrate the codebase to proto4