### PR TITLE
Rework logging setup

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -4,4 +4,7 @@ Utilities
 Logging
 ^^^^^^^
 
+.. autofunction:: manticore.utils.log.init_logging
+.. autofunction:: manticore.utils.log.get_manticore_logger_names
 .. autofunction:: manticore.utils.log.set_verbosity
+.. autofunction:: manticore.utils.log.default_handler

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -29,6 +29,9 @@ def main() -> None:
     """
     Dispatches execution into one of Manticore's engines: evm or native.
     """
+    # Only print with Manticore's logger
+    logging.getLogger().handlers = []
+    log.init_logging()
     args = parse_arguments()
 
     if args.no_colors:

--- a/manticore/__main__.py
+++ b/manticore/__main__.py
@@ -29,8 +29,6 @@ def main() -> None:
     """
     Dispatches execution into one of Manticore's engines: evm or native.
     """
-    # Only print with Manticore's logger
-    logging.getLogger().handlers = []
     log.init_logging()
     args = parse_arguments()
 
@@ -264,4 +262,6 @@ class ListEthereumDetectors(argparse.Action):
 
 
 if __name__ == "__main__":
+    # Only print with Manticore's logger
+    logging.getLogger().handlers = []
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from manticore.utils import log
+
+
+@pytest.fixture(scope="session", autouse=True)
+def initialize_manticore_logging(request):
+    """Initialize Manticore's logger for all tests"""
+    log.init_logging()


### PR DESCRIPTION
This allows projects to have more control over how Manticore logs are
handled. However, this also means that you need to explicitly enable
logging in Manticore scripts to see the logs. See
`manticore/__main__.py` file changes in this commit.