### PR TITLE
Loosen crytic-compile version restrictions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "ply",
         "rlp",
         "intervaltree",
-        "crytic-compile==0.2.2",
+        "crytic-compile>=0.2.2",
         "wasm",
         "dataclasses; python_version < '3.7'",
         "pyevmasm>=0.2.3",


### PR DESCRIPTION
Allow any newer release than 0.2.2