### PR TITLE
Add boolean simplifications

### DIFF
--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -508,19 +508,18 @@ class ArithmeticSimplifier(Visitor):
         !(a||b) -> !a && !b
         !(a&&b) -> !a || !b
         """
-        pass
-        # if isinstance(operands[0], BoolNot):
-        #     return operands[0].operands[0]
+        if isinstance(operands[0], BoolNot):
+            return operands[0].operands[0]
 
-        # if isinstance(operands[0], BoolAnd):
-        #     return BoolOr(
-        #         a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
-        #     )
+        if isinstance(operands[0], BoolAnd):
+            return BoolOr(
+                a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
+            )
 
-        # if isinstance(operands[0], BoolOr):
-        #     return BoolAnd(
-        #         a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
-        #     )
+        if isinstance(operands[0], BoolOr):
+            return BoolAnd(
+                a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
+            )
 
     def visit_BoolEqual(self, expression, *operands):
         """(EQ, ITE(cond, constant1, constant2), constant1) -> cond

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -508,18 +508,19 @@ class ArithmeticSimplifier(Visitor):
         !(a||b) -> !a && !b
         !(a&&b) -> !a || !b
         """
-        if isinstance(operands[0], BoolNot):
-            return operands[0].operands[0]
+        pass
+        # if isinstance(operands[0], BoolNot):
+        #     return operands[0].operands[0]
 
-        if isinstance(operands[0], BoolAnd):
-            return BoolOr(
-                BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
-            )
+        # if isinstance(operands[0], BoolAnd):
+        #     return BoolOr(
+        #         BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+        #     )
 
-        if isinstance(operands[0], BoolOr):
-            return BoolAnd(
-                BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
-            )
+        # if isinstance(operands[0], BoolOr):
+        #     return BoolAnd(
+        #         BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+        #     )
 
     def visit_BoolEqual(self, expression, *operands):
         """(EQ, ITE(cond, constant1, constant2), constant1) -> cond
@@ -555,8 +556,8 @@ class ArithmeticSimplifier(Visitor):
 
                 return BoolConstant(value=True, taint=expression.taint)
 
-        if isinstance(operands[1], BoolConstant):
-            return operands[0] if operands[1].value else BoolNot(value=operands[0])
+        # if isinstance(operands[1], BoolConstant):
+        #     return operands[0] if operands[1].value else BoolNot(value=operands[0])
 
     def visit_BoolOr(self, expression, a, b):
         if isinstance(a, Constant):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -743,9 +743,9 @@ class ArithmeticSimplifier(Visitor):
         left = operands[0]
         right = operands[1]
         if isinstance(right, BitVecConstant) and right.value == 1:
-                return left
+            return left
         if isinstance(left, BitVecConstant) and left.value == 1:
-                return right
+            return right
 
     def visit_BitVecSub(self, expression, *operands):
         """a - 0 ==> a

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -556,8 +556,8 @@ class ArithmeticSimplifier(Visitor):
 
                 return BoolConstant(value=True, taint=expression.taint)
 
-        # if isinstance(operands[1], BoolConstant):
-        #     return operands[0] if operands[1].value else BoolNot(value=operands[0])
+        if isinstance(operands[1], BoolConstant):
+            return operands[0] if operands[1].value else BoolNot(value=operands[0])
 
     def visit_BoolOr(self, expression, a, b):
         if isinstance(a, Constant):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -736,6 +736,17 @@ class ArithmeticSimplifier(Visitor):
             if left.value == 0:
                 return right
 
+    def visit_BitVecMul(self, expression, *operands):
+        """a * 1  ==> a
+        1 * a  ==> a
+        """
+        left = operands[0]
+        right = operands[1]
+        if isinstance(right, BitVecConstant) and right.value == 1:
+                return left
+        if isinstance(left, BitVecConstant) and left.value == 1:
+                return right
+
     def visit_BitVecSub(self, expression, *operands):
         """a - 0 ==> a
         (a + b) - b  ==> a

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -514,12 +514,12 @@ class ArithmeticSimplifier(Visitor):
 
         # if isinstance(operands[0], BoolAnd):
         #     return BoolOr(
