### PR TITLE
Loosen test dependency version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ auto_test_deps = ["py-evm"]
 # Development dependencies without keystone
 dev_noks = (
     native_deps
-    + ["coverage", "Sphinx", "pytest==5.3.0", "pytest-xdist==1.30.0", "pytest-cov==2.8.1", "jinja2"]
+    + ["coverage", "Sphinx", "pytest>=5.3.0", "pytest-xdist>=1.30.0", "pytest-cov>=2.8.1", "jinja2"]
     + lint_deps
     + auto_test_deps
 )


### PR DESCRIPTION
Only use a lower bound (not sure if the lower bound actually means
anything with regards to what Manticore _requires_, but better keep it
around just in case)