### PR TITLE
Fix #162: Remove STDIN from reports if there was no reads

### DIFF
--- a/manticore/platforms/linux.py
+++ b/manticore/platforms/linux.py
@@ -4158,10 +4158,13 @@ class SLinux(Linux):
             "argv": argIO.getvalue(),
             "env": envIO.getvalue(),
             "stdout": out.getvalue(),
-            "stdin": inn.getvalue(),
             "stderr": err.getvalue(),
             "net": net.getvalue(),
         }
+
+        if inn.getvalue():
+            ret["stdin"] = inn.getvalue()
+
         for f in chain((e.fdlike for e in self.fd_table.entries()), self._closed_files):
             if not isinstance(f, SymbolicFile):
                 continue


### PR DESCRIPTION
This PR fixes issue #162. Added a check to ensure inn.getvalue() is not empty before including the STDIN data in the workspace report. If no reads occurred, STDIN is excluded.

Fixes #162