-        #         BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+        #         a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
         #     )
 
         # if isinstance(operands[0], BoolOr):
         #     return BoolAnd(
-        #         BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+        #         a=BoolNot(value=operands[0].operands[0]), b=BoolNot(value=operands[0].operands[1])
         #     )
 
     def visit_BoolEqual(self, expression, *operands):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -503,13 +503,31 @@ class ArithmeticSimplifier(Visitor):
                         ) == BitVecExtract(operand=value1, offset=beg, size=end - beg + 1)
 
     def visit_BoolNot(self, expression, *operands):
+        """
+        !!a -> a
+        !(a||b) -> !a && !b
+        !(a&&b) -> !a || !b
+        """
         if isinstance(operands[0], BoolNot):
             return operands[0].operands[0]
+
+        if isinstance(operands[0], BoolAnd):
+            return BoolOr(
+                BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+            )
+
+        if isinstance(operands[0], BoolOr):
+            return BoolAnd(
+                BoolNot(value=operands[0].operands[0]), BoolNot(value=operands[0].operands[1])
+            )
 
     def visit_BoolEqual(self, expression, *operands):
         """(EQ, ITE(cond, constant1, constant2), constant1) -> cond
         (EQ, ITE(cond, constant1, constant2), constant2) -> NOT cond
         (EQ (extract a, b, c) (extract a, b, c))
+
+        EQ (a) True -> a
+        EQ (a) False -> !a
         """
         if isinstance(operands[0], BitVecITE) and isinstance(operands[1], Constant):
             if isinstance(operands[0].operands[1], Constant) and isinstance(
@@ -536,6 +554,9 @@ class ArithmeticSimplifier(Visitor):
             ):
 
                 return BoolConstant(value=True, taint=expression.taint)
+
+        if isinstance(operands[1], BoolConstant):
+            return operands[0] if operands[1].value else BoolNot(value=operands[0])
 
     def visit_BoolOr(self, expression, a, b):
         if isinstance(a, Constant):

--- a/manticore/core/smtlib/visitors.py
+++ b/manticore/core/smtlib/visitors.py
@@ -505,8 +505,8 @@ class ArithmeticSimplifier(Visitor):
     def visit_BoolNot(self, expression, *operands):
         """
         !!a -> a
-        !(a||b) -> !a && !b
         !(a&&b) -> !a || !b
+        !(a||b) -> !a && !b
         """
         if isinstance(operands[0], BoolNot):
             return operands[0].operands[0]
@@ -737,7 +737,8 @@ class ArithmeticSimplifier(Visitor):
                 return right
 
     def visit_BitVecMul(self, expression, *operands):
