### PR TITLE
Fix docker (try to use z3 prebuilt binary)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN [ "c9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580  /usr/bi
 RUN python3 -m pip install -U pip
 
 ADD . /manticore
-RUN python3 -m pip install -U --prefer-binary z3-solver 
+RUN python3 -m pip install -U --prefer-binary z3-solver==4.8.10
+RUN pip install protobuf==3.20
 RUN cd manticore && python3 -m pip install .[native]
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN [ "c9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580  /usr/bi
 RUN python3 -m pip install -U pip
 
 ADD . /manticore
+RUN python3 -m pip install -U --prefer-binary z3-solver 
 RUN cd manticore && python3 -m pip install .[native]
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Problem: Couldn't use docker on my M1 mac due to failure to build `z3-solver` wheel.

Solution: try to use a prebuilt binary if possible.

It works fine with this.

Original erorr message attached for context
[z3-error.txt](https://github.com/user-attachments/files/20298072/z3-error.txt)