-        """a * 1  ==> a
+        """
+        a * 1  ==> a
         1 * a  ==> a
         """
         left = operands[0]

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -847,12 +847,12 @@ class ExpressionTest(unittest.TestCase):
         x = BoolEqual(a=a, b=BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        x = BoolNot(Operators.BoolAnd(a=a, b=b))
-        expected = Operators.BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
+        x = BoolNot(BoolAnd(a=a, b=b))
+        expected = BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        x = BoolNot(Operators.BoolOr(a=a, b=b))
-        expected = Operators.BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
+        x = BoolNot(BoolOr(a=a, b=b))
+        expected = BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
         x = BoolNot(value=BoolNot(value=a))

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -841,42 +841,22 @@ class ExpressionTest(unittest.TestCase):
 
         x = Operators.BoolEqual(BoolConstant(value=False))
         self.assertEqual(
-            translate_to_smtlib(simplify(x)),
-            translate_to_smtlib(Operators.BoolNot(a))
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
         )
 
         x = Operators.BoolEqual(BoolConstant(value=True))
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)),
-            translate_to_smtlib(a)
-        )
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        x = Operators.BoolNot(Operators.BoolAnd(a,b))
-        expected = Operators.BoolOr(
-            Operators.BoolNot(a),
-            Operators.BoolNot(b)
-        )
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)),
-            translate_to_smtlib(expected)
-        )
+        x = Operators.BoolNot(Operators.BoolAnd(a, b))
+        expected = Operators.BoolOr(Operators.BoolNot(a), Operators.BoolNot(b))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        x = Operators.BoolNot(Operators.BoolOr(a,b))
-        expected = Operators.BoolAnd(
-            Operators.BoolNot(a),
-            Operators.BoolNot(b)
-        )
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)),
-            translate_to_smtlib(expected)
-        )
+        x = Operators.BoolNot(Operators.BoolOr(a, b))
+        expected = Operators.BoolAnd(Operators.BoolNot(a), Operators.BoolNot(b))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
         x = Operators.BoolNot(Operators.BoolNot(a))
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)),
-            translate_to_smtlib(a)
-        )
-
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
     def test_constant_folding_extract(self):
         cs = ConstraintSet()

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -839,23 +839,23 @@ class ExpressionTest(unittest.TestCase):
         a = cs.new_bool(name="A")
         b = cs.new_bool(name="B")
 
-        x = BoolEqual(BoolConstant(value=False))
+        x = BoolEqual(a, BoolConstant(value=False))
         self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(a))
         )
 
-        x = BoolEqual(BoolConstant(value=True))
+        x = BoolEqual(b, BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        # x = Operators.BoolNot(Operators.BoolAnd(a, b))
-        # expected = Operators.BoolOr(Operators.BoolNot(a), Operators.BoolNot(b))
+        # x = BoolNot(Operators.BoolAnd(a, b))
+        # expected = Operators.BoolOr(BoolNot(a), BoolNot(b))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = Operators.BoolNot(Operators.BoolOr(a, b))
-        # expected = Operators.BoolAnd(Operators.BoolNot(a), Operators.BoolNot(b))
+        # x = BoolNot(Operators.BoolOr(a, b))
+        # expected = Operators.BoolAnd(BoolNot(a), BoolNot(b))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = Operators.BoolNot(Operators.BoolNot(a))
+        # x = BoolNot(BoolNot(a))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
         pass
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -839,24 +839,25 @@ class ExpressionTest(unittest.TestCase):
         a = cs.new_bool(name="A")
         b = cs.new_bool(name="B")
 
-        x = Operators.BoolEqual(BoolConstant(value=False))
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
-        )
+        # x = BoolEqual(BoolConstant(value=False))
+        # self.assertEqual(
+        #     translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
+        # )
 
-        x = Operators.BoolEqual(BoolConstant(value=True))
-        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
+        # x = BoolEqual(BoolConstant(value=True))
+        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        x = Operators.BoolNot(Operators.BoolAnd(a, b))
-        expected = Operators.BoolOr(Operators.BoolNot(a), Operators.BoolNot(b))
-        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
+        # x = Operators.BoolNot(Operators.BoolAnd(a, b))
+        # expected = Operators.BoolOr(Operators.BoolNot(a), Operators.BoolNot(b))
+        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        x = Operators.BoolNot(Operators.BoolOr(a, b))
-        expected = Operators.BoolAnd(Operators.BoolNot(a), Operators.BoolNot(b))
-        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
+        # x = Operators.BoolNot(Operators.BoolOr(a, b))
+        # expected = Operators.BoolAnd(Operators.BoolNot(a), Operators.BoolNot(b))
+        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        x = Operators.BoolNot(Operators.BoolNot(a))
-        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
+        # x = Operators.BoolNot(Operators.BoolNot(a))
+        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
+        pass
 
     def test_constant_folding_extract(self):
         cs = ConstraintSet()

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -839,23 +839,23 @@ class ExpressionTest(unittest.TestCase):
         a = cs.new_bool(name="A")
         b = cs.new_bool(name="B")
 
-        x = BoolEqual(a, BoolConstant(value=False))
+        x = BoolEqual(a=a, b=BoolConstant(value=False))
         self.assertEqual(
             translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(a))
         )
 
-        x = BoolEqual(b, BoolConstant(value=True))
+        x = BoolEqual(a=a, b=BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        # x = BoolNot(Operators.BoolAnd(a, b))
-        # expected = Operators.BoolOr(BoolNot(a), BoolNot(b))
+        # x = BoolNot(Operators.BoolAnd(a=a, b=b))
+        # expected = Operators.BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = BoolNot(Operators.BoolOr(a, b))
-        # expected = Operators.BoolAnd(BoolNot(a), BoolNot(b))
+        # x = BoolNot(Operators.BoolOr(a=a, b=b))
+        # expected = Operators.BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = BoolNot(BoolNot(a))
+        # x = BoolNot(value=BoolNot(value=a))
         # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
         pass
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -861,13 +861,14 @@ class ExpressionTest(unittest.TestCase):
     def test_arithmetic_simplify_mul(self):
         cs = ConstraintSet()
         a = cs.new_bitvec(32, name="A")
+        one = BitVecConstant(size=32, value=1)
 
-        x = BitVecMul(a=1, b=a)
+        x = BitVecMul(a=one, b=a)
         self.assertEqual(
             translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
         )
 
-        x = BitVecMul(a=a, b=1)
+        x = BitVecMul(a=a, b=one)
         self.assertEqual(
             translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
         )

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -834,6 +834,50 @@ class ExpressionTest(unittest.TestCase):
         )
         self.assertEqual(translate_to_smtlib(simplify(c)), "((_ extract 23 8) VARA)")
 
+        def test_arithmetic_simplify_bool(self):
+        cs = ConstraintSet()
+        a = cs.new_bool(name="A")
+        b = cs.new_bool(name="B")
+
+        x = Operators.BoolEqual(BoolConstant(value=False))
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)),
+            translate_to_smtlib(Operators.BoolNot(a))
+        )
+
+        x = Operators.BoolEqual(BoolConstant(value=True))
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)),
+            translate_to_smtlib(a)
+        )
+
+        x = Operators.BoolNot(Operators.BoolAnd(a,b))
+        expected = Operators.BoolOr(
+            Operators.BoolNot(a),
+            Operators.BoolNot(b)
+        )
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)),
+            translate_to_smtlib(expected)
+        )
+
+        x = Operators.BoolNot(Operators.BoolOr(a,b))
+        expected = Operators.BoolAnd(
+            Operators.BoolNot(a),
+            Operators.BoolNot(b)
+        )
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)),
+            translate_to_smtlib(expected)
+        )
+
+        x = Operators.BoolNot(Operators.BoolNot(a))
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)),
+            translate_to_smtlib(a)
+        )
+
+
     def test_constant_folding_extract(self):
         cs = ConstraintSet()
         x = BitVecConstant(size=32, value=0xAB123456, taint=("important",))

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -840,9 +840,7 @@ class ExpressionTest(unittest.TestCase):
         b = cs.new_bool(name="B")
 
         x = BoolEqual(a=a, b=BoolConstant(value=False))
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(value=a))
-        )
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(value=a)))
 
         x = BoolEqual(a=a, b=BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
@@ -864,14 +862,10 @@ class ExpressionTest(unittest.TestCase):
         one = BitVecConstant(size=32, value=1)
 
         x = BitVecMul(a=one, b=a)
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
-        )
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
         x = BitVecMul(a=a, b=one)
-        self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
-        )
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
     def test_constant_folding_extract(self):
         cs = ConstraintSet()

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -847,11 +847,11 @@ class ExpressionTest(unittest.TestCase):
         x = BoolEqual(a=a, b=BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        x = BoolNot(BoolAnd(a=a, b=b))
+        x = BoolNot(value=BoolAnd(a=a, b=b))
         expected = BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        x = BoolNot(BoolOr(a=a, b=b))
+        x = BoolNot(value=BoolOr(a=a, b=b))
         expected = BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -841,7 +841,7 @@ class ExpressionTest(unittest.TestCase):
 
         x = BoolEqual(a=a, b=BoolConstant(value=False))
         self.assertEqual(
-            translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(a))
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(BoolNot(value=a))
         )
 
         x = BoolEqual(a=a, b=BoolConstant(value=True))

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -834,7 +834,7 @@ class ExpressionTest(unittest.TestCase):
         )
         self.assertEqual(translate_to_smtlib(simplify(c)), "((_ extract 23 8) VARA)")
 
-        def test_arithmetic_simplify_bool(self):
+    def test_arithmetic_simplify_bool(self):
         cs = ConstraintSet()
         a = cs.new_bool(name="A")
         b = cs.new_bool(name="B")

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -839,13 +839,13 @@ class ExpressionTest(unittest.TestCase):
         a = cs.new_bool(name="A")
         b = cs.new_bool(name="B")
 
-        # x = BoolEqual(BoolConstant(value=False))
-        # self.assertEqual(
-        #     translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
-        # )
+        x = BoolEqual(BoolConstant(value=False))
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(Operators.BoolNot(a))
+        )
 
-        # x = BoolEqual(BoolConstant(value=True))
-        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
+        x = BoolEqual(BoolConstant(value=True))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
         # x = Operators.BoolNot(Operators.BoolAnd(a, b))
         # expected = Operators.BoolOr(Operators.BoolNot(a), Operators.BoolNot(b))

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -847,17 +847,16 @@ class ExpressionTest(unittest.TestCase):
         x = BoolEqual(a=a, b=BoolConstant(value=True))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
-        # x = BoolNot(Operators.BoolAnd(a=a, b=b))
-        # expected = Operators.BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
-        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
+        x = BoolNot(Operators.BoolAnd(a=a, b=b))
+        expected = Operators.BoolOr(a=BoolNot(value=a), b=BoolNot(value=b))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = BoolNot(Operators.BoolOr(a=a, b=b))
-        # expected = Operators.BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
-        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
+        x = BoolNot(Operators.BoolOr(a=a, b=b))
+        expected = Operators.BoolAnd(a=BoolNot(value=a), b=BoolNot(value=b))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(expected))
 
-        # x = BoolNot(value=BoolNot(value=a))
-        # self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
-        pass
+        x = BoolNot(value=BoolNot(value=a))
+        self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
     def test_constant_folding_extract(self):
         cs = ConstraintSet()

--- a/tests/other/test_smtlibv2.py
+++ b/tests/other/test_smtlibv2.py
@@ -858,6 +858,20 @@ class ExpressionTest(unittest.TestCase):
         x = BoolNot(value=BoolNot(value=a))
         self.assertEqual(translate_to_smtlib(simplify(x)), translate_to_smtlib(a))
 
+    def test_arithmetic_simplify_mul(self):
+        cs = ConstraintSet()
+        a = cs.new_bitvec(32, name="A")
+
+        x = BitVecMul(a=1, b=a)
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
+        )
+
+        x = BitVecMul(a=a, b=1)
+        self.assertEqual(
+            translate_to_smtlib(simplify(x)), translate_to_smtlib(a)
+        )
+
     def test_constant_folding_extract(self):
         cs = ConstraintSet()
         x = BitVecConstant(size=32, value=0xAB123456, taint=("important",))


### PR DESCRIPTION
This PR adds the following simplification patterns on constraints that we often encounter within `MATE`:

```
!(a||b) -> !a && !b
!(a&&b) -> !a || !b
a == True -> a
a == False -> !a
1*a -> a
```